### PR TITLE
fix: restore Codex agent spawn PATH setup

### DIFF
--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -2,7 +2,7 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
+const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
 
 const activeAgents = new Map();
 const TERMINAL_CLI_PATH = path.join(__dirname, "../scripts/claudi-terminal.cjs");


### PR DESCRIPTION
Summary
- import buildSpawnPath into electron/codex-agent-manager.cjs
- restore the shared PATH builder used when spawning the Codex CLI
- fix the runtime ReferenceError that prevented Codex conversations from launching

Verification
- ran a local Node smoke test with CODEX_BIN=/bin/echo to exercise startCodexAgent() through the spawn path without throwing

Closes #62