### PR TITLE
fix: restore terminal focus after branch changes

### DIFF
--- a/electron/terminal-manager.cjs
+++ b/electron/terminal-manager.cjs
@@ -41,6 +41,22 @@ const DEFAULT_SHELL =
   process.env.SHELL ||
   (process.platform === "win32" ? "cmd.exe" : "/bin/sh");
 
+// Environment variables to strip from the PTY.  When the Electron app is
+// launched from VS Code (or another IDE), variables like TERM_PROGRAM,
+// VSCODE_*, and ZDOTDIR leak into process.env.  These cause the shell inside
+// our xterm.js terminal to load foreign shell-integration scripts that send
+// escape sequences xterm.js cannot handle, producing garbled output.
+const STRIP_ENV_PREFIXES = [
+  "VSCODE_",
+  "TERM_PROGRAM",  // also catches TERM_PROGRAM_VERSION
+  "USER_ZDOTDIR",
+];
+const STRIP_ENV_EXACT = new Set([
+  "CODESPACES",
+  "GIT_ASKPASS",
+  "ELECTRON_RUN_AS_NODE",
+]);
+
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
@@ -139,6 +155,20 @@ function createSession({ name, command, cwd } = {}) {
 
   log(`createSession name=${name} shell=${shell} cwd=${workDir}`);
 
+  // Build a clean environment: strip IDE-injected variables that confuse the
+  // shell into loading integrations meant for a different terminal emulator.
+  // Preserve the user's original ZDOTDIR if VS Code overwrote it.
+  const userZdotdir = process.env.USER_ZDOTDIR;
+  const cleanEnv = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (STRIP_ENV_EXACT.has(k)) continue;
+    if (STRIP_ENV_PREFIXES.some((p) => k.startsWith(p))) continue;
+    cleanEnv[k] = v;
+  }
+  if (userZdotdir) cleanEnv.ZDOTDIR = userZdotdir;
+  cleanEnv.PROMPT_EOL_MARK = "";
+  cleanEnv.TERM_PROGRAM = "Claudi";
+
   let ptyProcess;
   try {
     ptyProcess = pty.spawn(shell, [], {
@@ -146,7 +176,7 @@ function createSession({ name, command, cwd } = {}) {
       cols: 80,
       rows: 24,
       cwd: workDir,
-      env: { ...process.env, PROMPT_EOL_MARK: "" },
+      env: cleanEnv,
     });
   } catch (err) {
     log("spawn error:", err.message);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -488,6 +488,7 @@ export default function App() {
           terminalCount={terminal.sessions.length}
           wallpaper={wallpaper}
           cwd={activeConvo?.cwd || cwd}
+          onRefocusTerminal={terminal.focusActiveSession}
           onCwdChange={(newCwd) => {
             setCwd(newCwd);
             if (active) {

--- a/src/components/BranchSelector.jsx
+++ b/src/components/BranchSelector.jsx
@@ -6,7 +6,7 @@ import { useFontScale } from "../contexts/FontSizeContext";
 const MENU_GAP = 6;
 const VIEWPORT_PADDING = 8;
 
-export default function BranchSelector({ cwd, onCwdChange, hasMessages }) {
+export default function BranchSelector({ cwd, onCwdChange, hasMessages, onRefocusTerminal }) {
   const s = useFontScale();
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState(null);
@@ -74,6 +74,7 @@ export default function BranchSelector({ cwd, onCwdChange, hasMessages }) {
       setCurrent(name);
       setMenuStyle(null);
       setOpen(false);
+      onRefocusTerminal?.();
     } catch (e) {
       setError(e.message);
     }
@@ -93,6 +94,7 @@ export default function BranchSelector({ cwd, onCwdChange, hasMessages }) {
       } else {
         await window.api.gitCreateBranch(cwd, name);
         setCurrent(name);
+        onRefocusTerminal?.();
       }
       setNewName("");
       setCreating(false);

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -9,7 +9,7 @@ import SelectionToolbar from "./SelectionToolbar";
 import { useFontScale } from "../contexts/FontSizeContext";
 import { SIDEBAR_TOGGLE_LEFT, SIDEBAR_TOGGLE_SIZE, SIDEBAR_TOGGLE_TOP, WINDOW_DRAG_HEIGHT } from "../windowChrome";
 
-export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSidebar, sidebarOpen, onNew, onModelChange, defaultModel, queuedMessages, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, onCwdChange }) {
+export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSidebar, sidebarOpen, onNew, onModelChange, defaultModel, queuedMessages, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, onCwdChange, onRefocusTerminal }) {
   const s = useFontScale();
   const [input, setInput]             = useState("");
   const [inputFocused, setInputFocused] = useState(false);
@@ -284,7 +284,12 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
         </div>
 
         <div style={{ display: "flex", alignItems: "center", gap: 8, WebkitAppRegion: "no-drag" }}>
-          <BranchSelector cwd={cwd} onCwdChange={onCwdChange} hasMessages={convo?.msgs?.length > 0} />
+          <BranchSelector
+            cwd={cwd}
+            onCwdChange={onCwdChange}
+            hasMessages={convo?.msgs?.length > 0}
+            onRefocusTerminal={onRefocusTerminal}
+          />
           <ModelPicker value={convo?.model || defaultModel || "sonnet"} onChange={onModelChange} />
           {onToggleTerminal && (
             <button

--- a/src/components/TerminalDrawer.jsx
+++ b/src/components/TerminalDrawer.jsx
@@ -200,6 +200,8 @@ function TerminalViewport({
         } catch { /* ignore scrollback preload failures */ }
       }
 
+      term.focus();
+
       // Observe container size changes and re-fit
       const ro = new ResizeObserver(() => {
         if (fitAddonRef.current) {

--- a/src/hooks/useTerminal.js
+++ b/src/hooks/useTerminal.js
@@ -111,6 +111,24 @@ export default function useTerminal() {
     window.api.terminalResize({ name, cols, rows });
   }, []);
 
+  const focusSession = useCallback((name) => {
+    if (!name) return;
+    const term = terminalRefs.current.get(name);
+    if (!term || typeof term.focus !== "function") return;
+    window.requestAnimationFrame(() => {
+      try {
+        term.focus();
+      } catch (e) {
+        console.error("[useTerminal] focusSession failed:", e);
+      }
+    });
+  }, []);
+
+  const focusActiveSession = useCallback(() => {
+    if (!activeSession) return;
+    focusSession(activeSession);
+  }, [activeSession, focusSession]);
+
   const registerTerminal = useCallback((name, terminal) => {
     terminalRefs.current.set(name, terminal);
   }, []);
@@ -128,6 +146,8 @@ export default function useTerminal() {
     sendInput,
     killSession,
     resizeSession,
+    focusSession,
+    focusActiveSession,
     refreshSessions,
     registerTerminal,
     unregisterTerminal,


### PR DESCRIPTION
## Summary
- refocus the active terminal after branch checkout and branch creation
- auto-focus the xterm instance when a terminal viewport mounts
- keep the branch selector wired to the active terminal so keyboard input stays in the terminal after branch changes

Fixes #31