### PR TITLE
Fix thinking block isolation

### DIFF
--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -185,6 +185,7 @@ const mdComponentsStreaming = makeMdComponents(true);
 export default function Message({ msg, onEdit, onAnswer }) {
   const isUser = msg.role === "user";
   const hasThinkingPart = Boolean(msg.parts?.some((part) => part.type === "thinking"));
+  const activeThinkingByStreamKey = msg._streamState?.activeThinking || {};
 
   // Strip [Attached files/images: ...] prefix from display text and extract file names
   let displayText = msg.text || "";
@@ -406,7 +407,10 @@ export default function Message({ msg, onEdit, onAnswer }) {
           );
         }
         if (part.type === "thinking") {
-          return <ThinkingBlock key={"think-" + i} text={part.text} isThinking={msg.isThinking} />;
+          const isPartThinking = part._streamKey
+            ? Boolean(activeThinkingByStreamKey[part._streamKey])
+            : msg.isThinking;
+          return <ThinkingBlock key={"think-" + i} text={part.text} isThinking={isPartThinking} />;
         }
         if (part.type === "tool") {
           if (part.name === "AskUserQuestion") {


### PR DESCRIPTION
## Summary
- derive each rendered thinking block's active state from its own stream key
- keep the message-level thinking flag only as a fallback for placeholder thinking rows
- prevent later agent loops in the same assistant response from making earlier thinking blocks appear active again

## Verification
- npm run build
- npm run lint *(fails due to pre-existing repository-wide lint errors unrelated to this change)*

Closes #5