### PR TITLE
feat: global font size setting + unified serif font

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import useTerminal  from "./hooks/useTerminal";
 import TerminalDrawer from "./components/TerminalDrawer";
 import Settings     from "./components/Settings";
 import { getM }     from "./data/models";
+import { FontSizeContext } from "./contexts/FontSizeContext";
 
 function logCheckpoint(...args) {
   console.log("[checkpoint-ui]", ...args);
@@ -25,6 +26,7 @@ export default function App() {
   const [cwd, setCwd] = useState(null);
   const [stateLoaded, setStateLoaded] = useState(false);
   const [wallpaper, setWallpaper] = useState(null); // { path, opacity, blur }
+  const [fontSize, setFontSize] = useState(15);
   const [showSettings, setShowSettings] = useState(false);
   const messageQueue = useRef([]);
   const [queuedMessages, setQueuedMessages] = useState([]);
@@ -38,6 +40,7 @@ export default function App() {
         if (state.active) setActive(state.active);
         if (state.cwd) setCwd(state.cwd);
         if (state.defaultModel) setDefaultModel(state.defaultModel);
+        if (state.fontSize) setFontSize(state.fontSize);
         if (state.wallpaper) {
           setWallpaper(state.wallpaper);
           // Reload data URL from disk (not persisted — too large for JSON)
@@ -61,9 +64,9 @@ export default function App() {
     saveTimer.current = setTimeout(() => {
       // Strip dataUrl before persisting (too large for JSON, reloaded on startup)
       const wpSave = wallpaper ? { path: wallpaper.path, opacity: wallpaper.opacity, blur: wallpaper.blur, imgBlur: wallpaper.imgBlur, imgDarken: wallpaper.imgDarken } : null;
-      window.api.saveState({ convos: convoList, active, cwd, defaultModel, wallpaper: wpSave });
+      window.api.saveState({ convos: convoList, active, cwd, defaultModel, fontSize, wallpaper: wpSave });
     }, 300);
-  }, [convoList, active, cwd, defaultModel, wallpaper, stateLoaded]);
+  }, [convoList, active, cwd, defaultModel, fontSize, wallpaper, stateLoaded]);
 
   const activeConvo = convoList.find((c) => c.id === active);
   const activeData  = active ? getConversation(active) : { messages: [], isStreaming: false, error: null };
@@ -378,6 +381,7 @@ export default function App() {
   // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
+    <FontSizeContext.Provider value={fontSize}>
     <div style={{ display: "flex", height: "100vh", width: "100vw", overflow: "hidden", position: "relative" }}>
       {wallpaper?.dataUrl ? (
         <div style={{
@@ -444,6 +448,8 @@ export default function App() {
         <Settings
           wallpaper={wallpaper}
           onWallpaperChange={setWallpaper}
+          fontSize={fontSize}
+          onFontSizeChange={setFontSize}
           onClose={() => setShowSettings(false)}
         />
       ) : (
@@ -481,5 +487,6 @@ export default function App() {
         wallpaper={wallpaper}
       />
     </div>
+    </FontSizeContext.Provider>
   );
 }

--- a/src/components/AskUserQuestionBlock.jsx
+++ b/src/components/AskUserQuestionBlock.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Check, ChevronRight } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function AskUserQuestionBlock({ tool, onAnswer }) {
   const [selections, setSelections] = useState({});
+  const s = useFontScale();
   const [customText, setCustomText] = useState("");
   const [submitted, setSubmitted] = useState(false);
   const questions = tool.args?.questions || [];
@@ -73,7 +75,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
       >
         <span
           style={{
-            fontSize: 10,
+            fontSize: s(10),
             fontFamily: "'JetBrains Mono',monospace",
             color: "rgba(255,255,255,0.3)",
             letterSpacing: ".1em",
@@ -93,7 +95,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
                 <span
                   style={{
                     display: "inline-block",
-                    fontSize: 9,
+                    fontSize: s(9),
                     fontFamily: "'JetBrains Mono',monospace",
                     color: "rgba(255,255,255,0.35)",
                     background: "rgba(255,255,255,0.05)",
@@ -110,7 +112,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
               {/* Question text */}
               <div
                 style={{
-                  fontSize: 14,
+                  fontSize: s(14),
                   color: "rgba(255,255,255,0.82)",
                   fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
                   lineHeight: 1.6,
@@ -186,7 +188,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
                       <div style={{ flex: 1, minWidth: 0 }}>
                         <div
                           style={{
-                            fontSize: 13,
+                            fontSize: s(13),
                             fontFamily: "system-ui,-apple-system,sans-serif",
                             color: selected ? "rgba(255,255,255,0.88)" : "rgba(255,255,255,0.6)",
                             fontWeight: 500,
@@ -198,7 +200,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
                         {opt.description && (
                           <div
                             style={{
-                              fontSize: 11,
+                              fontSize: s(11),
                               color: "rgba(255,255,255,0.3)",
                               fontFamily: "system-ui,-apple-system,sans-serif",
                               lineHeight: 1.5,
@@ -238,7 +240,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
                       border: "1px solid rgba(255,255,255,0.05)",
                       borderRadius: 8,
                       color: "rgba(255,255,255,0.6)",
-                      fontSize: 13,
+                      fontSize: s(13),
                       fontFamily: "system-ui,-apple-system,sans-serif",
                       fontWeight: 400,
                       lineHeight: 1.4,
@@ -261,7 +263,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
                 padding: "6px 16px",
                 borderRadius: 6,
                 border: "none",
-                fontSize: 12,
+                fontSize: s(12),
                 fontFamily: "system-ui,-apple-system,sans-serif",
                 fontWeight: 500,
                 cursor: hasAnswer ? "pointer" : "default",
@@ -278,7 +280,7 @@ export default function AskUserQuestionBlock({ tool, onAnswer }) {
         {submitted && (
           <div style={{
             marginTop: 10,
-            fontSize: 10,
+            fontSize: s(10),
             fontFamily: "'JetBrains Mono',monospace",
             color: "rgba(255,255,255,0.25)",
             letterSpacing: ".06em",

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -5,8 +5,10 @@ import EmptyState from "./EmptyState";
 import ModelPicker from "./ModelPicker";
 import ImagePreview from "./ImagePreview";
 import SelectionToolbar from "./SelectionToolbar";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSidebar, sidebarOpen, onModelChange, defaultModel, queuedMessages, onToggleTerminal, terminalOpen, terminalCount, wallpaper }) {
+  const s = useFontScale();
   const [input, setInput]             = useState("");
   const [inputFocused, setInputFocused] = useState(false);
   const [attachments, setAttachments]   = useState([]);
@@ -246,7 +248,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
           {convo && (
             <div style={{ animation: "dropIn .2s ease" }}>
               <div style={{
-                fontSize: 13,
+                fontSize: s(13),
                 color: "rgba(255,255,255,0.88)",
                 fontFamily: "system-ui,sans-serif",
                 overflow: "hidden",
@@ -258,7 +260,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               </div>
               <div
                 style={{
-                  fontSize: 9,
+                  fontSize: s(9),
                   fontFamily: "'JetBrains Mono',monospace",
                   color: "rgba(255,255,255,0.3)",
                   marginTop: 1,
@@ -298,7 +300,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               <TerminalIcon size={14} strokeWidth={1.5} />
               {terminalCount > 0 && (
                 <span style={{
-                  fontSize: 10,
+                  fontSize: s(10),
                   fontFamily: "'JetBrains Mono',monospace",
                   color: "inherit",
                 }}>
@@ -358,12 +360,12 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
                   background: "rgba(255,255,255,0.03)",
                   border: "1px solid rgba(255,255,255,0.05)",
                   borderRadius: 8,
-                  fontSize: 12,
+                  fontSize: s(12),
                   color: "rgba(255,255,255,0.35)",
                   fontFamily: "system-ui,sans-serif",
                 }}>
                   <span style={{
-                    fontSize: 9,
+                    fontSize: s(9),
                     fontFamily: "'JetBrains Mono',monospace",
                     color: "rgba(255,255,255,0.2)",
                     letterSpacing: ".06em",
@@ -406,12 +408,12 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
                   onMouseEnter={() => setSelectedCmd(i)}
                 >
                   <span style={{
-                    fontSize: 12,
+                    fontSize: s(12),
                     fontFamily: "'JetBrains Mono',monospace",
                     color: "rgba(255,255,255,0.7)",
                   }}>{c.cmd}</span>
                   <span style={{
-                    fontSize: 11,
+                    fontSize: s(11),
                     color: "rgba(255,255,255,0.25)",
                     fontFamily: "system-ui,sans-serif",
                   }}>{c.desc}</span>
@@ -450,11 +452,11 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
                 border: "none",
                 resize: "none",
                 color: "rgba(255,255,255,0.92)",
-                fontSize: 13,
-                lineHeight: "20px",
-                fontFamily: "system-ui,sans-serif",
+                fontSize: s(15),
+                lineHeight: 1.7,
+                fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
                 maxHeight: 120,
-                height: 20,
+                height: "auto",
                 display: "block",
                 overflow: "hidden",
               }}
@@ -510,7 +512,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
             style={{
               textAlign: "center",
               marginTop: 8,
-              fontSize: 8,
+              fontSize: s(8),
               fontFamily: "'JetBrains Mono',monospace",
               color: "rgba(255,255,255,0.15)",
               letterSpacing: ".1em",

--- a/src/components/CopyBtn.jsx
+++ b/src/components/CopyBtn.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Copy, Check } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function CopyBtn({ text }) {
   const [ok, set] = useState(false);
+  const s = useFontScale();
 
   const handleCopy = () => {
     if (navigator.clipboard) {
@@ -26,7 +28,7 @@ export default function CopyBtn({ text }) {
         display: "inline-flex",
         alignItems: "center",
         gap: 3,
-        fontSize: 10,
+        fontSize: s(10),
         fontFamily: "'JetBrains Mono',monospace",
       }}
       onMouseEnter={(e) => { if (!ok) e.currentTarget.style.color = "rgba(255,255,255,0.5)"; }}

--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function EmptyState() {
+  const s = useFontScale();
   const [info, setInfo] = useState(null);
 
   useEffect(() => {
@@ -76,20 +78,20 @@ export default function EmptyState() {
           fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
         }}>
           <div style={{
-            fontSize: 15,
+            fontSize: s(15),
             color: "rgba(255,255,255,0.18)",
             letterSpacing: ".06em",
             fontWeight: 500,
           }}>
             {info.user}@{info.hostname}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.15)", letterSpacing: ".04em" }}>
+          <div style={{ fontSize: s(11), color: "rgba(255,255,255,0.15)", letterSpacing: ".04em" }}>
             {info.platform} {info.arch} · {info.cpus} cores · {info.memory}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.15)", letterSpacing: ".04em" }}>
+          <div style={{ fontSize: s(11), color: "rgba(255,255,255,0.15)", letterSpacing: ".04em" }}>
             node {info.nodeVersion} · electron {info.electronVersion}
           </div>
-          <div style={{ fontSize: 11, color: "rgba(255,255,255,0.15)", letterSpacing: ".04em" }}>
+          <div style={{ fontSize: s(11), color: "rgba(255,255,255,0.15)", letterSpacing: ".04em" }}>
             {info.shell}
           </div>
         </div>

--- a/src/components/ImagePreview.jsx
+++ b/src/components/ImagePreview.jsx
@@ -1,6 +1,8 @@
 import { X, FileText } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function ImagePreview({ items, onRemove }) {
+  const s = useFontScale();
   if (!items || items.length === 0) return null;
 
   return (
@@ -30,7 +32,7 @@ export default function ImagePreview({ items, onRemove }) {
               display: "flex",
               alignItems: "center",
               gap: 6,
-              fontSize: 11,
+              fontSize: s(11),
               fontFamily: "'JetBrains Mono',monospace",
               color: "rgba(255,255,255,0.5)",
             }}>

--- a/src/components/InteractiveBlock.jsx
+++ b/src/components/InteractiveBlock.jsx
@@ -1,7 +1,9 @@
 import { useRef, useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function InteractiveBlock({ code, isStreaming }) {
+  const s = useFontScale();
   const iframeRef = useRef(null);
   const [height, setHeight] = useState(300);
   const [loaded, setLoaded] = useState(false);
@@ -31,7 +33,7 @@ export default function InteractiveBlock({ code, isStreaming }) {
           }}
         />
         <span style={{
-          fontSize: 9,
+          fontSize: s(9),
           fontFamily: "'JetBrains Mono',monospace",
           color: "rgba(255,255,255,0.2)",
           letterSpacing: ".1em",
@@ -86,7 +88,7 @@ ${code}
       position: "relative",
     }}>
       <div style={{
-        fontSize: 8,
+        fontSize: s(8),
         fontFamily: "'JetBrains Mono',monospace",
         color: "rgba(255,255,255,0.2)",
         letterSpacing: ".1em",

--- a/src/components/MermaidBlock.jsx
+++ b/src/components/MermaidBlock.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import mermaid from "mermaid";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 let mermaidInitialized = false;
 let renderCounter = 0;
@@ -100,6 +101,7 @@ function initMermaid() {
 }
 
 export default function MermaidBlock({ code }) {
+  const s = useFontScale();
   const [svg, setSvg] = useState(null);
   const [error, setError] = useState(false);
   const lastRendered = useRef("");
@@ -144,7 +146,7 @@ export default function MermaidBlock({ code }) {
         borderRadius: 8,
         padding: "12px 14px",
         overflow: "auto",
-        fontSize: 12,
+        fontSize: s(12),
         fontFamily: "'JetBrains Mono',monospace",
         margin: "8px 0 12px",
         lineHeight: 1.6,
@@ -172,7 +174,7 @@ export default function MermaidBlock({ code }) {
         margin: "8px 0 12px",
         textAlign: "center",
         color: "rgba(255,255,255,0.25)",
-        fontSize: 11,
+        fontSize: s(11),
         fontFamily: "'JetBrains Mono',monospace",
         // Preserve last known height to prevent scroll jumps
         minHeight: lastHeight.current || undefined,

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Pencil, Loader2, FileText } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -15,6 +15,7 @@ import AskUserQuestionBlock from "./AskUserQuestionBlock";
 import MermaidBlock from "./MermaidBlock";
 import InteractiveBlock from "./InteractiveBlock";
 import ThinkingBlock from "./ThinkingBlock";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 // Allow SVG tags in markdown (rehype-sanitize schema)
 const sanitizeSchema = {
@@ -48,7 +49,7 @@ const sanitizeSchema = {
   },
 };
 
-const makeMdComponents = (isStreaming = false) => ({
+const makeMdComponents = (isStreaming = false, s = (x) => x) => ({
   p: ({ children }) => <p style={{ margin: "0 0 12px" }}>{children}</p>,
   code: ({ node, className, children, ...props }) => {
     const match = /language-(\w+)/.exec(className || "");
@@ -80,7 +81,7 @@ const makeMdComponents = (isStreaming = false) => ({
             background: "transparent",
             margin: 0,
             padding: 0,
-            fontSize: 12,
+            fontSize: s(12),
             fontFamily: "'JetBrains Mono',monospace",
             lineHeight: 1.6,
           }}
@@ -93,7 +94,7 @@ const makeMdComponents = (isStreaming = false) => ({
     return (
       <code style={{
         fontFamily: "'JetBrains Mono',monospace",
-        fontSize: 12,
+        fontSize: s(12),
       }} {...props}>{children}</code>
     );
   },
@@ -116,7 +117,7 @@ const makeMdComponents = (isStreaming = false) => ({
         borderRadius: 8,
         padding: "12px 14px",
         overflow: "auto",
-        fontSize: 12,
+        fontSize: s(12),
         fontFamily: "'JetBrains Mono',monospace",
         margin: "8px 0 12px",
         lineHeight: 1.6,
@@ -132,9 +133,9 @@ const makeMdComponents = (isStreaming = false) => ({
   ul: ({ children }) => <ul style={{ paddingLeft: 20, margin: "4px 0 12px" }}>{children}</ul>,
   ol: ({ children }) => <ol style={{ paddingLeft: 20, margin: "4px 0 12px" }}>{children}</ol>,
   li: ({ children }) => <li style={{ marginBottom: 4 }}>{children}</li>,
-  h1: ({ children }) => <h1 style={{ fontSize: 20, fontWeight: 600, margin: "16px 0 8px" }}>{children}</h1>,
-  h2: ({ children }) => <h2 style={{ fontSize: 17, fontWeight: 600, margin: "14px 0 6px" }}>{children}</h2>,
-  h3: ({ children }) => <h3 style={{ fontSize: 15, fontWeight: 600, margin: "12px 0 4px" }}>{children}</h3>,
+  h1: ({ children }) => <h1 style={{ fontSize: s(20), fontWeight: 600, margin: "16px 0 8px" }}>{children}</h1>,
+  h2: ({ children }) => <h2 style={{ fontSize: s(17), fontWeight: 600, margin: "14px 0 6px" }}>{children}</h2>,
+  h3: ({ children }) => <h3 style={{ fontSize: s(15), fontWeight: 600, margin: "12px 0 4px" }}>{children}</h3>,
   blockquote: ({ children }) => (
     <blockquote style={{
       borderLeft: "2px solid rgba(255,255,255,0.15)",
@@ -143,7 +144,7 @@ const makeMdComponents = (isStreaming = false) => ({
       color: "rgba(255,255,255,0.45)",
       fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
       fontStyle: "italic",
-      fontSize: 13,
+      fontSize: s(13),
       lineHeight: 1.7,
     }}>{children}</blockquote>
   ),
@@ -162,7 +163,7 @@ const makeMdComponents = (isStreaming = false) => ({
       width: "100%",
       borderCollapse: "collapse",
       margin: "8px 0 12px",
-      fontSize: 13,
+      fontSize: s(13),
     }}>{children}</table>
   ),
   thead: ({ children }) => <thead style={{ borderBottom: "1px solid rgba(255,255,255,0.1)" }}>{children}</thead>,
@@ -179,10 +180,14 @@ function sanitizeText(text) {
 }
 
 // Cache both variants to avoid recreating components on every render
+// Default (unscaled) components for module-level fallback
 const mdComponentsStatic = makeMdComponents(false);
-const mdComponentsStreaming = makeMdComponents(true);
+const scaledMdStreaming = makeMdComponents(true);
 
 export default function Message({ msg, onEdit, onAnswer }) {
+  const s = useFontScale();
+  const scaledMdStatic = useMemo(() => makeMdComponents(false, s), [s]);
+  const scaledMdStreaming = useMemo(() => makeMdComponents(true, s), [s]);
   const isUser = msg.role === "user";
   const hasThinkingPart = Boolean(msg.parts?.some((part) => part.type === "thinking"));
 
@@ -238,7 +243,7 @@ export default function Message({ msg, onEdit, onAnswer }) {
         }}
       >
         <div style={{
-          fontSize: 9,
+          fontSize: s(9),
           fontFamily: "'JetBrains Mono',monospace",
           color: "rgba(255,255,255,0.2)",
           letterSpacing: ".14em",
@@ -260,9 +265,9 @@ export default function Message({ msg, onEdit, onAnswer }) {
                 border: "1px solid rgba(255,255,255,0.1)",
                 borderRadius: 8,
                 color: "rgba(255,255,255,0.9)",
-                fontSize: 14,
+                fontSize: s(15),
                 lineHeight: 1.7,
-                fontFamily: "system-ui,sans-serif",
+                fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
                 padding: "10px 12px",
                 resize: "vertical",
                 minHeight: 60,
@@ -277,7 +282,7 @@ export default function Message({ msg, onEdit, onAnswer }) {
                   borderRadius: 6,
                   color: "rgba(255,255,255,0.4)",
                   padding: "4px 12px",
-                  fontSize: 11,
+                  fontSize: s(11),
                   height: 26,
                   cursor: "pointer",
                 }}
@@ -291,7 +296,7 @@ export default function Message({ msg, onEdit, onAnswer }) {
                   borderRadius: 6,
                   color: editChanged ? "#000" : "rgba(255,255,255,0.25)",
                   padding: "3px 12px",
-                  fontSize: 11,
+                  fontSize: s(11),
                   height: 24,
                   cursor: editChanged ? "pointer" : "default",
                 }}
@@ -319,7 +324,7 @@ export default function Message({ msg, onEdit, onAnswer }) {
                 background: "rgba(255,255,255,0.04)",
                 border: "1px solid rgba(255,255,255,0.08)",
                 borderRadius: 6,
-                fontSize: 11,
+                fontSize: s(11),
                 fontFamily: "'JetBrains Mono',monospace",
                 color: "rgba(255,255,255,0.5)",
               }}>
@@ -332,14 +337,14 @@ export default function Message({ msg, onEdit, onAnswer }) {
 
             <div style={{
               color: "rgba(255,255,255,0.92)",
-              fontSize: 15,
+              fontSize: s(15),
               lineHeight: 1.7,
-              fontFamily: "system-ui,-apple-system,sans-serif",
+              fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
               fontWeight: 400,
               textAlign: "left",
               maxWidth: "85%",
             }}>
-              <Markdown remarkPlugins={[remarkGfm]} components={mdComponentsStatic}>
+              <Markdown remarkPlugins={[remarkGfm]} components={scaledMdStatic}>
                 {displayText}
               </Markdown>
             </div>
@@ -369,7 +374,7 @@ export default function Message({ msg, onEdit, onAnswer }) {
       }}
     >
       <div style={{
-        fontSize: 9,
+        fontSize: s(9),
         fontFamily: "'JetBrains Mono',monospace",
         color: "rgba(255,255,255,0.2)",
         letterSpacing: ".14em",
@@ -388,13 +393,13 @@ export default function Message({ msg, onEdit, onAnswer }) {
           return (
             <div key={i} style={{
               color: "rgba(255,255,255,0.75)",
-              fontSize: 15,
+              fontSize: s(15),
               lineHeight: 1.85,
               fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
               letterSpacing: "0.008em",
               marginBottom: 4,
             }}>
-              <Markdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]} components={(msg.isStreaming && isLastPart) ? mdComponentsStreaming : mdComponentsStatic}>
+              <Markdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]} components={(msg.isStreaming && isLastPart) ? scaledMdStreaming : mdComponentsStatic}>
                 {sanitizeText(part.text)}
               </Markdown>
               {msg.isStreaming && isLastPart && (
@@ -439,12 +444,12 @@ export default function Message({ msg, onEdit, onAnswer }) {
       {!msg.parts && msg.text && (
         <div style={{
           color: "rgba(255,255,255,0.75)",
-          fontSize: 15,
+          fontSize: s(15),
           lineHeight: 1.85,
           fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
           letterSpacing: "0.008em",
         }}>
-          <Markdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]} components={mdComponentsStatic}>
+          <Markdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]} components={scaledMdStatic}>
             {sanitizeText(msg.text)}
           </Markdown>
         </div>

--- a/src/components/ModelPicker.jsx
+++ b/src/components/ModelPicker.jsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from "react";
 import { ChevronDown } from "lucide-react";
 import { MODELS, getM } from "../data/models";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function ModelPicker({ value, onChange }) {
+  const s = useFontScale();
   const [open, set] = useState(false);
   const ref = useRef(null);
   const m = getM(value);
@@ -28,7 +30,7 @@ export default function ModelPicker({ value, onChange }) {
           border: "1px solid rgba(255,255,255,0.04)",
           borderRadius: 7,
           color: "rgba(255,255,255,0.4)",
-          fontSize: 10,
+          fontSize: s(10),
           fontFamily: "'JetBrains Mono',monospace",
           cursor: "pointer",
           transition: "all .2s",
@@ -71,7 +73,7 @@ export default function ModelPicker({ value, onChange }) {
                 border: "none",
                 borderRadius: 7,
                 color: mm.id === value ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.4)",
-                fontSize: 11,
+                fontSize: s(11),
                 fontFamily: "'JetBrains Mono',monospace",
                 cursor: "pointer",
                 textAlign: "left",
@@ -81,7 +83,7 @@ export default function ModelPicker({ value, onChange }) {
               onMouseLeave={(e) => { if (mm.id !== value) e.currentTarget.style.background = "transparent"; }}
             >
               {mm.name}
-              <span style={{ fontSize: 9, opacity: 0.4, letterSpacing: ".1em" }}>{mm.tag}</span>
+              <span style={{ fontSize: s(9), opacity: 0.4, letterSpacing: ".1em" }}>{mm.tag}</span>
             </button>
           ))}
         </div>

--- a/src/components/SelectionToolbar.jsx
+++ b/src/components/SelectionToolbar.jsx
@@ -2,8 +2,10 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { Sparkles, Quote, Loader2 } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function SelectionToolbar({ onQuote, model }) {
+  const s = useFontScale();
   const [sel, setSel] = useState(null); // { text, x, y }
   const [explanation, setExplanation] = useState(null); // { text, loading }
   const [explaining, setExplaining] = useState(false);
@@ -151,6 +153,7 @@ export default function SelectionToolbar({ onQuote, model }) {
 }
 
 function ToolbarBtn({ label, onClick, active }) {
+  const s = useFontScale();
   const [hovered, setHovered] = useState(false);
   return (
     <button
@@ -167,7 +170,7 @@ function ToolbarBtn({ label, onClick, active }) {
         background: active ? "rgba(255,255,255,0.1)" : hovered ? "rgba(255,255,255,0.06)" : "transparent",
         color: active ? "rgba(255,255,255,0.9)" : hovered ? "rgba(255,255,255,0.8)" : "rgba(255,255,255,0.55)",
         cursor: "pointer",
-        fontSize: 11,
+        fontSize: s(11),
         fontFamily: "system-ui,sans-serif",
         fontWeight: 500,
         transition: "all .15s",
@@ -180,6 +183,7 @@ function ToolbarBtn({ label, onClick, active }) {
 }
 
 function ExplainPane({ explanation, position }) {
+  const s = useFontScale();
   return (
     <div style={{
       width: 340,
@@ -200,7 +204,7 @@ function ExplainPane({ explanation, position }) {
           alignItems: "center",
           gap: 6,
           color: "rgba(255,255,255,0.4)",
-          fontSize: 12,
+          fontSize: s(12),
           fontFamily: "system-ui,sans-serif",
         }}>
           <Loader2 size={12} strokeWidth={2} style={{ animation: "spin 1s linear infinite" }} />
@@ -209,7 +213,7 @@ function ExplainPane({ explanation, position }) {
       ) : (
         <div style={{
           color: "rgba(255,255,255,0.7)",
-          fontSize: 13,
+          fontSize: s(13),
           lineHeight: 1.6,
           fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
           letterSpacing: "0.005em",

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,9 +1,11 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { ArrowLeft, Image } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 const DEFAULTS = { path: null, dataUrl: null, opacity: 50, blur: 32, imgBlur: 0, imgDarken: 0 };
 
-export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
+export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFontSizeChange, onClose }) {
+  const s = useFontScale();
   const [local, setLocal] = useState(() => wallpaper ?? { ...DEFAULTS });
   const debounceRef = useRef(null);
 
@@ -144,7 +146,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
         </button>
         <span
           style={{
-            fontSize: 14,
+            fontSize: s(14),
             fontWeight: 600,
             color: "rgba(255,255,255,0.85)",
           }}
@@ -168,7 +170,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
           <div
             style={{
               fontFamily: "'JetBrains Mono', monospace",
-              fontSize: 10,
+              fontSize: s(10),
               fontWeight: 600,
               color: "rgba(255,255,255,0.25)",
               letterSpacing: ".12em",
@@ -183,7 +185,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
           <div style={{ marginBottom: 28 }}>
             <div
               style={{
-                fontSize: 13,
+                fontSize: s(13),
                 color: "rgba(255,255,255,0.8)",
                 marginBottom: 2,
               }}
@@ -192,7 +194,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
             </div>
             <div
               style={{
-                fontSize: 11,
+                fontSize: s(11),
                 color: "rgba(255,255,255,0.3)",
                 marginBottom: 12,
               }}
@@ -249,7 +251,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
                       : "rgba(255,255,255,0.06)",
                     border: "1px solid rgba(255,255,255,0.06)",
                     color: "rgba(255,255,255,0.75)",
-                    fontSize: 12,
+                    fontSize: s(12),
                     cursor: "pointer",
                     transition: "all .2s",
                     fontFamily: "system-ui, sans-serif",
@@ -270,7 +272,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
                         : "rgba(255,255,255,0.03)",
                       border: "1px solid rgba(255,255,255,0.06)",
                       color: "rgba(255,255,255,0.45)",
-                      fontSize: 12,
+                      fontSize: s(12),
                       cursor: "pointer",
                       transition: "all .2s",
                       fontFamily: "system-ui, sans-serif",
@@ -287,7 +289,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
               <div
                 style={{
                   fontFamily: "'JetBrains Mono', monospace",
-                  fontSize: 10,
+                  fontSize: s(10),
                   color: "rgba(255,255,255,0.15)",
                   marginTop: 4,
                   marginLeft: 2,
@@ -302,7 +304,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
           <div style={{ marginBottom: 24 }}>
             <div
               style={{
-                fontSize: 13,
+                fontSize: s(13),
                 color: "rgba(255,255,255,0.8)",
                 marginBottom: 10,
               }}
@@ -323,7 +325,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
           <div style={{ marginBottom: 24 }}>
             <div
               style={{
-                fontSize: 13,
+                fontSize: s(13),
                 color: "rgba(255,255,255,0.8)",
                 marginBottom: 10,
               }}
@@ -344,7 +346,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
           <div style={{ marginBottom: 24 }}>
             <div
               style={{
-                fontSize: 13,
+                fontSize: s(13),
                 color: "rgba(255,255,255,0.8)",
                 marginBottom: 10,
               }}
@@ -365,7 +367,7 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
           <div style={{ marginBottom: 24 }}>
             <div
               style={{
-                fontSize: 13,
+                fontSize: s(13),
                 color: "rgba(255,255,255,0.8)",
                 marginBottom: 10,
               }}
@@ -379,6 +381,43 @@ export default function Settings({ wallpaper, onWallpaperChange, onClose }) {
               value={local.blur}
               onChange={(e) => update({ blur: Number(e.target.value) })}
               style={sliderStyle(blurPct)}
+            />
+          </div>
+
+          {/* TYPOGRAPHY section label */}
+          <div
+            style={{
+              fontFamily: "'JetBrains Mono', monospace",
+              fontSize: s(10),
+              fontWeight: 600,
+              color: "rgba(255,255,255,0.25)",
+              letterSpacing: ".12em",
+              textTransform: "uppercase",
+              marginBottom: 20,
+              marginTop: 12,
+            }}
+          >
+            TYPOGRAPHY
+          </div>
+
+          {/* Font Size */}
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                fontSize: s(13),
+                color: "rgba(255,255,255,0.8)",
+                marginBottom: 10,
+              }}
+            >
+              Font Size: {fontSize}px
+            </div>
+            <input
+              type="range"
+              min={12}
+              max={22}
+              value={fontSize}
+              onChange={(e) => onFontSizeChange(Number(e.target.value))}
+              style={sliderStyle(((fontSize - 12) / 10) * 100)}
             />
           </div>
         </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { useFontScale } from "../contexts/FontSizeContext";
 import { Plus, Search, Trash2, X, FolderOpen, Settings as SettingsIcon } from "lucide-react";
 import { getM } from "../data/models";
 
 export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onToggleSidebar, cwd, onPickFolder, onOpenSettings }) {
+  const s = useFontScale();
   const [search, setSearch]     = useState("");
   const [searchFocused, setSF]  = useState(false);
 
@@ -111,7 +113,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
               background: "transparent",
               border: "none",
               color: "rgba(255,255,255,0.8)",
-              fontSize: 11,
+              fontSize: s(11),
               fontFamily: "'JetBrains Mono',monospace",
             }}
           />
@@ -132,7 +134,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             textAlign: "center",
           }}>
             <div style={{
-              fontSize: 11,
+              fontSize: s(11),
               fontFamily: "'JetBrains Mono',monospace",
               color: "rgba(255,255,255,0.15)",
               letterSpacing: ".08em",
@@ -140,7 +142,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
               NO CONVERSATIONS
             </div>
             <div style={{
-              fontSize: 10,
+              fontSize: s(10),
               color: "rgba(255,255,255,0.1)",
               fontFamily: "system-ui,sans-serif",
             }}>
@@ -180,7 +182,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div
                     style={{
-                      fontSize: 12.5,
+                      fontSize: s(12.5),
                       color: isActive ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.45)",
                       overflow: "hidden",
                       textOverflow: "ellipsis",
@@ -193,7 +195,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                   </div>
                   <div
                     style={{
-                      fontSize: 11,
+                      fontSize: s(11),
                       color: "rgba(255,255,255,0.3)",
                       overflow: "hidden",
                       textOverflow: "ellipsis",
@@ -221,7 +223,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
               <div
                 style={{
                   marginTop: 6,
-                  fontSize: 9,
+                  fontSize: s(9),
                   fontFamily: "'JetBrains Mono',monospace",
                   color: "rgba(255,255,255,0.35)",
                   letterSpacing: ".08em",
@@ -253,7 +255,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             background: "none",
             border: "none",
             cursor: "pointer",
-            fontSize: 8,
+            fontSize: s(8),
             fontFamily: "'JetBrains Mono',monospace",
             color: "rgba(255,255,255,0.28)",
             letterSpacing: ".08em",
@@ -287,7 +289,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
         >
           <SettingsIcon size={12} strokeWidth={1.5} />
         </button>
-        <span style={{ fontSize: 8, fontFamily: "'JetBrains Mono',monospace", color: "rgba(255,255,255,0.2)", letterSpacing: ".06em" }}>
+        <span style={{ fontSize: s(8), fontFamily: "'JetBrains Mono',monospace", color: "rgba(255,255,255,0.2)", letterSpacing: ".06em" }}>
           {convos.length} CHATS
         </span>
       </div>

--- a/src/components/TerminalDrawer.jsx
+++ b/src/components/TerminalDrawer.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { X, Plus, Terminal as TerminalIcon } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 // ── Shared style helpers ──────────────────────────────────────────────────────
 
@@ -233,6 +234,7 @@ function TerminalViewport({
 // ── EmptyState ────────────────────────────────────────────────────────────────
 
 function EmptyState({ onCreate }) {
+  const s = useFontScale();
   const btnHover = useHover(
     {
       marginTop: 12,
@@ -242,7 +244,7 @@ function EmptyState({ onCreate }) {
       border: "1px solid rgba(255,255,255,0.1)",
       color: "rgba(255,255,255,0.45)",
       cursor: "pointer",
-      fontSize: 11,
+      fontSize: s(11),
       fontFamily: FONT_FAMILY,
       letterSpacing: ".06em",
       transition: "background .15s, color .15s",
@@ -269,7 +271,7 @@ function EmptyState({ onCreate }) {
       <div
         style={{
           marginTop: 8,
-          fontSize: 11,
+          fontSize: s(11),
           fontFamily: FONT_FAMILY,
           color: "rgba(255,255,255,0.2)",
           letterSpacing: ".06em",
@@ -287,6 +289,7 @@ function EmptyState({ onCreate }) {
 // ── TabBar ────────────────────────────────────────────────────────────────────
 
 function TabBar({ sessions, activeSession, onSelectSession, onKillSession }) {
+  const s = useFontScale();
   return (
     <div
       style={{
@@ -323,7 +326,7 @@ function TabBar({ sessions, activeSession, onSelectSession, onKillSession }) {
           >
             <span
               style={{
-                fontSize: 11,
+                fontSize: s(11),
                 fontFamily: FONT_FAMILY,
                 color: isActive ? "rgba(255,255,255,0.7)" : "rgba(255,255,255,0.3)",
                 maxWidth: 120,
@@ -385,6 +388,7 @@ export default function TerminalDrawer({
   cwd,
   wallpaper,
 }) {
+  const s = useFontScale();
   const [width, setWidth] = useState(480);
   const dragging = useRef(false);
   const startX = useRef(0);
@@ -484,7 +488,7 @@ export default function TerminalDrawer({
           />
           <span
             style={{
-              fontSize: 10,
+              fontSize: s(10),
               fontFamily: FONT_FAMILY,
               color: "rgba(255,255,255,0.35)",
               letterSpacing: ".08em",

--- a/src/components/ThinkingBlock.jsx
+++ b/src/components/ThinkingBlock.jsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from "react";
 import { ChevronRight, Loader2, Check } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 export default function ThinkingBlock({ text, isThinking }) {
   const [open, setOpen] = useState(false);
+  const s = useFontScale();
   const hasText = Boolean(text && text.trim().length > 0);
   const startTime = useRef(Date.now());
   const [elapsed, setElapsed] = useState(0);
@@ -50,7 +52,7 @@ export default function ThinkingBlock({ text, isThinking }) {
         alignItems: "center",
         gap: 6,
         color: "rgba(255,255,255,0.25)",
-        fontSize: 11,
+        fontSize: s(11),
         fontFamily: "'JetBrains Mono',monospace",
         letterSpacing: ".04em",
       }}>
@@ -83,7 +85,7 @@ export default function ThinkingBlock({ text, isThinking }) {
           border: "none",
           cursor: "pointer",
           color: "rgba(255,255,255,0.3)",
-          fontSize: 11,
+          fontSize: s(11),
           fontFamily: "'JetBrains Mono',monospace",
           letterSpacing: ".04em",
           transition: "color .15s",
@@ -110,7 +112,7 @@ export default function ThinkingBlock({ text, isThinking }) {
       {open && hasText && (
         <div style={{
           padding: "0 12px 10px",
-          fontSize: 12,
+          fontSize: s(12),
           lineHeight: 1.6,
           fontFamily: "'JetBrains Mono',monospace",
           color: "rgba(255,255,255,0.25)",

--- a/src/components/ToolCallBlock.jsx
+++ b/src/components/ToolCallBlock.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { ChevronRight, ChevronDown, Terminal, FileText, Pencil, Search, Code, Loader2 } from "lucide-react";
+import { useFontScale } from "../contexts/FontSizeContext";
 
 const TOOL_ICONS = {
   Bash: Terminal,
@@ -41,6 +42,7 @@ function getPreview(tool) {
 
 export default function ToolCallBlock({ tool }) {
   const [expanded, setExpanded] = useState(false);
+  const s = useFontScale();
   const Icon = TOOL_ICONS[tool.name] || Code;
   const isRunning = tool.status === "running";
   const preview = getPreview(tool);
@@ -67,7 +69,7 @@ export default function ToolCallBlock({ tool }) {
           border: "none",
           color: "rgba(255,255,255,0.5)",
           cursor: "pointer",
-          fontSize: 11,
+          fontSize: s(11),
           fontFamily: "'JetBrains Mono',monospace",
           textAlign: "left",
         }}
@@ -77,7 +79,7 @@ export default function ToolCallBlock({ tool }) {
         {preview && !expanded && (
           <span style={{
             color: "rgba(255,255,255,0.25)",
-            fontSize: 10,
+            fontSize: s(10),
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
@@ -93,14 +95,14 @@ export default function ToolCallBlock({ tool }) {
             <Loader2 size={10} strokeWidth={2} style={{ color: "rgba(255,255,255,0.3)", animation: "spin 1s linear infinite" }} />
           )}
           {tool.status === "done" && (
-            <span style={{ color: "rgba(255,255,255,0.2)", fontSize: 10 }}>done</span>
+            <span style={{ color: "rgba(255,255,255,0.2)", fontSize: s(10) }}>done</span>
           )}
           {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </span>
       </button>
 
       {expanded && (
-        <div style={{ padding: "0 12px 10px", fontSize: 11, fontFamily: "'JetBrains Mono',monospace" }}>
+        <div style={{ padding: "0 12px 10px", fontSize: s(11), fontFamily: "'JetBrains Mono',monospace" }}>
           {tool.args && Object.keys(tool.args).length > 0 && (
             <div style={{ marginBottom: 8 }}>
               <div style={{ color: "rgba(255,255,255,0.3)", marginBottom: 4 }}>ARGS</div>
@@ -112,7 +114,7 @@ export default function ToolCallBlock({ tool }) {
                 padding: 8,
                 background: "rgba(0,0,0,0.3)",
                 borderRadius: 6,
-                fontSize: 10,
+                fontSize: s(10),
                 maxHeight: 200,
                 overflow: "auto",
               }}>
@@ -131,7 +133,7 @@ export default function ToolCallBlock({ tool }) {
                 padding: 8,
                 background: "rgba(0,0,0,0.3)",
                 borderRadius: 6,
-                fontSize: 10,
+                fontSize: s(10),
                 maxHeight: 300,
                 overflow: "auto",
               }}>

--- a/src/contexts/FontSizeContext.js
+++ b/src/contexts/FontSizeContext.js
@@ -1,0 +1,9 @@
+import { createContext, useContext } from "react";
+
+export const FontSizeContext = createContext(15);
+
+/** Scale a px value proportionally to the current font size setting. */
+export function useFontScale() {
+  const fontSize = useContext(FontSizeContext);
+  return (px) => px * fontSize / 15;
+}


### PR DESCRIPTION
## Summary
- Add font size slider (12–22px) in Settings under new Typography section
- All UI text across every component scales proportionally via `FontSizeContext`
- Unify user input and displayed message font to Newsreader serif (matching assistant messages)

## Test plan
- [ ] Open Settings, verify Typography section with Font Size slider appears
- [ ] Drag slider — all text (sidebar, chat, messages, labels, buttons) should scale
- [ ] Verify user input textarea uses Newsreader serif font
- [ ] Verify font size persists across app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)