### PR TITLE
[codex] speed up checkpointing by skipping non-source untracked roots

### DIFF
--- a/electron/checkpoint.cjs
+++ b/electron/checkpoint.cjs
@@ -8,6 +8,140 @@ const path = require("path");
 const { promisify } = require("util");
 
 const execFileAsync = promisify(execFile);
+const MAX_CAPTURED_UNTRACKED_FILE_BYTES = 512 * 1024;
+const SKIPPED_UNTRACKED_DIR_NAMES = new Set([
+  ".build",
+  ".cache",
+  ".claude",
+  ".next",
+  ".nuxt",
+  ".perch",
+  ".svelte-kit",
+  ".turbo",
+  "DerivedData",
+  "Pods",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "release",
+  "sessions",
+]);
+const SKIPPED_UNTRACKED_DIR_PREFIXES = [".codex", ".codex-source-packages"];
+const CAPTURED_TEXT_BASENAMES = new Set([
+  ".env",
+  ".env.example",
+  ".env.local",
+  ".gitignore",
+  ".npmrc",
+  ".prettierignore",
+  "AGENTS.md",
+  "Brewfile",
+  "CLAUDE.md",
+  "Dockerfile",
+  "Gemfile",
+  "Makefile",
+  "Podfile",
+  "README",
+  "README.md",
+]);
+const CAPTURED_TEXT_EXTENSIONS = new Set([
+  ".bash",
+  ".c",
+  ".cc",
+  ".cfg",
+  ".conf",
+  ".cpp",
+  ".cs",
+  ".css",
+  ".cjs",
+  ".go",
+  ".graphql",
+  ".h",
+  ".hpp",
+  ".html",
+  ".ini",
+  ".java",
+  ".js",
+  ".json",
+  ".json5",
+  ".jsonc",
+  ".jsonl",
+  ".jsx",
+  ".kt",
+  ".less",
+  ".m",
+  ".md",
+  ".mdx",
+  ".mm",
+  ".mjs",
+  ".php",
+  ".plist",
+  ".proto",
+  ".py",
+  ".rb",
+  ".rs",
+  ".sass",
+  ".scss",
+  ".sh",
+  ".sql",
+  ".strings",
+  ".swift",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".xcconfig",
+  ".xcstrings",
+  ".xml",
+  ".yaml",
+  ".yml",
+  ".zsh",
+]);
+const SKIPPED_BINARY_EXTENSIONS = new Set([
+  ".7z",
+  ".a",
+  ".app",
+  ".avi",
+  ".bin",
+  ".bmp",
+  ".class",
+  ".dmg",
+  ".dylib",
+  ".ear",
+  ".eot",
+  ".exe",
+  ".gif",
+  ".gz",
+  ".heic",
+  ".ico",
+  ".jar",
+  ".jpeg",
+  ".jpg",
+  ".m4a",
+  ".mov",
+  ".mp3",
+  ".mp4",
+  ".o",
+  ".otf",
+  ".pdf",
+  ".png",
+  ".pyc",
+  ".so",
+  ".svg",
+  ".tar",
+  ".tif",
+  ".tiff",
+  ".ttf",
+  ".war",
+  ".wav",
+  ".webm",
+  ".webp",
+  ".woff",
+  ".woff2",
+  ".xz",
+  ".zip",
+]);
 
 // ---------------------------------------------------------------------------
 // Logging
