### PR TITLE
feat: add steer-before-tool chat guidance

### DIFF
--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -82,6 +82,21 @@ function resolveLaunchCwd({ cwd, sessionId }) {
   throw new Error(`Invalid working directory: ${cwd}`);
 }
 
+function requestAgentSteer(conversationId) {
+  const child = activeAgents.get(conversationId);
+  if (!child) return false;
+
+  log("Scheduling steer at next tool boundary:", conversationId);
+  child._pendingSteer = true;
+
+  if (typeof child._activeToolUseIndex === "number") {
+    child._pendingSteer = false;
+    child._pauseOnToolStop = "steer";
+  }
+
+  return true;
+}
+
 function startAgent({ conversationId, prompt, model, cwd, images, files, sessionId, resumeSessionId, forkSession }, webContents) {
   cancelAgent(conversationId);
 
@@ -203,6 +218,9 @@ The user can see and type into these terminals in real time.`);
 
   log("Spawned PID:", child.pid);
 
+  child._activeToolUseIndex = null;
+  child._pauseOnToolStop = null;
+  child._pendingSteer = false;
   activeAgents.set(conversationId, child);
 
   let buffer = "";
@@ -228,26 +246,33 @@ The user can see and type into these terminals in real time.`);
         }
         webContents.send("agent-stream", { conversationId, event });
 
-        // Track when AskUserQuestion tool_use starts streaming
-        if (
-          event.type === "stream_event" &&
-          event.event?.type === "content_block_start" &&
-          event.event?.content_block?.type === "tool_use" &&
-          event.event?.content_block?.name === "AskUserQuestion"
-        ) {
-          child._waitingForQuestion = true;
-        }
+        if (event.type === "stream_event") {
+          const inner = event.event;
 
-        // Kill the process once the AskUserQuestion args are fully streamed,
-        // so Claude pauses and the renderer can show the question UI.
-        if (
-          child._waitingForQuestion &&
-          event.type === "stream_event" &&
-          event.event?.type === "content_block_stop"
-        ) {
-          log("AskUserQuestion fully streamed — killing process to wait for user answer");
-          child._waitingForQuestion = false;
-          child.kill("SIGTERM");
+          if (inner?.type === "content_block_start" && inner.content_block?.type === "tool_use") {
+            child._activeToolUseIndex = inner.index;
+            if (child._pendingSteer) {
+              log("Next tool boundary reached — pausing for steer:", conversationId);
+              child._pendingSteer = false;
+              child._pauseOnToolStop = "steer";
+            } else if (inner.content_block?.name === "AskUserQuestion") {
+              child._pauseOnToolStop = "question";
+            }
+          }
+
+          if (inner?.type === "content_block_stop" && child._activeToolUseIndex === inner.index) {
+            const pauseReason = child._pauseOnToolStop;
+            child._activeToolUseIndex = null;
+            child._pauseOnToolStop = null;
+
+            if (pauseReason === "steer") {
+              log("Tool args fully streamed — killing process to send queued steer message");
+              child.kill("SIGTERM");
+            } else if (pauseReason === "question") {
+              log("AskUserQuestion fully streamed — killing process to wait for user answer");
+              child.kill("SIGTERM");
+            }
+          }
         }
       } catch (e) {
         log("Failed to parse JSON line:", line.slice(0, 200), "error:", e.message);
@@ -357,4 +382,4 @@ function rewindFiles({ sessionId, messageUuid, cwd }) {
   });
 }
 
