### PR TITLE
ci: add build smoke verification workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,30 @@
+name: Build Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run build smoke check
+        run: npm run verify

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ against that renderer.
 - `npm run build` - build the renderer for production
 - `npm run build:electron` - build the renderer and package the desktop app
 - `npm run lint` - run ESLint
+- `npm run verify` - run the local build smoke check used in CI
 - `npm run preview` - preview the production renderer build
 - `npm run rebuild` - rebuild `node-pty` for the active Electron version
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "vite build",
     "build:electron": "vite build && electron-builder",
     "lint": "eslint .",
+    "verify": "npm run build",
     "preview": "vite preview",
     "rebuild": "electron-rebuild -f -w node-pty"
   },


### PR DESCRIPTION
Summary:
- add npm run verify as a stable build smoke command
- run the smoke check on pull requests and pushes to main with GitHub Actions
- document the command in the README

Testing:
- npm run verify

Note:
- npm run lint currently fails on the base branch, so this workflow is intentionally scoped to the passing production build smoke check for now

Closes #23