### PR TITLE
Copy selected wallpapers into app-managed storage

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -8,6 +8,16 @@ const { createCheckpoint, restoreCheckpoint } = require("./checkpoint.cjs");
 const terminalManager = require("./terminal-manager.cjs");
 
 const isDev = !app.isPackaged;
+const WALLPAPER_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "gif", "bmp", "avif"];
+const WALLPAPER_MIME_TYPES = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  gif: "image/gif",
+  bmp: "image/bmp",
+  avif: "image/avif",
+};
 
 // Override app name (in dev, Electron uses its own binary name)
 app.setName("Claudi");
@@ -22,6 +32,39 @@ if (isDev && process.platform === "darwin") {
 }
 
 let mainWindow;
+
+function getWallpaperStorageDir() {
+  const dir = path.join(app.getPath("userData"), "wallpapers");
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function isManagedWallpaperPath(filePath) {
+  if (!filePath) return false;
+  const relative = path.relative(getWallpaperStorageDir(), path.resolve(filePath));
+  return relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function removeManagedWallpaper(filePath) {
+  if (!isManagedWallpaperPath(filePath)) return;
+  try {
+    fs.unlinkSync(filePath);
+  } catch {}
+}
+
+function importWallpaperToStorage(sourcePath, previousPath) {
+  const ext = path.extname(sourcePath).toLowerCase();
+  const baseName = path.basename(sourcePath, ext)
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "wallpaper";
+  const storedPath = path.join(getWallpaperStorageDir(), `${Date.now()}-${baseName}${ext || ".png"}`);
+  fs.copyFileSync(sourcePath, storedPath);
+  if (previousPath && previousPath !== storedPath) {
+    removeManagedWallpaper(previousPath);
+  }
+  return storedPath;
+}
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -114,12 +157,28 @@ ipcMain.handle("folder-pick", async () => {
 });
 
 // IPC: wallpaper image picker
-ipcMain.handle("select-wallpaper", async () => {
+ipcMain.handle("select-wallpaper", async (_event, previousPath) => {
   const result = await dialog.showOpenDialog(mainWindow, {
     properties: ["openFile"],
-    filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "gif", "bmp", "avif"] }],
+    filters: [{ name: "Images", extensions: WALLPAPER_EXTENSIONS }],
   });
-  return result.canceled ? null : result.filePaths[0];
+  if (result.canceled) return null;
+  try {
+    return importWallpaperToStorage(result.filePaths[0], previousPath);
+  } catch (error) {
+    console.error("Failed to import wallpaper:", error);
+    return null;
+  }
+});
+
+ipcMain.handle("delete-wallpaper", async (_event, filePath) => {
+  try {
+    removeManagedWallpaper(filePath);
+    return true;
+  } catch (error) {
+    console.error("Failed to delete wallpaper:", error);
+    return false;
+  }
 });
 
 // IPC: read image file as data URL (for wallpaper preview + background)
@@ -127,7 +186,7 @@ ipcMain.handle("read-image", async (_event, filePath) => {
   try {
     const data = fs.readFileSync(filePath);
     const ext = path.extname(filePath).toLowerCase().replace(".", "");
-    const mime = { png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", webp: "image/webp", gif: "image/gif", bmp: "image/bmp", avif: "image/avif" }[ext] || "image/png";
+    const mime = WALLPAPER_MIME_TYPES[ext] || "image/png";
     return `data:${mime};base64,${data.toString("base64")}`;
   } catch {
     return null;

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -24,7 +24,8 @@ contextBridge.exposeInMainWorld("api", {
     return () => ipcRenderer.removeListener("agent-error", handler);
   },
   pickFolder: () => ipcRenderer.invoke("folder-pick"),
-  selectWallpaper: () => ipcRenderer.invoke("select-wallpaper"),
+  selectWallpaper: (previousPath) => ipcRenderer.invoke("select-wallpaper", previousPath),
+  deleteWallpaper: (filePath) => ipcRenderer.invoke("delete-wallpaper", filePath),
   readImage: (filePath) => ipcRenderer.invoke("read-image", filePath),
   listSessions: (cwd) => ipcRenderer.invoke("list-sessions", cwd),
   loadSession: (sessionId) => ipcRenderer.invoke("load-session", sessionId),

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -48,17 +48,21 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
   );
 
   const handleChooseImage = async () => {
-    const filePath = await window.api.selectWallpaper();
+    const filePath = await window.api.selectWallpaper(local.path);
     if (!filePath) return;
     const dataUrl = await window.api.readImage(filePath);
     update({ path: filePath, dataUrl });
   };
 
-  const handleRemove = () => {
+  const handleRemove = async () => {
+    const previousPath = local.path;
     const next = { ...DEFAULTS };
     setLocal(next);
     clearTimeout(debounceRef.current);
     onWallpaperChange(null);
+    if (previousPath && window.api?.deleteWallpaper) {
+      await window.api.deleteWallpaper(previousPath);
+    }
   };
 
   const pathHint =


### PR DESCRIPTION
## Summary
- copy user-selected wallpaper files into the app's user-data wallpaper directory before saving settings
- remove previously managed wallpaper copies when a wallpaper is replaced or removed
- keep the renderer pointed at the copied file path so wallpaper state no longer depends on cloud-backed originals

Closes #10