-module.exports = { startAgent, cancelAgent, cancelAll, rewindFiles };
+module.exports = { startAgent, cancelAgent, cancelAll, rewindFiles, requestAgentSteer };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -2,7 +2,7 @@ const { app, BrowserWindow, ipcMain, dialog, nativeImage, shell } = require("ele
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { startAgent, cancelAgent, cancelAll, rewindFiles } = require("./agent-manager.cjs");
+const { startAgent, cancelAgent, cancelAll, rewindFiles, requestAgentSteer } = require("./agent-manager.cjs");
 const { startCodexAgent, cancelCodexAgent, cancelAllCodex } = require("./codex-agent-manager.cjs");
 const { listSessions, loadSessionMessages, moveSession } = require("./session-reader.cjs");
 const { createCheckpoint, restoreCheckpoint } = require("./checkpoint.cjs");
@@ -250,6 +250,10 @@ ipcMain.on("agent-start", (event, opts) => {
 ipcMain.on("agent-cancel", (_event, { conversationId }) => {
   cancelAgent(conversationId);
   cancelCodexAgent(conversationId);
+});
+
+ipcMain.on("agent-steer", (_event, { conversationId }) => {
+  requestAgentSteer(conversationId);
 });
 
 ipcMain.on("agent-edit-resend", (event, opts) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -7,6 +7,7 @@ function logCheckpoint(...args) {
 contextBridge.exposeInMainWorld("api", {
   agentStart: (opts) => ipcRenderer.send("agent-start", opts),
   agentCancel: (id) => ipcRenderer.send("agent-cancel", id),
+  agentSteer: (opts) => ipcRenderer.send("agent-steer", opts),
   agentEditAndResend: (opts) => ipcRenderer.send("agent-edit-resend", opts),
   onAgentStream: (cb) => {
     const handler = (_e, data) => cb(data);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,7 +147,7 @@ export default function App() {
 
   // ── Actions ────────────────────────────────────────────────────────────────
 
-  const handleNew = () => {
+  const handleNew = useCallback(() => {
     const id = "c" + Date.now();
     const sessionId = crypto.randomUUID();
     const n = {
@@ -160,24 +160,17 @@ export default function App() {
     };
     setConvoList((p) => [n, ...p]);
     setActive(id);
-  };
+  }, [cwd, defaultModel]);
 
   const handleDelete = (id, e) => {
     e.stopPropagation();
     cancelMessage(id);
+    messageQueue.current = messageQueue.current.filter((item) => item.conversationId !== id);
+    setQueuedMessages([...messageQueue.current]);
     const remaining = convoList.filter((c) => c.id !== id);
     setConvoList(remaining);
     if (active === id) setActive(remaining[0]?.id || null);
   };
-
-  // Process queued messages when streaming ends
-  useEffect(() => {
-    if (!activeData.isStreaming && messageQueue.current.length > 0) {
-      const next = messageQueue.current.shift();
-      setQueuedMessages([...messageQueue.current]);
-      setTimeout(() => handleSend(next.text, next.attachments), 300);
-    }
-  }, [activeData.isStreaming]);
 
   // Capture Codex thread_id for session resume
   useEffect(() => {
@@ -194,7 +187,9 @@ export default function App() {
   }, [active, conversations]);
 
   const handleSend = useCallback(
-    async (text, attachments) => {
+    async (text, attachments, mode = "send", options = {}) => {
+      const { conversationId: requestedConversationId, bypassQueue = false } = options;
+
       // Handle slash commands client-side
       const trimmed = text.trim();
       if (trimmed.startsWith("/") && !trimmed.includes(" ")) {
@@ -213,15 +208,35 @@ export default function App() {
         // /compact and others — send as regular text so Claude handles them
       }
 
-      // Queue if currently streaming
-      if (activeData.isStreaming && active) {
-        messageQueue.current.push({ text, attachments });
+      const targetConversationId = requestedConversationId || active;
+      const targetConvo = targetConversationId
+        ? convoList.find((c) => c.id === targetConversationId)
+        : null;
+      const targetData = targetConversationId
+        ? getConversation(targetConversationId)
+        : { messages: [], isStreaming: false, error: null };
+      const targetModel = getM(targetConvo?.model || defaultModel);
+      const queueMode = mode === "steer" && targetModel.provider === "claude"
+        ? "steer"
+        : "queue";
+
+      // Queue if the target conversation is currently streaming
+      if (!bypassQueue && targetData.isStreaming && targetConversationId) {
+        messageQueue.current.push({
+          conversationId: targetConversationId,
+          text,
+          attachments,
+          mode: queueMode,
+        });
         setQueuedMessages([...messageQueue.current]);
+        if (queueMode === "steer" && window.api?.agentSteer) {
+          window.api.agentSteer({ conversationId: targetConversationId });
+        }
         return;
       }
 
-      let convo = activeConvo;
-      let convoId = active;
+      let convo = targetConvo;
+      let convoId = targetConversationId;
 
       // Auto-create conversation if none exists
       if (!convo) {
@@ -230,10 +245,10 @@ export default function App() {
         convo = { id, sessionId, title: text.slice(0, 50), model: defaultModel, ts: Date.now(), cwd: cwd || undefined };
         convoId = id;
         setConvoList((p) => [convo, ...p]);
-        setActive(id);
+        if (!requestedConversationId) setActive(id);
       } else {
         // Update title from first message
-        if (activeData.messages.length === 0) {
+        if (targetData.messages.length === 0) {
           setConvoList((p) =>
             p.map((c) => c.id === convoId ? { ...c, title: text.slice(0, 50) } : c)
           );
@@ -282,8 +297,27 @@ export default function App() {
         files: files?.length ? files : undefined,
       });
     },
-    [activeConvo, active, activeData, cwd, sendMessage]
+    [active, convoList, cwd, defaultModel, getConversation, handleNew, sendMessage]
   );
+
+  // Flush the next queued item as soon as its conversation is idle
+  useEffect(() => {
+    if (messageQueue.current.length === 0) return;
+    const nextQueued = messageQueue.current[0];
+    const queuedData = getConversation(nextQueued.conversationId);
+    if (queuedData.isStreaming) return;
+
+    const next = messageQueue.current.shift();
+    if (!next) return;
+
+    setQueuedMessages([...messageQueue.current]);
+    setTimeout(() => {
+      handleSend(next.text, next.attachments, "send", {
+        conversationId: next.conversationId,
+        bypassQueue: true,
+      });
+    }, 300);
+  }, [conversations, getConversation, handleSend]);
 
   const handleCancel = useCallback(() => {
     if (active) cancelMessage(active);
@@ -378,6 +412,8 @@ export default function App() {
         error: activeData.error,
       }
     : null;
+  const activeQueuedMessages = queuedMessages.filter((item) => item.conversationId === active);
+  const steeringSupported = getM(activeConvo?.model || defaultModel).provider === "claude";
 
   // Build convos for Sidebar
   const convosForSidebar = convoList.map((c) => {
@@ -489,7 +525,8 @@ export default function App() {
           onNew={handleNew}
           onModelChange={handleModelChange}
           defaultModel={defaultModel}
-          queuedMessages={queuedMessages}
+          queuedMessages={activeQueuedMessages}
+          steeringSupported={steeringSupported}
           onToggleTerminal={() => terminal.setDrawerOpen((o) => !o)}
           terminalOpen={terminal.drawerOpen}
           terminalCount={terminal.sessions.length}

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -9,11 +9,12 @@ import SelectionToolbar from "./SelectionToolbar";
 import { useFontScale } from "../contexts/FontSizeContext";
 import { SIDEBAR_TOGGLE_LEFT, SIDEBAR_TOGGLE_SIZE, SIDEBAR_TOGGLE_TOP, WINDOW_DRAG_HEIGHT } from "../windowChrome";
 
-export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSidebar, sidebarOpen, onNew, onModelChange, defaultModel, queuedMessages, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, onCwdChange }) {
+export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSidebar, sidebarOpen, onNew, onModelChange, defaultModel, queuedMessages, steeringSupported, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, onCwdChange }) {
   const s = useFontScale();
   const [input, setInput]             = useState("");
   const [inputFocused, setInputFocused] = useState(false);
   const [attachments, setAttachments]   = useState([]);
+  const [composeMode, setComposeMode]   = useState("queue");
   const endRef  = useRef(null);
   const inRef   = useRef(null);
 
@@ -44,6 +45,8 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
   }, [msgCount, convo?.isStreaming, lastPartText]);
 
   const isStreaming = convo?.isStreaming;
+  const hasDraft = Boolean(input.trim() || attachments.length > 0);
+  const showSteerOptions = isStreaming && steeringSupported && hasDraft;
 
   // Slash command suggestions
   const COMMANDS = [
@@ -59,11 +62,16 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
 
   const send = useCallback(() => {
     if (!input.trim() && attachments.length === 0) return;
-    onSend(input.trim(), attachments.length > 0 ? attachments : undefined);
+    onSend(
+      input.trim(),
+      attachments.length > 0 ? attachments : undefined,
+      isStreaming ? composeMode : "send"
+    );
     setInput("");
     setAttachments([]);
+    setComposeMode("queue");
     if (inRef.current) inRef.current.style.height = "20px";
-  }, [input, attachments, convo, onSend, isStreaming]);
+  }, [attachments, composeMode, input, isStreaming, onSend]);
 
   const handleInput = (e) => {
     setInput(e.target.value);
@@ -378,15 +386,15 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
                   <span style={{
                     fontSize: s(9),
                     fontFamily: "'JetBrains Mono',monospace",
-                    color: "rgba(255,255,255,0.2)",
+                    color: q.mode === "steer" ? "rgba(255,255,255,0.45)" : "rgba(255,255,255,0.2)",
                     letterSpacing: ".06em",
                     flexShrink: 0,
-                  }}>QUEUED</span>
+                  }}>{q.mode === "steer" ? "STEER" : "QUEUED"}</span>
                   <span style={{
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
-                  }}>{q.text}</span>
+                  }}>{q.text || `${q.attachments?.length || 0} attachment${(q.attachments?.length || 0) === 1 ? "" : "s"}`}</span>
                 </div>
               ))}
             </div>
@@ -432,6 +440,55 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               ))}
             </div>
           )}
+          {showSteerOptions && (
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+              marginBottom: 8,
+              padding: "7px 10px",
+              background: "rgba(255,255,255,0.025)",
+              border: "1px solid rgba(255,255,255,0.05)",
+              borderRadius: 10,
+            }}>
+              <div style={{
+                fontSize: s(10),
+                fontFamily: "'JetBrains Mono',monospace",
+                color: "rgba(255,255,255,0.24)",
+                letterSpacing: ".08em",
+              }}>
+                ACTIVE RUN
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                {[
+                  { id: "queue", label: "Queue after turn" },
+                  { id: "steer", label: "Steer before tool" },
+                ].map((option) => {
+                  const selected = composeMode === option.id;
+                  return (
+                    <button
+                      key={option.id}
+                      onClick={() => setComposeMode(option.id)}
+                      style={{
+                        padding: "5px 10px",
+                        borderRadius: 999,
+                        border: "1px solid " + (selected ? "rgba(255,255,255,0.16)" : "rgba(255,255,255,0.06)"),
+                        background: selected ? "rgba(255,255,255,0.08)" : "rgba(255,255,255,0.02)",
+                        color: selected ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.38)",
+                        fontSize: s(11),
+                        fontFamily: "system-ui,-apple-system,sans-serif",
+                        cursor: "pointer",
+                        transition: "all .18s ease",
+                      }}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
           <ImagePreview items={attachments} onRemove={removeAttachment} />
 
           <div
@@ -472,7 +529,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
                 overflow: "hidden",
               }}
             />
-            {isStreaming && !input.trim() ? (
+            {isStreaming && !hasDraft ? (
               <button
                 onClick={onCancel}
                 style={{
@@ -497,7 +554,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
             ) : (
               <button
                 onClick={send}
-                disabled={!input.trim() && attachments.length === 0}
+                disabled={!hasDraft}
                 style={{
                   display: "flex",
                   alignItems: "center",
@@ -506,12 +563,12 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
                   height: 30,
                   borderRadius: 8,
                   flexShrink: 0,
-                  background: (input.trim() || attachments.length > 0) ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.02)",
+                  background: hasDraft ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.02)",
                   border: "none",
-                  color: (input.trim() || attachments.length > 0) ? "#000000" : "rgba(255,255,255,0.06)",
-                  cursor: (input.trim() || attachments.length > 0) ? "pointer" : "default",
+                  color: hasDraft ? "#000000" : "rgba(255,255,255,0.06)",
+                  cursor: hasDraft ? "pointer" : "default",
                   transition: "all .3s cubic-bezier(.16,1,.3,1)",
-                  transform: (input.trim() || attachments.length > 0) ? "scale(1)" : "scale(0.88)",
+                  transform: hasDraft ? "scale(1)" : "scale(0.88)",
                 }}
               >
                 <ArrowRight size={16} strokeWidth={1.5} />
@@ -529,7 +586,9 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               letterSpacing: ".1em",
             }}
           >
-            ENTER TO SEND  //  SHIFT+ENTER NEWLINE  //  PASTE IMAGES
+            {showSteerOptions && composeMode === "steer"
+              ? "STEER SENDS AT THE NEXT TOOL BOUNDARY  //  SHIFT+ENTER NEWLINE  //  PASTE IMAGES"
+              : "ENTER TO SEND  //  SHIFT+ENTER NEWLINE  //  PASTE IMAGES"}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #21

## Summary
- add a steer request path from the chat composer so users can choose between queueing after the turn or steering before the next tool call
- pause Claude runs at the next tool-use boundary and resume with the queued steer message ahead of tool execution
- keep queued drafts conversation-scoped in the UI so steer and queue badges stay attached to the right chat

## Validation
- `npm run build`
- `node --check electron/agent-manager.cjs`
- `node --check electron/main.cjs`
- `node --check electron/preload.cjs`

## Notes
- `npm run lint` still fails on existing repo-wide issues unrelated to this change (for example `chat.jsx`, `src/components/ThinkingBlock.jsx`, `vite.config.js`)