### PR TITLE
fix: widen model picker and remove haiku

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -369,7 +369,7 @@ ipcMain.handle("quick-explain", async (_event, { text, model }) => {
       "--print",
       "--output-format", "text",
       "--tools", "",
-      "--model", model || "haiku",
+      "--model", model || "sonnet",
       "--no-session-persistence",
       "--system-prompt", "You are a concise explainer. Give 1-3 sentence explanations. Use markdown for formatting.",
       `Explain this briefly:\n\n${text}`,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import useAgent     from "./hooks/useAgent";
 import useTerminal  from "./hooks/useTerminal";
 import TerminalDrawer from "./components/TerminalDrawer";
 import Settings     from "./components/Settings";
-import { getM }     from "./data/models";
+import { DEFAULT_MODEL_ID, getM, normalizeModelId } from "./data/models";
 import { FontSizeContext } from "./contexts/FontSizeContext";
 
 function logCheckpoint(...args) {
@@ -22,7 +22,7 @@ export default function App() {
   const [convoList, setConvoList] = useState([]);
   const [active, setActive] = useState(null);
   const [sidebarOpen, setSidebarOpen] = useState(true);
-  const [defaultModel, setDefaultModel] = useState("sonnet");
+  const [defaultModel, setDefaultModel] = useState(DEFAULT_MODEL_ID);
   const [cwd, setCwd] = useState(null);
   const [stateLoaded, setStateLoaded] = useState(false);
   const [wallpaper, setWallpaper] = useState(null); // { path, opacity, blur }
@@ -36,10 +36,17 @@ export default function App() {
     if (!window.api) { setStateLoaded(true); return; }
     window.api.loadState().then((state) => {
       if (state) {
-        if (state.convos) setConvoList(state.convos);
+        if (state.convos) {
+          setConvoList(
+            state.convos.map((convo) => ({
+              ...convo,
+              model: normalizeModelId(convo.model),
+            }))
+          );
+        }
         if (state.active) setActive(state.active);
         if (state.cwd) setCwd(state.cwd);
-        if (state.defaultModel) setDefaultModel(state.defaultModel);
+        if (state.defaultModel) setDefaultModel(normalizeModelId(state.defaultModel));
         if (state.fontSize) setFontSize(state.fontSize);
         if (state.wallpaper) {
           setWallpaper(state.wallpaper);

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -352,7 +352,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
         )}
       </div>
 
-      <SelectionToolbar onQuote={handleQuote} model={convo?.model || defaultModel || "haiku"} />
+      <SelectionToolbar onQuote={handleQuote} model={convo?.model || defaultModel || "sonnet"} />
 
       {/* Input bar */}
       <div

--- a/src/components/ModelPicker.jsx
+++ b/src/components/ModelPicker.jsx
@@ -6,7 +6,6 @@ import { useFontScale } from "../contexts/FontSizeContext";
 
 const MENU_GAP = 6;
 const VIEWPORT_PADDING = 8;
-const MIN_BUTTON_WIDTH = 132;
 const MIN_MENU_WIDTH = 220;
 
 export default function ModelPicker({ value, onChange }) {
@@ -71,7 +70,6 @@ export default function ModelPicker({ value, onChange }) {
           alignItems: "center",
           justifyContent: "space-between",
           gap: 6,
-          minWidth: MIN_BUTTON_WIDTH,
           padding: "4px 12px",
           background: "rgba(255,255,255,0.02)",
           border: "1px solid rgba(255,255,255,0.04)",
@@ -111,7 +109,7 @@ export default function ModelPicker({ value, onChange }) {
           {["claude", "codex"].map((provider, gi) => (
             <div key={provider}>
               {gi > 0 && <div style={{ height: 1, background: "rgba(255,255,255,0.04)", margin: "4px 8px" }} />}
-              <div style={{ padding: "4px 10px 2px", fontSize: s(8), color: "rgba(255,255,255,0.2)", letterSpacing: ".12em", fontFamily: "'JetBrains Mono',monospace" }}>
+              <div style={{ padding: gi === 0 ? "6px 10px 2px" : "4px 10px 2px", fontSize: s(8), color: "rgba(255,255,255,0.2)", letterSpacing: ".12em", fontFamily: "'JetBrains Mono',monospace" }}>
                 {provider.toUpperCase()}
               </div>
               {MODELS.filter(mm => mm.provider === provider).map((mm) => (

--- a/src/components/ModelPicker.jsx
+++ b/src/components/ModelPicker.jsx
@@ -6,7 +6,8 @@ import { useFontScale } from "../contexts/FontSizeContext";
 
 const MENU_GAP = 6;
 const VIEWPORT_PADDING = 8;
-const MENU_WIDTH = 180;
+const MIN_BUTTON_WIDTH = 132;
+const MIN_MENU_WIDTH = 220;
 
 export default function ModelPicker({ value, onChange }) {
   const s = useFontScale();
@@ -19,14 +20,15 @@ export default function ModelPicker({ value, onChange }) {
   const updateMenuPosition = useCallback(() => {
     if (!ref.current) return;
     const rect = ref.current.getBoundingClientRect();
+    const menuWidth = Math.max(MIN_MENU_WIDTH, rect.width);
     const left = Math.max(
       VIEWPORT_PADDING,
-      Math.min(rect.right - MENU_WIDTH, window.innerWidth - MENU_WIDTH - VIEWPORT_PADDING)
+      Math.min(rect.right - menuWidth, window.innerWidth - menuWidth - VIEWPORT_PADDING)
     );
     setMenuStyle({
       top: rect.bottom + MENU_GAP,
       left,
-      width: MENU_WIDTH,
+      width: menuWidth,
     });
   }, []);
 
@@ -67,8 +69,10 @@ export default function ModelPicker({ value, onChange }) {
         style={{
           display: "flex",
           alignItems: "center",
+          justifyContent: "space-between",
           gap: 6,
-          padding: "4px 10px",
+          minWidth: MIN_BUTTON_WIDTH,
+          padding: "4px 12px",
           background: "rgba(255,255,255,0.02)",
           border: "1px solid rgba(255,255,255,0.04)",
           borderRadius: 7,

--- a/src/data/models.js
+++ b/src/data/models.js
@@ -1,10 +1,20 @@
+export const DEFAULT_MODEL_ID = "sonnet";
+
+const LEGACY_MODEL_IDS = {
+  haiku: DEFAULT_MODEL_ID,
+};
+
 export const MODELS = [
   { id: "opus",   name: "Claude Opus",   tag: "OPUS",   cliFlag: "opus",   provider: "claude" },
   { id: "sonnet", name: "Claude Sonnet", tag: "SONNET", cliFlag: "sonnet", provider: "claude" },
-  { id: "haiku",  name: "Claude Haiku",  tag: "HAIKU",  cliFlag: "haiku",  provider: "claude" },
   { id: "gpt54-med",   name: "GPT-5.4",        tag: "GPT-5.4",       cliFlag: "gpt-5.4", provider: "codex", effort: "medium" },
   { id: "gpt54-high",  name: "GPT-5.4 High",   tag: "GPT-5.4 HIGH",  cliFlag: "gpt-5.4", provider: "codex", effort: "high" },
   { id: "gpt54-xhigh", name: "GPT-5.4 XHigh",  tag: "GPT-5.4 XHIGH", cliFlag: "gpt-5.4", provider: "codex", effort: "xhigh" },
 ];
 
-export const getM = (id) => MODELS.find((m) => m.id === id) || MODELS[0];
+export const normalizeModelId = (id) => LEGACY_MODEL_IDS[id] || id;
+
+export const getM = (id) =>
+  MODELS.find((m) => m.id === normalizeModelId(id)) ||
+  MODELS.find((m) => m.id === DEFAULT_MODEL_ID) ||
+  MODELS[0];

--- a/src/data/models.js
+++ b/src/data/models.js
@@ -7,9 +7,9 @@ const LEGACY_MODEL_IDS = {
 export const MODELS = [
   { id: "opus",   name: "Claude Opus",   tag: "OPUS",   cliFlag: "opus",   provider: "claude" },
   { id: "sonnet", name: "Claude Sonnet", tag: "SONNET", cliFlag: "sonnet", provider: "claude" },
-  { id: "gpt54-med",   name: "GPT-5.4",        tag: "GPT-5.4",       cliFlag: "gpt-5.4", provider: "codex", effort: "medium" },
-  { id: "gpt54-high",  name: "GPT-5.4 High",   tag: "GPT-5.4 HIGH",  cliFlag: "gpt-5.4", provider: "codex", effort: "high" },
-  { id: "gpt54-xhigh", name: "GPT-5.4 XHigh",  tag: "GPT-5.4 XHIGH", cliFlag: "gpt-5.4", provider: "codex", effort: "xhigh" },
+  { id: "gpt54-med",   name: "GPT-5.4",         tag: "GPT-5.4",        cliFlag: "gpt-5.4", provider: "codex", effort: "medium" },
+  { id: "gpt54-high",  name: "GPT-5.4 high",    tag: "GPT-5.4 high",   cliFlag: "gpt-5.4", provider: "codex", effort: "high" },
+  { id: "gpt54-xhigh", name: "GPT-5.4 xhigh",   tag: "GPT-5.4 xhigh",  cliFlag: "gpt-5.4", provider: "codex", effort: "xhigh" },
 ];
 
 export const normalizeModelId = (id) => LEGACY_MODEL_IDS[id] || id;


### PR DESCRIPTION
## Summary
- widen the model picker trigger and dropdown so the selector has more room
- remove Claude Haiku from the available model list
- migrate stale haiku defaults and fallbacks to sonnet so older local state keeps working

## Testing
- npm run build
- npm run lint *(fails due pre-existing repo lint errors unrelated to this change)*

Fixes #28