@@ -15,6 +149,71 @@ const execFileAsync = promisify(execFile);
 
 function log(...args) {
   console.log("[checkpoint]", ...args);
+}
+
+function splitNullTerminated(stdout) {
+  if (!stdout) return [];
+  return stdout.split("\0").filter(Boolean);
+}
+
+function parseUntrackedPaths(stdout) {
+  return splitNullTerminated(stdout)
+    .filter((entry) => entry.startsWith("?? "))
+    .map((entry) => entry.slice(3));
+}
+
+function encodeMetaJson(value) {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64");
+}
+
+function decodeMetaJson(value) {
+  try {
+    return JSON.parse(Buffer.from(value, "base64").toString("utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function normalizeUntrackedPath(relPath) {
+  return relPath.endsWith("/") ? relPath.slice(0, -1) : relPath;
+}
+
+function pathSegments(relPath) {
+  return normalizeUntrackedPath(relPath).split("/").filter(Boolean);
+}
+
+function shouldSkipUntrackedDir(rootPath) {
+  return pathSegments(rootPath).some(
+    (segment) =>
+      SKIPPED_UNTRACKED_DIR_NAMES.has(segment) ||
+      SKIPPED_UNTRACKED_DIR_PREFIXES.some(
+        (prefix) => segment === prefix || segment.startsWith(`${prefix}-`)
+      )
+  );
+}
+
+function looksLikeCapturedTextPath(relPath) {
+  const normalizedPath = normalizeUntrackedPath(relPath);
+  const baseName = path.basename(normalizedPath);
+  if (CAPTURED_TEXT_BASENAMES.has(baseName)) return true;
+
+  const extension = path.extname(baseName).toLowerCase();
+  if (!extension) return false;
+  if (SKIPPED_BINARY_EXTENSIONS.has(extension)) return false;
+  return CAPTURED_TEXT_EXTENSIONS.has(extension);
+}
+
+function shouldCaptureUntrackedFile(repoRoot, relPath) {
+  const normalizedPath = normalizeUntrackedPath(relPath);
+  if (shouldSkipUntrackedDir(path.dirname(normalizedPath))) return false;
+  if (!looksLikeCapturedTextPath(normalizedPath)) return false;
+
+  try {
+    const fileStat = fs.statSync(path.join(repoRoot, normalizedPath));
+    return fileStat.isFile() && fileStat.size <= MAX_CAPTURED_UNTRACKED_FILE_BYTES;
+  } catch {
+    return false;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -76,14 +275,164 @@ async function resolveRepoRoot(cwdPath) {
   return repoRootResult.stdout;
 }
 
+async function listCurrentUntrackedRoots(repoRoot) {
+  const untrackedResult = await execGit(
+    ["status", "--porcelain=v1", "-z", "--untracked-files=normal"],
+    repoRoot
+  );
+  if (untrackedResult.exitCode !== 0) {
+    throw new Error(
+      `[checkpoint] git status --untracked-files=normal failed:\n${untrackedResult.stderr}`
+    );
+  }
+  return parseUntrackedPaths(untrackedResult.stdout);
+}
+
+async function inspectWorktreeState(repoRoot) {
+  const [trackedDeltaResult, untrackedAllResult, untrackedNormalResult] = await Promise.all([
+    execGit(["diff-files", "--name-only", "-z"], repoRoot),
+    execGit(["status", "--porcelain=v1", "-z", "--untracked-files=all"], repoRoot),
+    execGit(["status", "--porcelain=v1", "-z", "--untracked-files=normal"], repoRoot),
+  ]);
+
+  if (trackedDeltaResult.exitCode !== 0) {
+    throw new Error(
+      `[checkpoint] git diff-files failed:\n${trackedDeltaResult.stderr}`
+    );
+  }
+
+  if (untrackedAllResult.exitCode !== 0) {
+    throw new Error(
+      `[checkpoint] git status --untracked-files=all failed:\n${untrackedAllResult.stderr}`
+    );
+  }
+
+  if (untrackedNormalResult.exitCode !== 0) {
+    throw new Error(
+      `[checkpoint] git status --untracked-files=normal failed:\n${untrackedNormalResult.stderr}`
+    );
+  }
+
+  const trackedDeltaPaths = splitNullTerminated(trackedDeltaResult.stdout);
+  const untrackedAllPaths = parseUntrackedPaths(untrackedAllResult.stdout);
+  const untrackedRoots = parseUntrackedPaths(untrackedNormalResult.stdout);
+
+  const captureUntrackedPaths = [];
+  const cleanableUntrackedDirRoots = [];
+  const skippedUntrackedRoots = [];
+
+  for (const root of untrackedRoots) {
+    const normalizedRoot = normalizeUntrackedPath(root);
+    let stat;
+    try {
+      stat = fs.statSync(path.join(repoRoot, normalizedRoot));
+    } catch {
+      continue;
+    }
+
+    if (!stat.isDirectory()) {
+      if (shouldCaptureUntrackedFile(repoRoot, normalizedRoot)) {
+        captureUntrackedPaths.push(normalizedRoot);
+      } else {
+        skippedUntrackedRoots.push(root);
+      }
+      continue;
+    }
+
+    if (shouldSkipUntrackedDir(root)) {
+      skippedUntrackedRoots.push(root);
+      continue;
+    }
+
+    const dirPaths = untrackedAllPaths.filter((candidate) => candidate.startsWith(root));
+    if (
+      dirPaths.length > 0 &&
+      dirPaths.every((candidate) => shouldCaptureUntrackedFile(repoRoot, candidate))
+    ) {
+      captureUntrackedPaths.push(...dirPaths.map((candidate) => normalizeUntrackedPath(candidate)));
+      cleanableUntrackedDirRoots.push(root);
+    } else {
+      skippedUntrackedRoots.push(root);
+    }
+  }
+
+  return {
+    trackedDeltaPaths,
+    capturePaths: [...new Set([...trackedDeltaPaths, ...captureUntrackedPaths])],
+    untrackedRoots,
+    cleanableUntrackedDirRoots,
+    skippedUntrackedRoots,
+    exactUntrackedPathCount: captureUntrackedPaths.length,
+  };
+}
+
+async function buildWorktreeTree(repoRoot, indexTree, capturePaths) {
+  log("worktree delta paths:", capturePaths.length);
+
+  if (capturePaths.length === 0) {
+    log("no captured worktree paths; reusing index tree for checkpoint snapshot");
+    return indexTree;
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claudi-cp-"));
+  const tempIndex = path.join(tempDir, "index");
+  const pathspecFile = path.join(tempDir, "paths");
+
+  try {
+    log("building worktree tree with temp index:", tempIndex);
+
+    const readTreeResult = await execGit(["read-tree", indexTree], repoRoot, {
+      GIT_INDEX_FILE: tempIndex,
+    });
+    if (readTreeResult.exitCode !== 0) {
+      throw new Error(
+        `[checkpoint] git read-tree (temp index) failed:\n${readTreeResult.stderr}`
+      );
+    }
+
+    fs.writeFileSync(pathspecFile, Buffer.from(`${capturePaths.join("\0")}\0`));
+
+    const addResult = await execGit(
+      ["add", "-A", `--pathspec-from-file=${pathspecFile}`, "--pathspec-file-nul"],
+      repoRoot,
+      { GIT_INDEX_FILE: tempIndex }
+    );
+    if (addResult.exitCode !== 0) {
+      throw new Error(
+        `[checkpoint] git add -A (temp index) failed:\n${addResult.stderr}`
+      );
+    }
+
+    const worktreeTreeResult = await execGit(["write-tree"], repoRoot, {
+      GIT_INDEX_FILE: tempIndex,
+    });
+    if (worktreeTreeResult.exitCode !== 0) {
+      throw new Error(
+        `[checkpoint] git write-tree (worktree) failed:\n${worktreeTreeResult.stderr}`
+      );
+    }
+
+    return worktreeTreeResult.stdout;
+  } finally {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch (cleanupErr) {
+      log("warn: failed to clean up temp dir:", tempDir, cleanupErr.message);
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // createCheckpoint
 // ---------------------------------------------------------------------------
 
 /**
  * Snapshot the current working state (HEAD + index + worktree) as a git ref
- * under refs/claudi-checkpoints/.  The user's real staging area is never
- * modified — the worktree tree is built through a throwaway temp index.
+ * under refs/claudi-checkpoints/. The user's real staging area is never
+ * modified — the worktree tree is built through a throwaway temp index that
+ * only refreshes paths that differ from the current index. Untracked content
+ * is captured only when it looks like small source/text content; generated,
+ * binary, and mixed-content roots are preserved instead of restaged.
  *
  * @param {string} cwdPath  Absolute path to a git repository root (or subdir)
  * @returns {Promise<{ ref: string }>}
@@ -136,39 +485,26 @@ async function createCheckpoint(cwdPath) {
   const indexTree = indexTreeResult.stdout;
   log("index tree:", indexTree);
 
-  // 5. Capture the worktree tree via a temporary index
-  let worktreeTree;
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "claudi-cp-"));
-  const tempIndex = path.join(tempDir, "index");
-  try {
-    log("building worktree tree with temp index:", tempIndex);
-
-    const addResult = await execGit(["add", "-A", "--", "."], repoRoot, {
-      GIT_INDEX_FILE: tempIndex,
-    });
-    if (addResult.exitCode !== 0) {
-      throw new Error(
-        `[checkpoint] git add -A (temp index) failed:\n${addResult.stderr}`
-      );
-    }
-
-    const worktreeTreeResult = await execGit(["write-tree"], repoRoot, {
-      GIT_INDEX_FILE: tempIndex,
-    });
-    if (worktreeTreeResult.exitCode !== 0) {
-      throw new Error(
-        `[checkpoint] git write-tree (worktree) failed:\n${worktreeTreeResult.stderr}`
-      );
-    }
-    worktreeTree = worktreeTreeResult.stdout;
-    log("worktree tree:", worktreeTree);
-  } finally {
-    try {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    } catch (cleanupErr) {
-      log("warn: failed to clean up temp dir:", tempDir, cleanupErr.message);
-    }
+  // 5. Inspect worktree changes and capture a targeted temp-index snapshot
+  const worktreeState = await inspectWorktreeState(repoRoot);
+  log(
+    "untracked roots:",
+    worktreeState.untrackedRoots.length,
+    "exact paths:",
+    worktreeState.exactUntrackedPathCount,
+    "skipped roots:",
+    worktreeState.skippedUntrackedRoots.length
+  );
+  if (worktreeState.skippedUntrackedRoots.length > 0) {
+    log("skipping non-source untracked roots:", worktreeState.skippedUntrackedRoots.join(", "));
   }
+
+  const worktreeTree = await buildWorktreeTree(
+    repoRoot,
+    indexTree,
+    worktreeState.capturePaths
+  );
+  log("worktree tree:", worktreeTree);
 
   // 6. Compose the metadata commit message
   const createdAt = now.toISOString();
@@ -178,7 +514,19 @@ async function createCheckpoint(cwdPath) {
     `index-tree ${indexTree}`,
     `worktree-tree ${worktreeTree}`,
     `created ${createdAt}`,
-  ].join("\n");
+  ];
+  if (worktreeState.untrackedRoots.length > 0) {
+    commitMessage.push(
+      `untracked-roots-json ${encodeMetaJson(worktreeState.untrackedRoots)}`
+    );
+  }
+  if (worktreeState.cleanableUntrackedDirRoots.length > 0) {
+    commitMessage.push(
+      `cleanable-untracked-dirs-json ${encodeMetaJson(
+        worktreeState.cleanableUntrackedDirRoots
+      )}`
+    );
+  }
 
   // 7. Create the commit object (Inspector-style author env vars)
   const authorEnv = {
@@ -188,7 +536,7 @@ async function createCheckpoint(cwdPath) {
     GIT_COMMITTER_EMAIL: "checkpoint@claudi.local",
   };
 
-  const commitTreeArgs = ["commit-tree", worktreeTree, "-m", commitMessage];
+  const commitTreeArgs = ["commit-tree", worktreeTree, "-m", commitMessage.join("\n")];
   // If HEAD is a real commit, parent the checkpoint against it so history is
   // browsable, but this is purely cosmetic — restore ignores the parent chain.
   if (headOid !== "0000000000000000000000000000000000000000") {
@@ -225,7 +573,9 @@ async function createCheckpoint(cwdPath) {
 
 /**
  * Revert the working tree (and index) to a previously created checkpoint.
- * Untracked files introduced after the checkpoint are removed via git clean.
+ * Untracked files introduced after the checkpoint are removed selectively so
+ * pre-existing skipped roots can be preserved without exact restaging on every
+ * checkpoint.
  *
  * @param {string} cwdPath  Absolute path to the git repository
  * @param {string} ref      Checkpoint ID returned by createCheckpoint, e.g.
@@ -279,6 +629,9 @@ async function restoreCheckpoint(cwdPath, ref) {
   const headOid = parseMeta("head");
   const indexTree = parseMeta("index-tree");
   const worktreeTree = parseMeta("worktree-tree");
+  const untrackedRoots = decodeMetaJson(parseMeta("untracked-roots-json") || "") || [];
+  const cleanableUntrackedDirRoots =
+    decodeMetaJson(parseMeta("cleanable-untracked-dirs-json") || "") || [];
 
   if (!worktreeTree) {
     throw new Error(
@@ -316,12 +669,36 @@ async function restoreCheckpoint(cwdPath, ref) {
     );
   }
 
-  // 5. Remove files that were untracked at snapshot time but exist now
-  log("cleaning untracked files");
-  const cleanResult = await execGit(["clean", "-fd"], repoRoot);
-  if (cleanResult.exitCode !== 0) {
-    // Non-fatal: log and continue
-    log("warn: git clean -fd exited with", cleanResult.exitCode, cleanResult.stderr);
+  // 5. Remove untracked roots that were introduced after the checkpoint.
+  // For small captured directories, git clean can safely remove extra files
+  // while preserving snapshot files because they are still tracked in the
+  // temporary worktree tree at this point.
+  const currentUntrackedRoots = await listCurrentUntrackedRoots(repoRoot);
+  const preservedRootSet = new Set(untrackedRoots);
+  const cleanableDirRootSet = new Set(cleanableUntrackedDirRoots);
+  log("cleaning untracked roots:", currentUntrackedRoots.length);
+
+  for (const root of currentUntrackedRoots) {
+    if (cleanableDirRootSet.has(root)) {
+      const cleanResult = await execGit(["clean", "-fd", "--", root], repoRoot);
+      if (cleanResult.exitCode !== 0) {
+        log(
+          "warn: git clean -fd failed for preserved dir",
+          root,
+          cleanResult.exitCode,
+          cleanResult.stderr
+        );
+      }
+      continue;
+    }
+
+    if (preservedRootSet.has(root)) continue;
+
+    try {
+      fs.rmSync(path.join(repoRoot, root), { recursive: true, force: true });
+    } catch (removeErr) {
+      log("warn: failed to remove untracked root:", root, removeErr.message);
+    }
   }
 
   // 6. Restore the index to the captured index tree (if available)


### PR DESCRIPTION
## What changed
This updates checkpoint creation to snapshot tracked changes and the index exactly, while only exact-capturing untracked content that looks like small source or text files.

Generated/tool-owned directories and binary or artifact-like untracked roots are now skipped from exact checkpoint snapshots and preserved across restore instead of being re-indexed on every message.

## Why
Per-message checkpointing was slow in larger repos because the temp-index snapshot path was traversing large untracked trees.

On `/Users/kira-chan/Documents/Development/Conflux`, the root cause was untracked content like `.claude/`, `build/`, and other generated or binary-heavy roots. Those were forcing expensive `git add` work during every checkpoint.

## Impact
Message-time checkpoint creation is much faster in repos with large untracked caches or build outputs.

The tradeoff is intentional: skipped untracked roots are preserved rather than rewound. Newly created source-like untracked files still rewind correctly.

## Validation
- `node --check electron/checkpoint.cjs`
- temp-repo exact round-trip for tracked edits plus untracked source files
- temp-repo skip-policy round-trip for build outputs and binary roots
- `npm run build`
- measured `createCheckpoint` on Conflux at about `612 ms` after this change
