### PR TITLE
Add Codex provider support to Claudi

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ features that are hard to get from a plain terminal session:
 - message editing with checkpoint-based file rewind support
 - image and file attachments
 - embedded terminal sessions exposed through MCP
+- terminal session CLI fallback for agents that can run shell commands
 - quick system context and local workspace selection
 
 ## Tech Stack
@@ -101,6 +102,7 @@ Some files worth reading first:
 - `electron/main.cjs` - Electron bootstrap and IPC surface
 - `electron/agent-manager.cjs` - Claude process spawning and stream handling
 - `electron/terminal-manager.cjs` - persistent PTY-backed terminal sessions
+- `scripts/claudi-terminal.cjs` - shell-friendly wrapper for the terminal session backend
 - `src/App.jsx` - top-level chat application state and interaction flow
 - `src/hooks/useAgent.js` - streamed message assembly in the renderer
 
@@ -110,4 +112,3 @@ Some files worth reading first:
   snapshot in `src-ui-backup/`.
 - External links are opened in the system browser from the Electron shell.
 - App state is persisted to the Electron user data directory as `claudi-state.json`.
-

--- a/docs/plans/2026-04-14-codex-support.md
+++ b/docs/plans/2026-04-14-codex-support.md
@@ -1,0 +1,902 @@
+# Codex (GPT-5.4) Provider Support Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add OpenAI Codex CLI as a second provider alongside Claude Code, supporting GPT-5.4 with medium/high/xhigh reasoning effort levels.
+
+**Architecture:** Provider-per-conversation model. Each conversation is bound to either Claude or Codex at creation time. The agent-manager routes to the correct CLI binary based on the model's `provider` field. The `useAgent` hook normalizes both stream formats into the same `parts[]` structure so the UI layer is provider-agnostic. Session resume uses provider-specific commands (Claude: `--resume <id>`, Codex: `exec resume <id> "prompt"`).
+
+**Tech Stack:** Electron (main process spawns CLI), React (renderer), existing IPC bridge unchanged.
+
+**Key constraints discovered during research:**
+- Codex `exec` defaults to `read-only` sandbox -- must pass `--full-auto` for workspace-write
+- Codex `--json` sends complete items (no incremental text deltas) -- text appears all at once per item
+- Codex uses `thread_id` (from `thread.started` event) for session resume, not a pre-generated UUID
+- Codex resume is a subcommand: `codex exec resume <thread_id> "prompt"`, not a flag
+- Codex images use native `-i <file>` flag (simpler than Claude's approach)
+- Codex tool calls appear as `command_execution` items, not `tool_use`/`tool_result`
+
+---
+
+### Task 1: Update model definitions
+
+**Files:**
+- Modify: `src/data/models.js`
+
+**Step 1: Add provider field and Codex models**
+
+```js
+export const MODELS = [
+  { id: "opus",   name: "Claude Opus",   tag: "OPUS",   cliFlag: "opus",   provider: "claude" },
+  { id: "sonnet", name: "Claude Sonnet", tag: "SONNET", cliFlag: "sonnet", provider: "claude" },
+  { id: "haiku",  name: "Claude Haiku",  tag: "HAIKU",  cliFlag: "haiku",  provider: "claude" },
+  { id: "gpt54-med",   name: "GPT-5.4",        tag: "GPT-5.4",       cliFlag: "gpt-5.4", provider: "codex", effort: "medium" },
+  { id: "gpt54-high",  name: "GPT-5.4 High",   tag: "GPT-5.4 HIGH",  cliFlag: "gpt-5.4", provider: "codex", effort: "high" },
+  { id: "gpt54-xhigh", name: "GPT-5.4 XHigh",  tag: "GPT-5.4 XHIGH", cliFlag: "gpt-5.4", provider: "codex", effort: "xhigh" },
+];
+
+export const getM = (id) => MODELS.find((m) => m.id === id) || MODELS[0];
+```
+
+**Step 2: Verify nothing breaks**
+
+Run: `cd /Users/kira-chan/Downloads/Ensue-Chat && npx vite build 2>&1 | tail -5`
+Expected: Build succeeds (no import errors).
+
+**Step 3: Commit**
+
+```bash
+git add src/data/models.js
+git commit -m "feat: add GPT-5.4 model definitions with provider field"
+```
+
+---
+
+### Task 2: Create Codex agent manager
+
+**Files:**
+- Create: `electron/codex-agent-manager.cjs`
+
+This module mirrors the structure of `electron/agent-manager.cjs` but spawns `codex exec` instead of `claude`.
+
+**Step 1: Write the codex agent manager**
+
+```js
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+
+const activeAgents = new Map();
+const EXTRA_PATH_DIRS = [
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+];
+
+function log(...args) {
+  console.log("[codex-agent-manager]", ...args);
+}
+
+function isExecutable(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isDirectory(dirPath) {
+  try {
+    return !!dirPath && fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function buildSpawnPath() {
+  const pathParts = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+  return [...new Set([...pathParts, ...EXTRA_PATH_DIRS])].join(path.delimiter);
+}
+
+let cachedCodexBin = null;
+
+function resolveCodexBin() {
+  if (cachedCodexBin && isExecutable(cachedCodexBin)) return cachedCodexBin;
+
+  const searchPath = buildSpawnPath();
+  const candidates = [process.env.CODEX_BIN, "codex"].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (path.isAbsolute(candidate) && isExecutable(candidate)) {
+      cachedCodexBin = candidate;
+      return candidate;
+    }
+    for (const dir of searchPath.split(path.delimiter).filter(Boolean)) {
+      const fullPath = path.join(dir, candidate);
+      if (isExecutable(fullPath)) {
+        cachedCodexBin = fullPath;
+        return fullPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, sessionId, resumeSessionId }, webContents) {
+  cancelCodexAgent(conversationId);
+
+  const codexBin = resolveCodexBin();
+  if (!codexBin) {
+    const error = "Unable to locate the Codex CLI binary. Install with: brew install codex";
+    log(error);
+    webContents.send("agent-error", { conversationId, error });
+    webContents.send("agent-done", { conversationId, exitCode: -1 });
+    return null;
+  }
+
+  // Build args: either "exec resume <id> <prompt>" or "exec <prompt>"
+  const args = ["exec"];
+
+  if (resumeSessionId) {
+    args.push("resume", resumeSessionId);
+  }
+
+  args.push("--json", "--full-auto");
+
+  if (model) args.push("-m", model);
+  if (effort) args.push("-c", `model_reasoning_effort="${effort}"`);
+
+  // Set working directory
+  if (cwd && isDirectory(cwd)) {
+    args.push("-C", cwd);
+  }
+
+  // Attach images natively
+  if (images && images.length > 0) {
+    for (let i = 0; i < images.length; i++) {
+      const dataUrl = images[i];
+      const match = dataUrl.match(/^data:image\/([\w+.-]+);base64,(.+)$/);
+      if (match) {
+        const ext = match[1] === "jpeg" ? "jpg" : match[1];
+        const tmpPath = path.join(os.tmpdir(), `ensue-codex-img-${Date.now()}-${i}.${ext}`);
+        fs.writeFileSync(tmpPath, Buffer.from(match[2], "base64"));
+        args.push("-i", tmpPath);
+      }
+    }
+  }
+
+  // Prompt goes last
+  args.push(prompt);
+
+  log("Starting codex agent:", { conversationId, model, effort, cwd, resumeSessionId });
+  log("Full args:", args.filter(a => a !== prompt).join(" "));
+
+  const child = spawn(codexBin, args, {
+    cwd: cwd || process.cwd(),
+    env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  log("Spawned PID:", child.pid);
+  activeAgents.set(conversationId, child);
+
+  let buffer = "";
+  let stderrBuffer = "";
+
+  child.stdout.on("data", (chunk) => {
+    const raw = chunk.toString();
+    log("stdout chunk:", raw.slice(0, 300));
+    buffer += raw;
+    const lines = buffer.split("\n");
+    buffer = lines.pop();
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        log("Parsed event type:", event.type);
+        webContents.send("agent-stream", { conversationId, event });
+      } catch (e) {
+        log("Failed to parse JSON line:", line.slice(0, 200), "error:", e.message);
+      }
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    log("stderr:", text);
+    stderrBuffer += text;
+  });
+
+  child.on("close", (exitCode) => {
+    log("Process closed, exitCode:", exitCode);
+    if (stderrBuffer.trim()) {
+      log("Full stderr:", stderrBuffer);
+      webContents.send("agent-error", { conversationId, error: stderrBuffer.trim() });
+    }
+    if (buffer.trim()) {
+      try {
+        const event = JSON.parse(buffer);
+        webContents.send("agent-stream", { conversationId, event });
+      } catch {}
+    }
+    activeAgents.delete(conversationId);
+    webContents.send("agent-done", { conversationId, exitCode });
+  });
+
+  child.on("error", (err) => {
+    log("Spawn error:", err.message);
+    activeAgents.delete(conversationId);
+    webContents.send("agent-error", { conversationId, error: err.message });
+  });
+
+  return child;
+}
+
+function cancelCodexAgent(conversationId) {
+  const child = activeAgents.get(conversationId);
+  if (child) {
+    log("Cancelling codex agent:", conversationId);
+    child.kill("SIGTERM");
+    activeAgents.delete(conversationId);
+  }
+}
+
+function cancelAllCodex() {
+  for (const [id, child] of activeAgents) {
+    child.kill("SIGTERM");
+  }
+  activeAgents.clear();
+}
+
+module.exports = { startCodexAgent, cancelCodexAgent, cancelAllCodex, resolveCodexBin };
+```
+
+**Step 2: Verify it loads**
+
+Run: `node -e "require('./electron/codex-agent-manager.cjs'); console.log('OK')"`
+Expected: `OK`
+
+**Step 3: Commit**
+
+```bash
+git add electron/codex-agent-manager.cjs
+git commit -m "feat: add codex agent manager for GPT-5.4 CLI integration"
+```
+
+---
+
+### Task 3: Route IPC to correct agent manager
+
+**Files:**
+- Modify: `electron/main.cjs:1-8` (imports)
+- Modify: `electron/main.cjs:196-211` (IPC handlers)
+
+**Step 1: Add codex import to main.cjs**
+
+At the top of `main.cjs`, after line 5, add the codex import:
+
+```js
+const { startCodexAgent, cancelCodexAgent, cancelAllCodex } = require("./codex-agent-manager.cjs");
+```
+
+**Step 2: Update `agent-start` IPC handler**
+
+Replace the `agent-start` handler at line 197-199 with routing logic. The `opts` object already carries `model` (the cliFlag string). We need to also pass the `provider` and `effort` fields. The renderer will send these as part of `opts`.
+
+```js
+// IPC: agent
+ipcMain.on("agent-start", (event, opts) => {
+  if (opts.provider === "codex") {
+    startCodexAgent(opts, event.sender);
+  } else {
+    startAgent(opts, event.sender);
+  }
+});
+```
+
+**Step 3: Update `agent-cancel` IPC handler**
+
+Replace line 201-203. Since we don't know which manager owns the agent, cancel on both:
+
+```js
+ipcMain.on("agent-cancel", (_event, { conversationId }) => {
+  cancelAgent(conversationId);
+  cancelCodexAgent(conversationId);
+});
+```
+
+**Step 4: Update `agent-edit-resend` IPC handler**
+
+Replace line 205-207:
+
+```js
+ipcMain.on("agent-edit-resend", (event, opts) => {
+  if (opts.provider === "codex") {
+    // Codex doesn't have fork-session; resume with the thread_id is the equivalent
+    startCodexAgent({ ...opts, resumeSessionId: opts.resumeSessionId }, event.sender);
+  } else {
+    startAgent({ ...opts, forkSession: true }, event.sender);
+  }
+});
+```
+
+**Step 5: Update app quit cleanup**
+
+Find where `cancelAll()` is called (in the `window-all-closed` or `before-quit` handler) and add `cancelAllCodex()`.
+
+**Step 6: Verify build**
+
+Run: `cd /Users/kira-chan/Downloads/Ensue-Chat && npx vite build 2>&1 | tail -5`
+Expected: Build succeeds.
+
+**Step 7: Commit**
+
+```bash
+git add electron/main.cjs
+git commit -m "feat: route agent IPC to claude or codex based on provider"
+```
+
+---
+
+### Task 4: Normalize Codex stream events in useAgent
+
+**Files:**
+- Modify: `src/hooks/useAgent.js:67-234` (inside the `onAgentStream` callback)
+
+The key mapping from Codex events to the existing `parts[]` structure:
+
+| Codex event | Action |
+|------------|--------|
+| `thread.started` | Store `thread_id` for session resume |
+| `turn.started` | Ensure assistant message exists |
+| `item.completed` + `type: "agent_message"` | Add `{ type: "text", text }` part |
+| `item.started` + `type: "command_execution"` | Add `{ type: "tool", name: cmd, status: "running" }` part |
+| `item.completed` + `type: "command_execution"` | Update tool part with result + status: "done" |
+| `turn.completed` | Mark assistant as done streaming |
+
+**Step 1: Add Codex event handling branch**
+
+Inside the `onAgentStream` callback (after the existing `if (event.type === "stream_event")` block at line 67), add an else-if chain for Codex events. The Codex events use different top-level `type` values (`thread.started`, `turn.started`, `item.completed`, etc.) so they won't collide with Claude's events.
+
+Add this after the closing `}` of the `if (event.type === "result")` block (around line 234), but before `next.set(conversationId, ...)`:
+
+```js
+// ── Codex event handling ──
+else if (event.type === "thread.started") {
+  // Store thread_id on the conversation for session resume
+  const threadId = event.thread_id;
+  if (threadId) {
+    convo._codexThreadId = threadId;
+  }
+}
+else if (event.type === "turn.started") {
+  ensureAssistant();
+}
+else if (event.type === "item.started") {
+  const item = event.item;
+  if (item?.type === "command_execution") {
+    ensureAssistant();
+    const parts = cloneParts(lastMsg.parts);
+    parts.push({
+      type: "tool",
+      id: item.id || "codex-" + uid(),
+      name: item.command || "command",
+      args: { command: item.command },
+      result: null,
+      status: "running",
+    });
+    const merged = { ...lastMsg, parts };
+    msgs[msgs.length - 1] = merged;
+    lastMsg = merged;
+  }
+}
+else if (event.type === "item.completed") {
+  const item = event.item;
+  if (item?.type === "agent_message" && item.text) {
+    ensureAssistant();
+    const parts = cloneParts(lastMsg.parts);
+    parts.push({ type: "text", text: item.text });
+    const merged = { ...lastMsg, parts };
+    msgs[msgs.length - 1] = merged;
+    lastMsg = merged;
+  }
+  else if (item?.type === "command_execution") {
+    ensureAssistant();
+    const parts = cloneParts(lastMsg.parts);
+    // Find the matching in-progress tool part
+    const toolIdx = parts.findIndex(p => p.type === "tool" && p.id === item.id);
+    if (toolIdx >= 0) {
+      parts[toolIdx] = {
+        ...parts[toolIdx],
+        result: item.aggregated_output || `exit code: ${item.exit_code}`,
+        status: "done",
+      };
+    } else {
+      // No matching item.started was seen — add complete tool part
+      parts.push({
+        type: "tool",
+        id: item.id || "codex-" + uid(),
+        name: item.command || "command",
+        args: { command: item.command },
+        result: item.aggregated_output || `exit code: ${item.exit_code}`,
+        status: "done",
+      });
+    }
+    const merged = { ...lastMsg, parts };
+    msgs[msgs.length - 1] = merged;
+    lastMsg = merged;
+  }
+}
+else if (event.type === "turn.completed") {
+  if (lastMsg && lastMsg.role === "assistant") {
+    msgs[msgs.length - 1] = { ...lastMsg, isStreaming: false, isThinking: false };
+  }
+}
+```
+
+**Step 2: Verify build**
+
+Run: `cd /Users/kira-chan/Downloads/Ensue-Chat && npx vite build 2>&1 | tail -5`
+Expected: Build succeeds.
+
+**Step 3: Commit**
+
+```bash
+git add src/hooks/useAgent.js
+git commit -m "feat: normalize codex stream events into parts[] format"
+```
+
+---
+
+### Task 5: Pass provider and effort through the send flow
+
+**Files:**
+- Modify: `src/App.jsx:249-260` (in `handleSend`)
+
+**Step 1: Update sendMessage call to include provider and effort**
+
+The `getM()` call at line 249 already returns the full model object. We need to pass `provider` and `effort` through to the IPC layer.
+
+Replace lines 249-260:
+
+```js
+      const m = getM(convo.model);
+
+      sendMessage({
+        conversationId: convoId,
+        sessionId: isFirstMessage ? convo.sessionId : undefined,
+        resumeSessionId: isFirstMessage ? undefined : convo.sessionId,
+        prompt: text,
+        model: m.cliFlag,
+        provider: m.provider || "claude",
+        effort: m.effort,
+        cwd: effectiveCwd,
+        images: images?.length ? images : undefined,
+        files: files?.length ? files : undefined,
+      });
+```
+
+**Step 2: Handle Codex thread_id for session resume**
+
+For Codex, the `sessionId` for resume is the `thread_id` returned by the `thread.started` event, not the pre-generated UUID. We need to capture it.
+
+In `App.jsx`, after the `sendMessage` call, we need to watch for the `_codexThreadId` from `useAgent` and store it on the conversation. This is tricky because the thread_id arrives asynchronously.
+
+Better approach: store the thread_id in the conversation when we receive it. Add an effect that watches for it:
+
+After the existing `useEffect` that handles state loading, add:
+
+```js
+  // Capture Codex thread_id for session resume
+  useEffect(() => {
+    if (!active) return;
+    const data = getConversation(active);
+    if (data._codexThreadId) {
+      const convo = convoList.find(c => c.id === active);
+      if (convo && convo.sessionId !== data._codexThreadId) {
+        setConvoList((p) =>
+          p.map((c) => c.id === active ? { ...c, sessionId: data._codexThreadId } : c)
+        );
+      }
+    }
+  }, [active, conversations]);
+```
+
+**Step 3: Update editAndResend to pass provider**
+
+Find the `handleEdit` callback. It calls `editAndResend()`. Ensure it passes `provider` and `effort`:
+
+```js
+  const handleEdit = useCallback(
+    async (messageIndex, newText) => {
+      // ... existing checkpoint logic ...
+      const m = getM(activeConvo.model);
+      editAndResend({
+        conversationId: active,
+        sessionId: activeConvo.sessionId,
+        messageIndex,
+        newText,
+        model: m.cliFlag,
+        provider: m.provider || "claude",
+        effort: m.effort,
+        cwd: activeConvo.cwd || cwd,
+      });
+    },
+    [active, activeConvo, cwd, editAndResend]
+  );
+```
+
+**Step 4: Verify build**
+
+Run: `cd /Users/kira-chan/Downloads/Ensue-Chat && npx vite build 2>&1 | tail -5`
+
+**Step 5: Commit**
+
+```bash
+git add src/App.jsx
+git commit -m "feat: pass provider and effort through send flow for codex routing"
+```
+
+---
+
+### Task 6: Update ModelPicker with provider grouping
+
+**Files:**
+- Modify: `src/components/ModelPicker.jsx`
+
+**Step 1: Group models by provider in dropdown**
+
+Replace the `MODELS.map()` block inside the dropdown with grouped rendering:
+
+```jsx
+{/* Claude models */}
+<div style={{ padding: "4px 10px 2px", fontSize: s(8), color: "rgba(255,255,255,0.2)", letterSpacing: ".12em", fontFamily: "'JetBrains Mono',monospace" }}>
+  CLAUDE
+</div>
+{MODELS.filter(mm => mm.provider === "claude").map((mm) => (
+  <button
+    key={mm.id}
+    onClick={() => { onChange(mm.id); set(false); }}
+    style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      width: "100%",
+      padding: "9px 13px",
+      background: mm.id === value ? "rgba(255,255,255,0.04)" : "transparent",
+      border: "none",
+      borderRadius: 7,
+      color: mm.id === value ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.4)",
+      fontSize: s(11),
+      fontFamily: "'JetBrains Mono',monospace",
+      cursor: "pointer",
+      textAlign: "left",
+      transition: "all .12s",
+    }}
+    onMouseEnter={(e) => { if (mm.id !== value) e.currentTarget.style.background = "rgba(255,255,255,0.025)"; }}
+    onMouseLeave={(e) => { if (mm.id !== value) e.currentTarget.style.background = "transparent"; }}
+  >
+    {mm.name}
+    <span style={{ fontSize: s(9), opacity: 0.4, letterSpacing: ".1em" }}>{mm.tag}</span>
+  </button>
+))}
+
+{/* Divider */}
+<div style={{ height: 1, background: "rgba(255,255,255,0.04)", margin: "4px 8px" }} />
+
+{/* Codex models */}
+<div style={{ padding: "4px 10px 2px", fontSize: s(8), color: "rgba(255,255,255,0.2)", letterSpacing: ".12em", fontFamily: "'JetBrains Mono',monospace" }}>
+  CODEX
+</div>
+{MODELS.filter(mm => mm.provider === "codex").map((mm) => (
+  <button
+    key={mm.id}
+    onClick={() => { onChange(mm.id); set(false); }}
+    style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      width: "100%",
+      padding: "9px 13px",
+      background: mm.id === value ? "rgba(255,255,255,0.04)" : "transparent",
+      border: "none",
+      borderRadius: 7,
+      color: mm.id === value ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.4)",
+      fontSize: s(11),
+      fontFamily: "'JetBrains Mono',monospace",
+      cursor: "pointer",
+      textAlign: "left",
+      transition: "all .12s",
+    }}
+    onMouseEnter={(e) => { if (mm.id !== value) e.currentTarget.style.background = "rgba(255,255,255,0.025)"; }}
+    onMouseLeave={(e) => { if (mm.id !== value) e.currentTarget.style.background = "transparent"; }}
+  >
+    {mm.name}
+    <span style={{ fontSize: s(9), opacity: 0.4, letterSpacing: ".1em" }}>{mm.tag}</span>
+  </button>
+))}
+```
+
+**Step 2: Verify build**
+
+Run: `cd /Users/kira-chan/Downloads/Ensue-Chat && npx vite build 2>&1 | tail -5`
+
+**Step 3: Commit**
+
+```bash
+git add src/components/ModelPicker.jsx
+git commit -m "feat: group model picker by provider (claude/codex)"
+```
+
+---
+
+### Task 7: Add Codex session reading to sidebar
+
+**Files:**
+- Modify: `electron/session-reader.cjs`
+
+Codex sessions live in `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`. The format is different from Claude's JSONL. We need `listSessions` to also scan Codex session files for the given cwd, and `loadSessionMessages` to parse Codex events.
+
+**Step 1: Add Codex session directory constant**
+
+After line 5 (`const CLAUDE_DIR = ...`), add:
+
+```js
+const CODEX_DIR = path.join(os.homedir(), ".codex");
+```
+
+**Step 2: Add Codex session listing to `listSessions`**
+
+After the existing Claude session scanning in `listSessions` (before the `sessions.sort` at line 140), add Codex session scanning:
+
+```js
+  // Also scan Codex sessions
+  const codexSessionsBase = path.join(CODEX_DIR, "sessions");
+  if (fs.existsSync(codexSessionsBase)) {
+    // Walk YYYY/MM/DD directories
+    const walkDir = (dir) => {
+      try {
+        const entries = fs.readdirSync(dir, { withFileTypes: true });
+        for (const entry of entries) {
+          const fullPath = path.join(dir, entry.name);
+          if (entry.isDirectory()) {
+            walkDir(fullPath);
+          } else if (entry.name.endsWith(".jsonl")) {
+            try {
+              const content = fs.readFileSync(fullPath, "utf-8");
+              const firstLine = content.split("\n").find(l => l.trim());
+              if (!firstLine) continue;
+              const meta = JSON.parse(firstLine);
+              // Only include sessions from matching cwd
+              if (meta.type !== "session_meta" || meta.payload?.cwd !== cwd) continue;
+
+              const threadId = meta.payload?.id;
+              if (!threadId) continue;
+              const stat = fs.statSync(fullPath);
+
+              // Extract title from first user message
+              let title = "Untitled";
+              const lines = content.split("\n").slice(0, 30);
+              for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                  const evt = JSON.parse(line);
+                  if (evt.type === "response_item" && evt.payload?.role === "user") {
+                    const textBlock = evt.payload?.content?.find(b => b.type === "input_text");
+                    if (textBlock?.text && !textBlock.text.startsWith("<") && !textBlock.text.startsWith("#")) {
+                      title = textBlock.text.slice(0, 60);
+                      break;
+                    }
+                  }
+                } catch {}
+              }
+
+              sessions.push({
+                id: threadId,
+                title,
+                model: null,
+                ts: stat.mtimeMs,
+                cwd,
+                provider: "codex",
+                filePath: fullPath,
+              });
+            } catch {}
+          }
+        }
+      } catch {}
+    };
+    walkDir(codexSessionsBase);
+  }
+```
+
+**Step 3: Add Codex session loading to `loadSessionMessages`**
+
+In `loadSessionMessages`, after the `findSessionFile` check, add a branch for Codex sessions. If `findSessionFile` returns null, try finding the session in Codex's directory:
+
+```js
+  // If not a Claude session, try Codex sessions
+  if (!found) {
+    const codexFile = findCodexSessionFile(sessionId);
+    if (codexFile) {
+      return loadCodexSessionMessages(codexFile);
+    }
+    return { messages: [], cwd: null };
+  }
+```
+
+Add helper functions:
+
+```js
+function findCodexSessionFile(threadId) {
+  const sessionsDir = path.join(CODEX_DIR, "sessions");
+  if (!fs.existsSync(sessionsDir)) return null;
+
+  // Walk YYYY/MM/DD directories looking for matching thread_id
+  const walk = (dir) => {
+    try {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          const result = walk(fullPath);
+          if (result) return result;
+        } else if (entry.name.endsWith(".jsonl") && entry.name.includes(threadId)) {
+          return fullPath;
+        }
+      }
+    } catch {}
+    return null;
+  };
+
+  return walk(sessionsDir);
+}
+
+function loadCodexSessionMessages(filePath) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const messages = [];
+  let sessionCwd = null;
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let evt;
+    try { evt = JSON.parse(line); } catch { continue; }
+
+    if (evt.type === "session_meta" && evt.payload?.cwd) {
+      sessionCwd = evt.payload.cwd;
+    }
+
+    // User messages
+    if (evt.type === "response_item" && evt.payload?.role === "user") {
+      const textBlock = evt.payload?.content?.find(b => b.type === "input_text");
+      if (textBlock?.text) {
+        let text = textBlock.text;
+        // Skip system/skill injections
+        if (text.startsWith("<") || text.startsWith("#")) continue;
+        messages.push({
+          id: "u" + Date.now() + Math.random(),
+          role: "user",
+          text,
+        });
+      }
+    }
+
+    // Agent messages (completed items from turns)
+    if (evt.type === "event_msg" || (evt.type === "response_item" && evt.payload?.type === "message" && evt.payload?.role === "assistant")) {
+      const content = evt.payload?.content;
+      if (Array.isArray(content)) {
+        const parts = [];
+        for (const block of content) {
+          if (block.type === "output_text" && block.text) {
+            parts.push({ type: "text", text: block.text });
+          }
+        }
+        if (parts.length > 0) {
+          messages.push({
+            id: "a" + Date.now() + Math.random(),
+            role: "assistant",
+            parts,
+            isStreaming: false,
+            isThinking: false,
+          });
+        }
+      }
+    }
+  }
+
+  const result = messages.length > MAX_MESSAGES ? messages.slice(-MAX_MESSAGES) : messages;
+  return { messages: result, cwd: sessionCwd };
+}
+```
+
+**Step 4: Verify it loads**
+
+Run: `node -e "const r = require('./electron/session-reader.cjs'); console.log('OK')"`
+Expected: `OK`
+
+**Step 5: Commit**
+
+```bash
+git add electron/session-reader.cjs
+git commit -m "feat: add codex session reading for sidebar history"
+```
+
+---
+
+### Task 8: End-to-end integration test
+
+**Files:** None (manual testing)
+
+**Step 1: Start the dev server**
+
+Run: `cd /Users/kira-chan/Downloads/Ensue-Chat && npm run dev`
+
+**Step 2: Test Claude flow (regression)**
+
+1. Open the app
+2. Select "Claude Sonnet" from model picker
+3. Send a message: "What is 2+2?"
+4. Verify streaming text appears incrementally
+5. Verify tool calls render if triggered
+
+**Step 3: Test Codex flow**
+
+1. Select "GPT-5.4" from model picker
+2. Send a message: "List the files in the current directory"
+3. Verify text appears (will appear all at once per item)
+4. Verify command_execution tool calls show with output
+
+**Step 4: Test session resume for both providers**
+
+1. Send a follow-up message in both Claude and Codex conversations
+2. Verify context is maintained (can reference prior messages)
+
+**Step 5: Test model picker UI**
+
+1. Verify CLAUDE and CODEX group headers appear
+2. Verify divider between groups
+3. Verify all 6 models are selectable
+
+**Step 6: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: integration test fixes for codex support"
+```
+
+---
+
+## Appendix: Codex CLI Cheat Sheet
+
+```bash
+# Basic exec with JSON output
+codex exec --json --full-auto -m gpt-5.4 -c 'model_reasoning_effort="medium"' "prompt"
+
+# Resume session
+codex exec resume --json --full-auto -m gpt-5.4 "<thread_id>" "follow-up prompt"
+
+# With images
+codex exec --json --full-auto -m gpt-5.4 -i /path/to/image.png "describe this"
+
+# Ephemeral (no session persistence)
+codex exec --json --full-auto --ephemeral -m gpt-5.4 "one-shot prompt"
+
+# With extra writable directories
+codex exec --json --full-auto --add-dir /tmp -m gpt-5.4 "prompt"
+```
+
+## Appendix: Stream Event Format Reference
+
+```jsonl
+{"type":"thread.started","thread_id":"019d8a78-be9d-7512-a573-5de2de0ef55d"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"response text"}}
+{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc ls","aggregated_output":"file1\nfile2\n","exit_code":0,"status":"completed"}}
+{"type":"turn.completed","usage":{"input_tokens":12181,"cached_input_tokens":3456,"output_tokens":18}}
+```

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -1,0 +1,209 @@
+const { spawn } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+
+const activeAgents = new Map();
+const EXTRA_PATH_DIRS = [
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+];
+
+function log(...args) {
+  console.log("[codex-agent-manager]", ...args);
+}
+
+function isExecutable(filePath) {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isDirectory(dirPath) {
+  try {
+    return !!dirPath && fs.statSync(dirPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function buildSpawnPath() {
+  const pathParts = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+  return [...new Set([...pathParts, ...EXTRA_PATH_DIRS])].join(path.delimiter);
+}
+
+let cachedCodexBin = null;
+
+function resolveCodexBin() {
+  if (cachedCodexBin && isExecutable(cachedCodexBin)) return cachedCodexBin;
+
+  const searchPath = buildSpawnPath();
+  const candidates = [process.env.CODEX_BIN, "codex"].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (path.isAbsolute(candidate) && isExecutable(candidate)) {
+      cachedCodexBin = candidate;
+      return candidate;
+    }
+    for (const dir of searchPath.split(path.delimiter).filter(Boolean)) {
+      const fullPath = path.join(dir, candidate);
+      if (isExecutable(fullPath)) {
+        cachedCodexBin = fullPath;
+        return fullPath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, sessionId, resumeSessionId }, webContents) {
+  cancelCodexAgent(conversationId);
+
+  const args = ["exec"];
+
+  // Resume an existing thread if requested
+  if (resumeSessionId) {
+    args.push("resume", resumeSessionId);
+  }
+
+  args.push("--json", "--full-auto");
+
+  if (model) {
+    args.push("-m", model);
+  }
+
+  if (effort) {
+    args.push("-c", `model_reasoning_effort="${effort}"`);
+  }
+
+  // Working directory
+  let launchCwd = process.cwd();
+  if (cwd && isDirectory(cwd)) {
+    launchCwd = cwd;
+    args.push("-C", cwd);
+  } else if (cwd) {
+    const error = `Invalid working directory: ${cwd}`;
+    log(error);
+    webContents.send("agent-error", { conversationId, error });
+    webContents.send("agent-done", { conversationId, exitCode: -1 });
+    return null;
+  }
+
+  // Handle images — decode base64 data URLs to temp files, pass via -i
+  if (images && images.length > 0) {
+    for (let i = 0; i < images.length; i++) {
+      const dataUrl = images[i];
+      const match = dataUrl.match(/^data:image\/([\w+.-]+);base64,(.+)$/);
+      if (match) {
+        const ext = match[1] === "jpeg" ? "jpg" : match[1];
+        const tmpPath = path.join(os.tmpdir(), `ensue-codex-img-${Date.now()}-${i}.${ext}`);
+        fs.writeFileSync(tmpPath, Buffer.from(match[2], "base64"));
+        args.push("-i", tmpPath);
+      }
+    }
+  }
+
+  // Prompt goes last as positional arg
+  args.push(prompt);
+
+  const codexBin = resolveCodexBin();
+  if (!codexBin) {
+    const error = "Unable to locate the Codex CLI binary";
+    log(error);
+    webContents.send("agent-error", { conversationId, error });
+    webContents.send("agent-done", { conversationId, exitCode: -1 });
+    return null;
+  }
+
+  log("Starting codex agent:", { conversationId, model, effort, cwd: launchCwd, resumeSessionId });
+  log("Full args:", args.filter(a => a !== prompt).join(" "));
+  log("Prompt:", prompt.slice(0, 100));
+
+  const child = spawn(codexBin, args, {
+    cwd: launchCwd,
+    env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  log("Spawned PID:", child.pid);
+
+  activeAgents.set(conversationId, child);
+
+  let buffer = "";
+  let stderrBuffer = "";
+
+  child.stdout.on("data", (chunk) => {
+    const raw = chunk.toString();
+    log("stdout chunk:", raw.slice(0, 300));
+    buffer += raw;
+    const lines = buffer.split("\n");
+    buffer = lines.pop();
+
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        log("Parsed event type:", event.type);
+        webContents.send("agent-stream", { conversationId, event });
+      } catch (e) {
+        log("Failed to parse JSON line:", line.slice(0, 200), "error:", e.message);
+      }
+    }
+  });
+
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    log("stderr:", text);
+    stderrBuffer += text;
+  });
+
+  child.on("close", (exitCode) => {
+    log("Process closed, exitCode:", exitCode);
+    if (stderrBuffer.trim()) {
+      log("Full stderr:", stderrBuffer);
+      webContents.send("agent-error", { conversationId, error: stderrBuffer.trim() });
+    }
+    // Flush remaining buffer
+    if (buffer.trim()) {
+      log("Flushing remaining buffer:", buffer.slice(0, 200));
+      try {
+        const event = JSON.parse(buffer);
+        webContents.send("agent-stream", { conversationId, event });
+      } catch {}
+    }
+    activeAgents.delete(conversationId);
+    webContents.send("agent-done", { conversationId, exitCode });
+  });
+
+  child.on("error", (err) => {
+    log("Spawn error:", err.message);
+    activeAgents.delete(conversationId);
+    webContents.send("agent-error", { conversationId, error: err.message });
+  });
+
+  return child;
+}
+
+function cancelCodexAgent(conversationId) {
+  const child = activeAgents.get(conversationId);
+  if (child) {
+    log("Cancelling codex agent:", conversationId);
+    child.kill("SIGTERM");
+    activeAgents.delete(conversationId);
+  }
+}
+
+function cancelAllCodex() {
+  for (const [id, child] of activeAgents) {
+    child.kill("SIGTERM");
+  }
+  activeAgents.clear();
+}
+
+module.exports = { startCodexAgent, cancelCodexAgent, cancelAllCodex, resolveCodexBin };

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -10,6 +10,7 @@ const EXTRA_PATH_DIRS = [
   "/usr/bin",
   "/bin",
 ];
+const TERMINAL_CLI_PATH = path.join(__dirname, "../scripts/claudi-terminal.cjs");
 
 function log(...args) {
   console.log("[codex-agent-manager]", ...args);
@@ -62,7 +63,130 @@ function resolveCodexBin() {
   return null;
 }
 
-function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, sessionId, resumeSessionId }, webContents) {
+function getExecutionFlags() {
+  // Claudi is expected to run Codex without internal CLI sandboxing so it can
+  // use the full local environment. Set CLAUDI_CODEX_BYPASS_SANDBOX=0 to fall
+  // back to Codex's workspace-write sandboxed mode.
+  if (process.env.CLAUDI_CODEX_BYPASS_SANDBOX === "0") {
+    return ["--full-auto"];
+  }
+  return ["--dangerously-bypass-approvals-and-sandbox"];
+}
+
+function readConfiguredMcpServers() {
+  const configPath = global.mcpConfigPath;
+  if (!configPath) {
+    log("No MCP config path available for Codex");
+    return [];
+  }
+  if (!fs.existsSync(configPath)) {
+    log("Codex MCP config path does not exist:", configPath);
+    return [];
+  }
+
+  try {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    return Object.entries(parsed?.mcpServers || {});
+  } catch (error) {
+    log("Failed to load MCP config overrides:", error.message);
+    return [];
+  }
+}
+
+function buildClaudiPrompt(prompt, files, mcpServers) {
+  let fullPrompt = prompt;
+
+  if (files && files.length > 0) {
+    const filePaths = files.map((f) => f.path).join("\n");
+    fullPrompt = `[Attached files:\n${filePaths}]\n\n${fullPrompt}`;
+  }
+
+  const hasTerminalSessions = (mcpServers || []).some(
+    ([name, config]) => name === "terminal-sessions" && config?.command && config?.enabled !== false
+  );
+
+  const terminalInstructions = hasTerminalSessions
+    ? `Terminal sessions:
+Claudi's terminal means the visible sidebar terminal drawer inside the app. Sessions created there are user-visible and remain available across turns.
+Use Claudi's terminal when you want the user to see or interact with a shell, when a process should keep running, or when stdin needs to be sent over time.
+Prefer Claudi's terminal over one-off shell commands for dev servers, watchers, REPLs, or any command the user may want to monitor.
+If MCP terminal tools are unavailable, use the local terminal CLI exposed via $CLAUDI_TERMINAL_CLI.
+CLI examples:
+- node "$CLAUDI_TERMINAL_CLI" list
+- node "$CLAUDI_TERMINAL_CLI" create <name> --cwd <path>
+- node "$CLAUDI_TERMINAL_CLI" send <name> "npm run dev\\n"
+- node "$CLAUDI_TERMINAL_CLI" read <name> --lines 80
+- node "$CLAUDI_TERMINAL_CLI" kill <name>`
+    : `Terminal sessions:
+Claudi's terminal means the visible sidebar terminal drawer inside the app. Do not describe it generically; use it when you want a user-visible, long-lived shell inside Claudi itself.
+If terminal-session MCP tools are not exposed, use the local terminal CLI exposed via $CLAUDI_TERMINAL_CLI to control Claudi's sidebar terminal directly.
+CLI examples:
+- node "$CLAUDI_TERMINAL_CLI" list
+- node "$CLAUDI_TERMINAL_CLI" create <name> --cwd <path>
+- node "$CLAUDI_TERMINAL_CLI" send <name> "npm run dev\\n"
+- node "$CLAUDI_TERMINAL_CLI" read <name> --lines 80
+- node "$CLAUDI_TERMINAL_CLI" kill <name>`;
+
+  const claudiInstructions = `System context for this run:
+You are running inside Claudi, a desktop GUI client for coding agents.
+The user is interacting via a chat interface, not a terminal.
+Keep responses concise and conversational.
+Use markdown formatting; the client renders headings, code blocks, tables, lists, and mermaid diagrams.
+When showing diagrams, prefer mermaid code blocks.
+Do not ask the user to run terminal commands when you can do the work yourself.
+For math, use LaTeX: $inline$ and $$block$$. Never wrap LaTeX in code blocks.
+
+Interactive render blocks:
+Output fenced code blocks with language tag "render" to display live HTML inline in the chat.
+
+${terminalInstructions}
+
+The text below is the actual user prompt.
+--- USER PROMPT ---
+${fullPrompt}`;
+
+  return claudiInstructions;
+}
+
+function appendCodexMcpOverrides(args, mcpServers) {
+  const names = (mcpServers || []).map(([name]) => name);
+  if (names.length === 0) return;
+
+  log("Applying Codex MCP servers:", names);
+
+  for (const [name, config] of mcpServers) {
+    if (!config?.command) continue;
+
+    const commandOverride = `mcp_servers."${name}".command=${JSON.stringify(config.command)}`;
+    args.push("-c", commandOverride);
+    log("Codex MCP override:", commandOverride);
+
+    if (Array.isArray(config.args)) {
+      const argsOverride = `mcp_servers."${name}".args=${JSON.stringify(config.args)}`;
+      args.push("-c", argsOverride);
+      log("Codex MCP override:", argsOverride);
+    }
+
+    if (config.env && typeof config.env === "object") {
+      const envOverride = `mcp_servers."${name}".env=${JSON.stringify(config.env)}`;
+      args.push("-c", envOverride);
+      log("Codex MCP override:", envOverride);
+    }
+
+    if (typeof config.cwd === "string" && config.cwd) {
+      const cwdOverride = `mcp_servers."${name}".cwd=${JSON.stringify(config.cwd)}`;
+      args.push("-c", cwdOverride);
+      log("Codex MCP override:", cwdOverride);
+    }
+
+    const enabledOverride = `mcp_servers."${name}".enabled=${config.enabled !== false}`;
+    args.push("-c", enabledOverride);
+    log("Codex MCP override:", enabledOverride);
+  }
+}
+
+function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, files, sessionId, resumeSessionId }, webContents) {
   cancelCodexAgent(conversationId);
 
   const args = ["exec"];
@@ -72,7 +196,7 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, s
     args.push("resume", resumeSessionId);
   }
 
-  args.push("--json", "--full-auto");
+  args.push("--json", ...getExecutionFlags());
 
   if (model) {
     args.push("-m", model);
@@ -81,6 +205,9 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, s
   if (effort) {
     args.push("-c", `model_reasoning_effort="${effort}"`);
   }
+
+  const mcpServers = readConfiguredMcpServers();
+  appendCodexMcpOverrides(args, mcpServers);
 
   // Working directory — only pass -C for new sessions (resume doesn't accept it)
   let launchCwd = process.cwd();
@@ -112,7 +239,8 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, s
   }
 
   // Prompt goes last as positional arg
-  args.push(prompt);
+  const fullPrompt = buildClaudiPrompt(prompt, files, mcpServers);
+  args.push(fullPrompt);
 
   const codexBin = resolveCodexBin();
   if (!codexBin) {
@@ -124,12 +252,19 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, s
   }
 
   log("Starting codex agent:", { conversationId, model, effort, cwd: launchCwd, resumeSessionId });
-  log("Full args:", args.filter(a => a !== prompt).join(" "));
-  log("Prompt:", prompt.slice(0, 100));
+  log("Full args:", args.filter(a => a !== fullPrompt).join(" "));
+  log("Prompt:", fullPrompt.slice(0, 100));
 
   const child = spawn(codexBin, args, {
     cwd: launchCwd,
-    env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
+    env: {
+      ...process.env,
+      FORCE_COLOR: "0",
+      PATH: buildSpawnPath(),
+      CLAUDI_TERMINAL_CLI: TERMINAL_CLI_PATH,
+      CLAUDI_TERMINAL_PORT: global.terminalWsPort ? String(global.terminalWsPort) : "",
+      CLAUDI_TERMINAL_MCP_CONFIG: global.mcpConfigPath || "",
+    },
     stdio: ["ignore", "pipe", "pipe"],
   });
 

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -82,11 +82,13 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, s
     args.push("-c", `model_reasoning_effort="${effort}"`);
   }
 
-  // Working directory
+  // Working directory — only pass -C for new sessions (resume doesn't accept it)
   let launchCwd = process.cwd();
   if (cwd && isDirectory(cwd)) {
     launchCwd = cwd;
-    args.push("-C", cwd);
+    if (!resumeSessionId) {
+      args.push("-C", cwd);
+    }
   } else if (cwd) {
     const error = `Invalid working directory: ${cwd}`;
     log(error);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -131,6 +131,7 @@ app.whenReady().then(() => {
     const mcpConfigPath = path.join(app.getPath("userData"), "mcp-terminal.json");
     fs.writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2));
     global.mcpConfigPath = mcpConfigPath;
+    global.terminalWsPort = port;
   });
 
   // Forward terminal output to renderer

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3,6 +3,7 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 const { startAgent, cancelAgent, cancelAll, rewindFiles } = require("./agent-manager.cjs");
+const { startCodexAgent, cancelCodexAgent, cancelAllCodex } = require("./codex-agent-manager.cjs");
 const { listSessions, loadSessionMessages, moveSession } = require("./session-reader.cjs");
 const { createCheckpoint, restoreCheckpoint } = require("./checkpoint.cjs");
 const terminalManager = require("./terminal-manager.cjs");
@@ -195,15 +196,24 @@ ipcMain.handle("read-image", async (_event, filePath) => {
 
 // IPC: agent
 ipcMain.on("agent-start", (event, opts) => {
-  startAgent(opts, event.sender);
+  if (opts.provider === "codex") {
+    startCodexAgent(opts, event.sender);
+  } else {
+    startAgent(opts, event.sender);
+  }
 });
 
 ipcMain.on("agent-cancel", (_event, { conversationId }) => {
   cancelAgent(conversationId);
+  cancelCodexAgent(conversationId);
 });
 
 ipcMain.on("agent-edit-resend", (event, opts) => {
-  startAgent({ ...opts, forkSession: true }, event.sender);
+  if (opts.provider === "codex") {
+    startCodexAgent({ ...opts, resumeSessionId: opts.resumeSessionId }, event.sender);
+  } else {
+    startAgent({ ...opts, forkSession: true }, event.sender);
+  }
 });
 
 ipcMain.handle("rewind-files", async (_event, opts) => {
@@ -464,5 +474,6 @@ app.on("before-quit", () => {
     } catch {}
   }
   cancelAll();
+  cancelAllCodex();
   terminalManager.stopServer();
 });

--- a/electron/session-reader.cjs
+++ b/electron/session-reader.cjs
@@ -5,6 +5,7 @@ const os = require("os");
 const CLAUDE_DIR = path.join(os.homedir(), ".claude");
 const CODEX_DIR = path.join(os.homedir(), ".codex");
 const MAX_MESSAGES = 50; // max user+assistant message pairs to load
+const CODEX_USER_PROMPT_MARKER = "--- USER PROMPT ---";
 
 function projectDirName(cwd) {
   return cwd.replace(/\//g, "-");
@@ -122,6 +123,19 @@ function findCodexSessionFile(threadId) {
   return null;
 }
 
+function stripCodexSystemContext(text) {
+  if (typeof text !== "string") return "";
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("System context for this run:")) {
+    return trimmed;
+  }
+
+  const markerIndex = trimmed.indexOf(CODEX_USER_PROMPT_MARKER);
+  if (markerIndex === -1) return trimmed;
+
+  return trimmed.slice(markerIndex + CODEX_USER_PROMPT_MARKER.length).trim();
+}
+
 function loadCodexSessionMessages(filePath) {
   const content = fs.readFileSync(filePath, "utf-8");
   const lines = content.split("\n");
@@ -150,7 +164,7 @@ function loadCodexSessionMessages(filePath) {
         }
       }
       // Skip system injections
-      const trimmed = text.trim();
+      const trimmed = stripCodexSystemContext(text);
       if (!trimmed || trimmed.startsWith("<") || trimmed.startsWith("#")) continue;
 
       messages.push({
@@ -268,7 +282,7 @@ async function listSessions(cwd) {
               }
             }
           }
-          const trimmed = text.trim();
+          const trimmed = stripCodexSystemContext(text);
           if (trimmed && !trimmed.startsWith("<") && !trimmed.startsWith("#")) {
             title = trimmed.slice(0, 60);
             break;

--- a/electron/session-reader.cjs
+++ b/electron/session-reader.cjs
@@ -3,6 +3,8 @@ const path = require("path");
 const os = require("os");
 
 const CLAUDE_DIR = path.join(os.homedir(), ".claude");
+const CODEX_DIR = path.join(os.homedir(), ".codex");
+const MAX_MESSAGES = 50; // max user+assistant message pairs to load
 
 function projectDirName(cwd) {
   return cwd.replace(/\//g, "-");
@@ -92,6 +94,105 @@ function findSessionCwd(sessionId) {
   return extractSessionCwdFromFile(found.filePath) || cwdFromProjectDir(found.projectDir);
 }
 
+function walkJsonlFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        results.push(...walkJsonlFiles(fullPath));
+      } else if (entry.name.endsWith(".jsonl")) {
+        results.push(fullPath);
+      }
+    }
+  } catch {}
+  return results;
+}
+
+function findCodexSessionFile(threadId) {
+  const sessionsDir = path.join(CODEX_DIR, "sessions");
+  const files = walkJsonlFiles(sessionsDir);
+  for (const filePath of files) {
+    if (path.basename(filePath).includes(threadId)) {
+      return filePath;
+    }
+  }
+  return null;
+}
+
+function loadCodexSessionMessages(filePath) {
+  const content = fs.readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const messages = [];
+  let sessionCwd = null;
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let evt;
+    try { evt = JSON.parse(line); } catch { continue; }
+
+    if (evt.type === "session_meta" && evt.payload?.cwd) {
+      sessionCwd = evt.payload.cwd;
+      continue;
+    }
+
+    if (evt.type === "event_msg") continue;
+
+    if (evt.type === "response_item" && evt.payload?.role === "user") {
+      let text = "";
+      if (Array.isArray(evt.payload.content)) {
+        for (const block of evt.payload.content) {
+          if (block.type === "input_text" && block.text) {
+            text += block.text;
+          }
+        }
+      }
+      // Skip system injections
+      const trimmed = text.trim();
+      if (!trimmed || trimmed.startsWith("<") || trimmed.startsWith("#")) continue;
+
+      messages.push({
+        id: "u" + Date.now() + Math.random(),
+        role: "user",
+        text: trimmed,
+      });
+    } else if (
+      evt.type === "response_item" &&
+      evt.payload?.type === "message" &&
+      evt.payload?.role === "assistant"
+    ) {
+      let text = "";
+      if (Array.isArray(evt.payload.content)) {
+        for (const block of evt.payload.content) {
+          if (block.type === "output_text" && block.text) {
+            text += block.text;
+          }
+        }
+      }
+      if (text) {
+        const lastMsg = messages[messages.length - 1];
+        const part = { type: "text", text };
+        if (lastMsg && lastMsg.role === "assistant") {
+          lastMsg.parts.push(part);
+        } else {
+          messages.push({
+            id: "a" + Date.now() + Math.random(),
+            role: "assistant",
+            parts: [part],
+            isStreaming: false,
+            isThinking: false,
+          });
+        }
+      }
+    }
+  }
+
+  const result = messages.length > MAX_MESSAGES ? messages.slice(-MAX_MESSAGES) : messages;
+  return { messages: result, cwd: sessionCwd };
+}
+
 async function listSessions(cwd) {
   const projectDir = path.join(CLAUDE_DIR, "projects", projectDirName(cwd));
 
@@ -137,15 +238,62 @@ async function listSessions(cwd) {
     sessions.push({ id: sessionId, title, model, ts: stat.mtimeMs, cwd });
   }
 
+  // Scan Codex sessions
+  const codexSessionsDir = path.join(CODEX_DIR, "sessions");
+  const codexFiles = walkJsonlFiles(codexSessionsDir);
+  for (const codexFile of codexFiles) {
+    try {
+      const firstLine = fs.readFileSync(codexFile, "utf-8").split("\n")[0];
+      if (!firstLine.trim()) continue;
+      const meta = JSON.parse(firstLine);
+      if (meta.type !== "session_meta" || meta.payload?.cwd !== cwd) continue;
+
+      const threadId = meta.payload.id;
+      const stat = fs.statSync(codexFile);
+
+      // Find first user message for title
+      let title = "Untitled";
+      const content = fs.readFileSync(codexFile, "utf-8");
+      const allLines = content.split("\n").slice(0, 100);
+      for (const line of allLines) {
+        if (!line.trim()) continue;
+        let evt;
+        try { evt = JSON.parse(line); } catch { continue; }
+        if (evt.type === "response_item" && evt.payload?.role === "user") {
+          let text = "";
+          if (Array.isArray(evt.payload.content)) {
+            for (const block of evt.payload.content) {
+              if (block.type === "input_text" && block.text) {
+                text += block.text;
+              }
+            }
+          }
+          const trimmed = text.trim();
+          if (trimmed && !trimmed.startsWith("<") && !trimmed.startsWith("#")) {
+            title = trimmed.slice(0, 60);
+            break;
+          }
+        }
+      }
+
+      sessions.push({ id: threadId, title, model: null, ts: stat.mtimeMs, cwd, provider: "codex" });
+    } catch {}
+  }
+
   sessions.sort((a, b) => b.ts - a.ts);
   return sessions;
 }
 
-const MAX_MESSAGES = 50; // max user+assistant message pairs to load
-
 async function loadSessionMessages(sessionId) {
   const found = findSessionFile(sessionId);
-  if (!found) return { messages: [], cwd: null };
+  if (!found) {
+    // Fall back to Codex sessions
+    const codexFile = findCodexSessionFile(sessionId);
+    if (codexFile) {
+      return loadCodexSessionMessages(codexFile);
+    }
+    return { messages: [], cwd: null };
+  }
 
   const { filePath, projectDir } = found;
   const sessionCwd = extractSessionCwdFromFile(filePath) || cwdFromProjectDir(projectDir);

--- a/scripts/claudi-terminal.cjs
+++ b/scripts/claudi-terminal.cjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const WebSocket = require("ws");
+
+function usage() {
+  process.stderr.write(`Claudi terminal CLI
+
+Usage:
+  claudi-terminal list [--json]
+  claudi-terminal create <name> [--cwd <path>] [--command <executable>] [--json]
+  claudi-terminal send <name> <text> [--json]
+  claudi-terminal read <name> [--lines <n>] [--json]
+  claudi-terminal kill <name> [--json]
+  claudi-terminal resize <name> <cols> <rows> [--json]
+
+Environment:
+  CLAUDI_TERMINAL_PORT         WebSocket port of Claudi terminal manager
+  CLAUDI_TERMINAL_MCP_CONFIG   Optional path to mcp-terminal.json for port discovery
+`);
+}
+
+function fail(message, code = 1) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function readPortFromMcpConfig(configPath) {
+  if (!configPath || !fs.existsSync(configPath)) return null;
+
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    const args = parsed?.mcpServers?.["terminal-sessions"]?.args;
+    if (!Array.isArray(args) || args.length < 2) return null;
+    const maybePort = Number(args[args.length - 1]);
+    return Number.isFinite(maybePort) && maybePort > 0 ? maybePort : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolvePort() {
+  const direct = Number(process.env.CLAUDI_TERMINAL_PORT);
+  if (Number.isFinite(direct) && direct > 0) return direct;
+
+  const fromConfig = readPortFromMcpConfig(process.env.CLAUDI_TERMINAL_MCP_CONFIG);
+  if (fromConfig) return fromConfig;
+
+  return null;
+}
+
+function parseArgs(argv) {
+  const positionals = [];
+  const options = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) {
+      positionals.push(arg);
+      continue;
+    }
+
+    const key = arg.slice(2);
+    if (key === "json") {
+      options.json = true;
+      continue;
+    }
+
+    const value = argv[i + 1];
+    if (value == null || value.startsWith("--")) {
+      fail(`Missing value for --${key}`);
+    }
+    options[key] = value;
+    i += 1;
+  }
+
+  return { positionals, options };
+}
+
+function printResult(result, asJson) {
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (Array.isArray(result)) {
+    if (result.length === 0) {
+      process.stdout.write("No terminal sessions.\n");
+      return;
+    }
+    for (const session of result) {
+      process.stdout.write(`${session.name}\t${session.cwd}\tpid=${session.pid}\n`);
+    }
+    return;
+  }
+
+  if (result?.lines) {
+    process.stdout.write(`${result.lines.join("\n")}\n`);
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+function callManager(port, action, params) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    const id = Date.now();
+    let settled = false;
+
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      try {
+        ws.close();
+      } catch {}
+      fn(value);
+    };
+
+    const timer = setTimeout(() => {
+      finish(reject, new Error(`Timed out calling ${action}`));
+    }, 10000);
+
+    ws.on("open", () => {
+      ws.send(JSON.stringify({ id, action, params }));
+    });
+
+    ws.on("message", (data) => {
+      let msg;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+      if (msg.id !== id) return;
+      clearTimeout(timer);
+      finish(resolve, msg.result);
+    });
+
+    ws.on("error", (error) => {
+      clearTimeout(timer);
+      finish(reject, error);
+    });
+
+    ws.on("close", () => {
+      clearTimeout(timer);
+      if (!settled) {
+        finish(reject, new Error("Connection closed before response"));
+      }
+    });
+  });
+}
+
+async function main() {
+  const { positionals, options } = parseArgs(process.argv.slice(2));
+  const [command, ...rest] = positionals;
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    usage();
+    process.exit(command ? 0 : 1);
+  }
+
+  const port = resolvePort();
+  if (!port) {
+    fail("Claudi terminal server is not available. Missing CLAUDI_TERMINAL_PORT / CLAUDI_TERMINAL_MCP_CONFIG.");
+  }
+
+  let action;
+  let params;
+
+  switch (command) {
+    case "list":
+      action = "list_sessions";
+      params = {};
+      break;
+    case "create":
+      if (!rest[0]) fail("create requires <name>");
+      action = "create_session";
+      params = {
+        name: rest[0],
+        cwd: options.cwd,
+        command: options.command,
+      };
+      break;
+    case "send":
+      if (!rest[0] || rest[1] == null) fail("send requires <name> <text>");
+      action = "send_input";
+      params = {
+        name: rest[0],
+        text: rest.slice(1).join(" "),
+      };
+      break;
+    case "read":
+      if (!rest[0]) fail("read requires <name>");
+      action = "read_output";
+      params = {
+        name: rest[0],
+        lines: options.lines ? Number(options.lines) : undefined,
+      };
+      if (params.lines !== undefined && !Number.isFinite(params.lines)) {
+        fail("--lines must be a number");
+      }
+      break;
+    case "kill":
+      if (!rest[0]) fail("kill requires <name>");
+      action = "kill_session";
+      params = { name: rest[0] };
+      break;
+    case "resize":
+      if (!rest[0] || !rest[1] || !rest[2]) fail("resize requires <name> <cols> <rows>");
+      params = {
+        name: rest[0],
+        cols: Number(rest[1]),
+        rows: Number(rest[2]),
+      };
+      if (!Number.isFinite(params.cols) || !Number.isFinite(params.rows)) {
+        fail("resize expects numeric <cols> and <rows>");
+      }
+      action = "resize";
+      break;
+    default:
+      fail(`Unknown command: ${command}`);
+  }
+
+  const result = await callManager(port, action, params);
+  if (result && typeof result === "object" && result.error) {
+    fail(result.error);
+  }
+  printResult(result, options.json);
+}
+
+main().catch((error) => {
+  fail(error.message || String(error));
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -172,6 +172,20 @@ export default function App() {
     }
   }, [activeData.isStreaming]);
 
+  // Capture Codex thread_id for session resume
+  useEffect(() => {
+    if (!active) return;
+    const data = getConversation(active);
+    if (data._codexThreadId) {
+      const convo = convoList.find(c => c.id === active);
+      if (convo && convo.sessionId !== data._codexThreadId) {
+        setConvoList((p) =>
+          p.map((c) => c.id === active ? { ...c, sessionId: data._codexThreadId } : c)
+        );
+      }
+    }
+  }, [active, conversations]);
+
   const handleSend = useCallback(
     async (text, attachments) => {
       // Handle slash commands client-side
@@ -254,6 +268,8 @@ export default function App() {
         resumeSessionId: isFirstMessage ? undefined : convo.sessionId,
         prompt: text,
         model: m.cliFlag,
+        provider: m.provider || "claude",
+        effort: m.effort,
         cwd: effectiveCwd,
         images: images?.length ? images : undefined,
         files: files?.length ? files : undefined,
@@ -294,6 +310,8 @@ export default function App() {
         messageIndex,
         newText,
         model: m.cliFlag,
+        provider: m.provider || "claude",
+        effort: m.effort,
         cwd: convoCwd,
       });
     },

--- a/src/components/ModelPicker.jsx
+++ b/src/components/ModelPicker.jsx
@@ -59,32 +59,40 @@ export default function ModelPicker({ value, onChange }) {
             animation: "dropIn .15s ease",
           }}
         >
-          {MODELS.map((mm) => (
-            <button
-              key={mm.id}
-              onClick={() => { onChange(mm.id); set(false); }}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                width: "100%",
-                padding: "9px 13px",
-                background: mm.id === value ? "rgba(255,255,255,0.04)" : "transparent",
-                border: "none",
-                borderRadius: 7,
-                color: mm.id === value ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.4)",
-                fontSize: s(11),
-                fontFamily: "'JetBrains Mono',monospace",
-                cursor: "pointer",
-                textAlign: "left",
-                transition: "all .12s",
-              }}
-              onMouseEnter={(e) => { if (mm.id !== value) e.currentTarget.style.background = "rgba(255,255,255,0.025)"; }}
-              onMouseLeave={(e) => { if (mm.id !== value) e.currentTarget.style.background = "transparent"; }}
-            >
-              {mm.name}
-              <span style={{ fontSize: s(9), opacity: 0.4, letterSpacing: ".1em" }}>{mm.tag}</span>
-            </button>
+          {["claude", "codex"].map((provider, gi) => (
+            <div key={provider}>
+              {gi > 0 && <div style={{ height: 1, background: "rgba(255,255,255,0.04)", margin: "4px 8px" }} />}
+              <div style={{ padding: "4px 10px 2px", fontSize: s(8), color: "rgba(255,255,255,0.2)", letterSpacing: ".12em", fontFamily: "'JetBrains Mono',monospace" }}>
+                {provider.toUpperCase()}
+              </div>
+              {MODELS.filter(mm => mm.provider === provider).map((mm) => (
+                <button
+                  key={mm.id}
+                  onClick={() => { onChange(mm.id); set(false); }}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    width: "100%",
+                    padding: "9px 13px",
+                    background: mm.id === value ? "rgba(255,255,255,0.04)" : "transparent",
+                    border: "none",
+                    borderRadius: 7,
+                    color: mm.id === value ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.4)",
+                    fontSize: s(11),
+                    fontFamily: "'JetBrains Mono',monospace",
+                    cursor: "pointer",
+                    textAlign: "left",
+                    transition: "all .12s",
+                  }}
+                  onMouseEnter={(e) => { if (mm.id !== value) e.currentTarget.style.background = "rgba(255,255,255,0.025)"; }}
+                  onMouseLeave={(e) => { if (mm.id !== value) e.currentTarget.style.background = "transparent"; }}
+                >
+                  {mm.name}
+                  <span style={{ fontSize: s(9), opacity: 0.4, letterSpacing: ".1em" }}>{mm.tag}</span>
+                </button>
+              ))}
+            </div>
           ))}
         </div>
       )}

--- a/src/components/TerminalDrawer.jsx
+++ b/src/components/TerminalDrawer.jsx
@@ -300,11 +300,11 @@ function TabBar({ sessions, activeSession, onSelectSession, onKillSession }) {
         scrollbarWidth: "none",
       }}
     >
-      {sessions.map((s) => {
-        const isActive = s.name === activeSession;
+      {sessions.map((session) => {
+        const isActive = session.name === activeSession;
         return (
           <div
-            key={s.name}
+            key={session.name}
             style={{
               display: "flex",
               alignItems: "center",
@@ -322,7 +322,7 @@ function TabBar({ sessions, activeSession, onSelectSession, onKillSession }) {
             onMouseLeave={(e) => {
               if (!isActive) e.currentTarget.style.background = "transparent";
             }}
-            onClick={() => onSelectSession(s.name)}
+            onClick={() => onSelectSession(session.name)}
           >
             <span
               style={{
@@ -336,12 +336,12 @@ function TabBar({ sessions, activeSession, onSelectSession, onKillSession }) {
                 letterSpacing: ".04em",
               }}
             >
-              {s.name}
+              {session.name}
             </span>
             <button
               onClick={(e) => {
                 e.stopPropagation();
-                onKillSession(s.name);
+                onKillSession(session.name);
               }}
               title="Kill session"
               style={{

--- a/src/components/ToolCallBlock.jsx
+++ b/src/components/ToolCallBlock.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { ChevronRight, ChevronDown, Terminal, FileText, Pencil, Search, Code, Loader2 } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
 
+const BODY_PREVIEW_LIMIT = 2400;
+
 const TOOL_ICONS = {
   Bash: Terminal,
   Read: FileText,
@@ -16,6 +18,15 @@ function truncate(str, max) {
   return str.length > max ? str.slice(0, max) + "..." : str;
 }
 
+function getToolLabel(tool) {
+  if (!tool?.name) return "Tool";
+  if (tool.args?.command && tool.name === tool.args.command) return "Command";
+  if (tool.name.startsWith("/") || tool.name.includes(" -lc ") || tool.name.includes(" --")) {
+    return "Command";
+  }
+  return tool.name;
+}
+
 function getPreview(tool) {
   const args = tool.args;
   if (!args || typeof args !== "object") return null;
@@ -24,6 +35,9 @@ function getPreview(tool) {
     // Replace absolute/home paths with just the binary name
     cmd = cmd.replace(/(?:^|\s)[~\/][\w.~\/-]+\/([\w.-]+)/g, (_, bin) => " " + bin);
     return truncate(cmd.trim(), 30);
+  }
+  if (args.command) {
+    return truncate(args.command.replace(/\s+/g, " ").trim(), 48);
   }
   if (tool.name === "Read") return args.file_path?.split("/").pop();
   if (tool.name === "Edit") return args.file_path?.split("/").pop();
@@ -40,12 +54,74 @@ function getPreview(tool) {
   return null;
 }
 
+function serializeValue(value) {
+  if (value == null) return null;
+  return typeof value === "string" ? value : JSON.stringify(value, null, 2);
+}
+
+function ToolBody({ label, value, maxHeight, fontScale }) {
+  const [showFull, setShowFull] = useState(false);
+  const serialized = serializeValue(value);
+  if (!serialized) return null;
+
+  const isTrimmed = serialized.length > BODY_PREVIEW_LIMIT;
+  const displayValue = !showFull && isTrimmed
+    ? `${serialized.slice(0, BODY_PREVIEW_LIMIT)}\n\n... [truncated ${serialized.length - BODY_PREVIEW_LIMIT} chars]`
+    : serialized;
+
+  return (
+    <div style={{ marginBottom: label === "ARGS" ? 8 : 0 }}>
+      <div style={{
+        color: "rgba(255,255,255,0.3)",
+        marginBottom: 4,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 8,
+      }}>
+        <span>{label}</span>
+        {isTrimmed && (
+          <button
+            onClick={() => setShowFull((prev) => !prev)}
+            style={{
+              border: "none",
+              background: "none",
+              color: "rgba(255,255,255,0.35)",
+              cursor: "pointer",
+              fontSize: fontScale(10),
+              fontFamily: "'JetBrains Mono',monospace",
+              padding: 0,
+            }}
+          >
+            {showFull ? "show less" : "show full"}
+          </button>
+        )}
+      </div>
+      <pre style={{
+        color: "rgba(255,255,255,0.5)",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-all",
+        margin: 0,
+        padding: 8,
+        background: "rgba(0,0,0,0.3)",
+        borderRadius: 6,
+        fontSize: fontScale(10),
+        maxHeight,
+        overflow: "auto",
+      }}>
+        {displayValue}
+      </pre>
+    </div>
+  );
+}
+
 export default function ToolCallBlock({ tool }) {
   const [expanded, setExpanded] = useState(false);
   const s = useFontScale();
   const Icon = TOOL_ICONS[tool.name] || Code;
   const isRunning = tool.status === "running";
   const preview = getPreview(tool);
+  const toolLabel = getToolLabel(tool);
 
   return (
     <div
@@ -75,7 +151,14 @@ export default function ToolCallBlock({ tool }) {
         }}
       >
         <Icon size={13} strokeWidth={1.5} />
-        <span style={{ color: "rgba(255,255,255,0.7)" }}>{tool.name}</span>
+        <span style={{
+          color: "rgba(255,255,255,0.7)",
+          flexShrink: 1,
+          minWidth: 0,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}>{toolLabel}</span>
         {preview && !expanded && (
           <span style={{
             color: "rgba(255,255,255,0.25)",
@@ -103,44 +186,8 @@ export default function ToolCallBlock({ tool }) {
 
       {expanded && (
         <div style={{ padding: "0 12px 10px", fontSize: s(11), fontFamily: "'JetBrains Mono',monospace" }}>
-          {tool.args && Object.keys(tool.args).length > 0 && (
-            <div style={{ marginBottom: 8 }}>
-              <div style={{ color: "rgba(255,255,255,0.3)", marginBottom: 4 }}>ARGS</div>
-              <pre style={{
-                color: "rgba(255,255,255,0.5)",
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-all",
-                margin: 0,
-                padding: 8,
-                background: "rgba(0,0,0,0.3)",
-                borderRadius: 6,
-                fontSize: s(10),
-                maxHeight: 200,
-                overflow: "auto",
-              }}>
-                {typeof tool.args === "string" ? tool.args : JSON.stringify(tool.args, null, 2)}
-              </pre>
-            </div>
-          )}
-          {tool.result != null && (
-            <div>
-              <div style={{ color: "rgba(255,255,255,0.3)", marginBottom: 4 }}>RESULT</div>
-              <pre style={{
-                color: "rgba(255,255,255,0.5)",
-                whiteSpace: "pre-wrap",
-                wordBreak: "break-all",
-                margin: 0,
-                padding: 8,
-                background: "rgba(0,0,0,0.3)",
-                borderRadius: 6,
-                fontSize: s(10),
-                maxHeight: 300,
-                overflow: "auto",
-              }}>
-                {typeof tool.result === "string" ? tool.result : JSON.stringify(tool.result, null, 2)}
-              </pre>
-            </div>
-          )}
+          {tool.args && Object.keys(tool.args).length > 0 && <ToolBody label="ARGS" value={tool.args} maxHeight={200} fontScale={s} />}
+          {tool.result != null && <ToolBody label="RESULT" value={tool.result} maxHeight={300} fontScale={s} />}
         </div>
       )}
     </div>

--- a/src/data/models.js
+++ b/src/data/models.js
@@ -1,7 +1,10 @@
 export const MODELS = [
-  { id: "opus",   name: "Claude Opus",   tag: "OPUS",   cliFlag: "opus"   },
-  { id: "sonnet", name: "Claude Sonnet", tag: "SONNET", cliFlag: "sonnet" },
-  { id: "haiku",  name: "Claude Haiku",  tag: "HAIKU",  cliFlag: "haiku"  },
+  { id: "opus",   name: "Claude Opus",   tag: "OPUS",   cliFlag: "opus",   provider: "claude" },
+  { id: "sonnet", name: "Claude Sonnet", tag: "SONNET", cliFlag: "sonnet", provider: "claude" },
+  { id: "haiku",  name: "Claude Haiku",  tag: "HAIKU",  cliFlag: "haiku",  provider: "claude" },
+  { id: "gpt54-med",   name: "GPT-5.4",        tag: "GPT-5.4",       cliFlag: "gpt-5.4", provider: "codex", effort: "medium" },
+  { id: "gpt54-high",  name: "GPT-5.4 High",   tag: "GPT-5.4 HIGH",  cliFlag: "gpt-5.4", provider: "codex", effort: "high" },
+  { id: "gpt54-xhigh", name: "GPT-5.4 XHigh",  tag: "GPT-5.4 XHIGH", cliFlag: "gpt-5.4", provider: "codex", effort: "xhigh" },
 ];
 
 export const getM = (id) => MODELS.find((m) => m.id === id) || MODELS[0];

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -334,7 +334,7 @@ export default function useAgent() {
     return () => cleanupRefs.current.forEach((fn) => fn?.());
   }, []);
 
-  const sendMessage = useCallback(({ conversationId, sessionId, prompt, model, cwd, images, files, resumeSessionId, forkSession }) => {
+  const sendMessage = useCallback(({ conversationId, sessionId, prompt, model, provider, effort, cwd, images, files, resumeSessionId, forkSession }) => {
     setConversations((prev) => {
       const next = new Map(prev);
       const convo = next.get(conversationId) || { messages: [], isStreaming: false, error: null };
@@ -348,7 +348,7 @@ export default function useAgent() {
     });
 
     if (window.api) {
-      window.api.agentStart({ conversationId, sessionId, prompt, model, cwd, images, files, resumeSessionId, forkSession });
+      window.api.agentStart({ conversationId, sessionId, prompt, model, provider, effort, cwd, images, files, resumeSessionId, forkSession });
     }
   }, []);
 
@@ -358,7 +358,7 @@ export default function useAgent() {
     }
   }, []);
 
-  const editAndResend = useCallback(({ conversationId, sessionId, messageIndex, newText, model, cwd }) => {
+  const editAndResend = useCallback(({ conversationId, sessionId, messageIndex, newText, model, provider, effort, cwd }) => {
     setConversations((prev) => {
       const next = new Map(prev);
       const convo = next.get(conversationId);
@@ -378,6 +378,8 @@ export default function useAgent() {
         forkSession: true,
         prompt: newText,
         model,
+        provider,
+        effort,
         cwd,
       });
     }

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -233,6 +233,67 @@ export default function useAgent() {
           }
         }
 
+        // --- Codex JSONL stream events ---
+        else if (event.type === "thread.started") {
+          convo._codexThreadId = event.thread_id;
+        } else if (event.type === "turn.started") {
+          ensureAssistant();
+        } else if (event.type === "item.started") {
+          const item = event.item || {};
+          if (item.type === "command_execution") {
+            const am = ensureAssistant();
+            const parts = cloneParts(am.parts);
+            parts.push({
+              type: "tool",
+              id: item.id || uid(),
+              name: item.command || "command",
+              args: { command: item.command },
+              result: null,
+              status: "running",
+            });
+            msgs[msgs.length - 1] = { ...am, parts };
+            lastMsg = msgs[msgs.length - 1];
+          }
+        } else if (event.type === "item.completed") {
+          const item = event.item || {};
+          if (item.type === "agent_message") {
+            const am = ensureAssistant();
+            const parts = cloneParts(am.parts);
+            parts.push({ type: "text", text: item.text || "" });
+            msgs[msgs.length - 1] = { ...am, parts };
+            lastMsg = msgs[msgs.length - 1];
+          } else if (item.type === "command_execution") {
+            const am = ensureAssistant();
+            const parts = cloneParts(am.parts);
+            const existingIdx = parts.findIndex(
+              (p) => p.type === "tool" && p.id === item.id
+            );
+            if (existingIdx >= 0) {
+              parts[existingIdx] = {
+                ...parts[existingIdx],
+                result: item.aggregated_output,
+                status: "done",
+              };
+            } else {
+              parts.push({
+                type: "tool",
+                id: item.id || uid(),
+                name: item.command || "command",
+                args: { command: item.command },
+                result: item.aggregated_output,
+                status: "done",
+              });
+            }
+            msgs[msgs.length - 1] = { ...am, parts };
+            lastMsg = msgs[msgs.length - 1];
+          }
+        } else if (event.type === "turn.completed") {
+          if (lastMsg && lastMsg.role === "assistant") {
+            msgs[msgs.length - 1] = { ...lastMsg, isStreaming: false, isThinking: false };
+            lastMsg = msgs[msgs.length - 1];
+          }
+        }
+
         next.set(conversationId, { ...convo, messages: msgs });
         return next;
       });


### PR DESCRIPTION
Closes #19

## Summary
- add GPT-5.4 Codex provider support and route conversations by provider
- normalize Codex stream events, resume with thread IDs, and read Codex session history in the sidebar
- pass Claudi-specific terminal context into Codex, including the terminal CLI fallback and MCP terminal wiring
- improve tool call rendering for Codex command executions
- fix the terminal drawer tab bar crash caused by variable shadowing

## Verification
- `npm run build`
- exercised Claudi terminal creation and interactive `vi` launch via the terminal CLI fallback
