### PR TITLE
Add shell mode for !chat commands

### DIFF
--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -2,7 +2,7 @@ const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
+const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
 
 const activeAgents = new Map();
 const TERMINAL_CLI_PATH = path.join(__dirname, "../scripts/claudi-terminal.cjs");

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -11,6 +11,8 @@ const terminalManager = require("./terminal-manager.cjs");
 const ghManager = require("./github-manager.cjs");
 
 const isDev = !app.isPackaged;
+const SHELL_COMMAND_TIMEOUT_MS = 15000;
+const SHELL_OUTPUT_LIMIT = 128 * 1024;
 const WALLPAPER_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "gif", "bmp", "avif"];
 const WALLPAPER_MIME_TYPES = {
   png: "image/png",
@@ -433,6 +435,132 @@ ipcMain.handle("quick-explain", async (_event, { text, model }) => {
     child.on("close", () => resolve(out.trim()));
     child.on("error", (err) => resolve(`Error: ${err.message}`));
     setTimeout(() => { child.kill(); resolve(out.trim() || "Timed out"); }, 30000);
+  });
+});
+
+ipcMain.handle("shell-run", async (_event, { command, cwd }) => {
+  const { spawn } = require("child_process");
+
+  return new Promise((resolve) => {
+    const shellCommand = String(command || "").trim();
+    const workDir = cwd || os.homedir();
+
+    if (!shellCommand) {
+      resolve({
+        ok: false,
+        command: shellCommand,
+        cwd: workDir,
+        stdout: "",
+        stderr: "",
+        exitCode: null,
+        timedOut: false,
+        truncated: false,
+        error: "Command is required.",
+      });
+      return;
+    }
+
+    const isWindows = process.platform === "win32";
+    const shellBin = isWindows ? (process.env.ComSpec || "cmd.exe") : "/bin/sh";
+    const shellArgs = isWindows
+      ? ["/d", "/s", "/c", shellCommand]
+      : ["-c", shellCommand];
+    const env = { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() };
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let truncated = false;
+    let settled = false;
+
+    const appendChunk = (current, chunk) => {
+      if (current.length >= SHELL_OUTPUT_LIMIT) {
+        truncated = true;
+        return current;
+      }
+
+      const text = chunk.toString();
+      const remaining = SHELL_OUTPUT_LIMIT - current.length;
+      if (text.length > remaining) {
+        truncated = true;
+        return current + text.slice(0, remaining);
+      }
+
+      return current + text;
+    };
+
+    let child;
+    try {
+      child = spawn(shellBin, shellArgs, {
+        cwd: workDir,
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (error) {
+      resolve({
+        ok: false,
+        command: shellCommand,
+        cwd: workDir,
+        stdout: "",
+        stderr: "",
+        exitCode: null,
+        timedOut: false,
+        truncated: false,
+        error: error.message || String(error),
+      });
+      return;
+    }
+
+    const finish = (payload) => {
+      if (settled) return;
+      settled = true;
+      resolve(payload);
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        child.kill();
+      } catch {}
+    }, SHELL_COMMAND_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk) => {
+      stdout = appendChunk(stdout, chunk);
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr = appendChunk(stderr, chunk);
+    });
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      finish({
+        ok: false,
+        command: shellCommand,
+        cwd: workDir,
+        stdout,
+        stderr,
+        exitCode: null,
+        timedOut,
+        truncated,
+        error: error.message || String(error),
+      });
+    });
+
+    child.on("close", (exitCode) => {
+      clearTimeout(timer);
+      finish({
+        ok: true,
+        command: shellCommand,
+        cwd: workDir,
+        stdout,
+        stderr,
+        exitCode,
+        timedOut,
+        truncated,
+      });
+    });
   });
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -47,6 +47,7 @@ contextBridge.exposeInMainWorld("api", {
   quickExplain: (opts) => ipcRenderer.invoke("quick-explain", opts),
   getSystemInfo: () => ipcRenderer.invoke("system-info"),
   getDraftsPath: () => ipcRenderer.invoke("get-drafts-path"),
+  shellRun: ({ command, cwd }) => ipcRenderer.invoke("shell-run", { command, cwd }),
 
   // Git operations
   gitBranches: (cwd) => ipcRenderer.invoke("git-branches", cwd),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ensue",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ensue",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ function logSendFlow(...args) {
 }
 
 const SHELL_TRANSCRIPT_LIMIT = 12000;
+const SHELL_TERMINAL_TIMEOUT_MS = 15000;
 
 function getMainRepoRoot(dir) {
   if (!dir) return dir;
@@ -40,49 +41,169 @@ function truncateShellText(text) {
   return `${text.slice(0, SHELL_TRANSCRIPT_LIMIT)}\n\n[output truncated: ${remaining} more characters]`;
 }
 
-function formatShellTranscript(result) {
-  const fence = "````";
-  const sections = [`!${result.command}`];
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
-  sections.push("");
-  sections.push(`Executed locally${result.cwd ? ` in \`${result.cwd}\`` : ""}.`);
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripAnsi(text) {
+  const esc = String.fromCharCode(27);
+  return text.replace(new RegExp(`${esc}(?:[@-Z\\\\-_]|\\[[0-?]*[ -/]*[@-~])`, "g"), "");
+}
+
+function cleanTerminalShellOutput(text, marker) {
+  if (!text) return "";
+
+  const markerPattern = new RegExp(`^${escapeRegExp(marker)}:\\d+$`);
+  const helperPatterns = [
+    /^__claudi_exit_code=\$\?$/,
+    /^printf ['"].*__CLAUDI_SHELL_EXIT__.*$/,
+  ];
+
+  return stripAnsi(text)
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return true;
+      if (markerPattern.test(trimmed)) return false;
+      return !helperPatterns.some((pattern) => pattern.test(trimmed));
+    })
+    .join("\n")
+    .trim();
+}
+
+async function runShellViaTerminalApi({ command, cwd }) {
+  if (!window.api?.terminalCreate || !window.api?.terminalSend || !window.api?.terminalRead || !window.api?.terminalKill) {
+    return {
+      ok: false,
+      command,
+      cwd,
+      stdout: "",
+      stderr: "",
+      exitCode: null,
+      timedOut: false,
+      truncated: false,
+      error: "Terminal session APIs are not available.",
+    };
+  }
+
+  const sessionName = `shell-run-${Date.now()}`;
+  const marker = `__CLAUDI_SHELL_EXIT__${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  const deadline = Date.now() + SHELL_TERMINAL_TIMEOUT_MS;
+
+  const createResult = await window.api.terminalCreate({ name: sessionName, cwd });
+  if (createResult?.error) {
+    return {
+      ok: false,
+      command,
+      cwd,
+      stdout: "",
+      stderr: "",
+      exitCode: null,
+      timedOut: false,
+      truncated: false,
+      error: createResult.error,
+    };
+  }
+
+  const sendInput = async (text) => {
+    const result = await window.api.terminalSend({ name: sessionName, text });
+    if (result?.error) throw new Error(result.error);
+  };
+
+  try {
+    await sendInput(`${command}\n`);
+    await sendInput("__claudi_exit_code=$?\n");
+    await sendInput(`printf '${marker}:%s\\n' "$__claudi_exit_code"\n`);
+
+    let rawOutput = "";
+    let exitCode = null;
+
+    while (Date.now() < deadline) {
+      const readResult = await window.api.terminalRead({ name: sessionName, lines: 400 });
+      if (readResult?.error) throw new Error(readResult.error);
+
+      rawOutput = (readResult?.lines || []).join("\n");
+      const match = rawOutput.match(new RegExp(`${escapeRegExp(marker)}:(\\d+)`));
+      if (match) {
+        exitCode = Number(match[1]);
+        break;
+      }
+
+      await sleep(120);
+    }
+
+    const output = cleanTerminalShellOutput(rawOutput, marker);
+
+    if (exitCode == null) {
+      return {
+        ok: true,
+        command,
+        cwd,
+        stdout: output,
+        stderr: "",
+        exitCode: null,
+        timedOut: true,
+        truncated: false,
+      };
+    }
+
+    return {
+      ok: true,
+      command,
+      cwd,
+      stdout: output,
+      stderr: "",
+      exitCode,
+      timedOut: false,
+      truncated: false,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      command,
+      cwd,
+      stdout: "",
+      stderr: "",
+      exitCode: null,
+      timedOut: false,
+      truncated: false,
+      error: error.message || String(error),
+    };
+  } finally {
+    try {
+      await window.api.terminalKill({ name: sessionName });
+    } catch (error) {
+      console.warn("[shell-fallback] terminal kill failed:", error);
+    }
+  }
+}
+
+function formatShellResult(result) {
+  const fence = "````";
 
   if (!result.ok) {
-    sections.push("");
-    sections.push(`Shell error: ${result.error || "Unknown error"}`);
-    return sections.join("\n");
-  }
-
-  sections.push(`Exit code: \`${result.exitCode ?? "unknown"}\`${result.timedOut ? " (timed out)" : ""}`);
-
-  if (result.timedOut) {
-    sections.push("");
-    sections.push("Command timed out. Partial output is shown below.");
-  }
-
-  if (result.truncated) {
-    sections.push("");
-    sections.push("Captured output was truncated.");
+    return `${fence}text\n${result.error || "Unknown error"}\n${fence}`;
   }
 
   const stdout = truncateShellText(result.stdout || "");
   const stderr = truncateShellText(result.stderr || "");
+  const sections = [];
 
   if (stdout) {
-    sections.push("");
-    sections.push("Stdout:");
     sections.push(`${fence}text\n${stdout}\n${fence}`);
   }
 
   if (stderr) {
-    sections.push("");
-    sections.push("Stderr:");
+    if (stdout) sections.push("");
     sections.push(`${fence}text\n${stderr}\n${fence}`);
   }
 
   if (!stdout && !stderr) {
-    sections.push("");
-    sections.push("No output.");
+    sections.push(`${fence}text\n(no output)\n${fence}`);
   }
 
   return sections.join("\n");
@@ -116,6 +237,7 @@ export default function App() {
     conversations,
     getConversation,
     prepareMessage,
+    appendLocalMessages,
     startPreparedMessage,
     cancelMessage,
     editAndResend,
@@ -427,9 +549,11 @@ export default function App() {
 
   const handleSend = useCallback(
     async (text, attachments) => {
-      // Handle slash commands client-side
       const trimmed = text.trim();
       const isShellCommand = trimmed.startsWith("!") && trimmed.length > 1;
+      if (trimmed === "!") return;
+
+      // Handle slash commands client-side
       if (trimmed.startsWith("/") && !trimmed.includes(" ")) {
         const cmd = trimmed.toLowerCase();
         if (cmd === "/clear" || cmd === "/new") {
@@ -466,33 +590,57 @@ export default function App() {
         setActive(id);
       }
 
-      let messageText = text;
-      let titleText = text;
-
       if (isShellCommand) {
         const command = trimmed.slice(1).trim();
         const effectiveCwd = getEffectiveConversationCwd(convo, cwd, draftsPath);
-        const result = window.api?.shellRun
-          ? await window.api.shellRun({ command, cwd: effectiveCwd })
-          : {
-              ok: false,
-              command,
-              cwd: effectiveCwd,
-              error: "Shell mode is not available in this environment.",
-            };
-        messageText = formatShellTranscript(result);
-        titleText = trimmed;
+        const isFirstMessage = getConversation(convoId).messages.length === 0;
+        let result;
+
+        if (window.api?.shellRun) {
+          result = await window.api.shellRun({ command, cwd: effectiveCwd });
+        } else if (window.api?.terminalCreate && window.api?.terminalSend && window.api?.terminalRead && window.api?.terminalKill) {
+          result = await runShellViaTerminalApi({ command, cwd: effectiveCwd });
+        } else {
+          result = {
+            ok: false,
+            command,
+            cwd: effectiveCwd,
+            error: "Shell mode is not available in this environment.",
+          };
+        }
+
+        if (isFirstMessage) {
+          setConvoList((p) =>
+            p.map((c) => c.id === convoId ? { ...c, title: trimmed.slice(0, 50) } : c)
+          );
+        }
+
+        appendLocalMessages(convoId, [
+          {
+            role: "user",
+            text: command,
+            mode: "shell-command",
+          },
+          {
+            role: "system",
+            text: formatShellResult(result),
+            mode: "shell-result",
+            command,
+            exitCode: result.exitCode,
+          },
+        ]);
+        return;
       }
 
       await sendMessageToConversation({
         conversationId: convoId,
         conversation: convo,
-        text: messageText,
+        text,
         attachments,
-        titleText,
+        titleText: text,
       });
     },
-    [activeConvo, active, activeData, cwd, defaultModel, draftsPath, sendMessageToConversation]
+    [activeConvo, active, activeData, appendLocalMessages, cwd, defaultModel, draftsPath, getConversation, sendMessageToConversation]
   );
 
   // Process queued messages when streaming ends

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,10 +18,74 @@ function logSendFlow(...args) {
   console.log("[send-flow]", ...args);
 }
 
+const SHELL_TRANSCRIPT_LIMIT = 12000;
+
 function getMainRepoRoot(dir) {
   if (!dir) return dir;
   const wtIdx = dir.indexOf("/.worktrees/");
   return wtIdx !== -1 ? dir.slice(0, wtIdx) : dir;
+}
+
+function getEffectiveConversationCwd(conversation, appCwd, draftsPath) {
+  const convoCwd = conversation?.cwd;
+  if (convoCwd === null) return draftsPath || undefined;
+  if (convoCwd !== undefined) return convoCwd || undefined;
+  return appCwd || undefined;
+}
+
+function truncateShellText(text) {
+  if (!text) return "";
+  if (text.length <= SHELL_TRANSCRIPT_LIMIT) return text;
+  const remaining = text.length - SHELL_TRANSCRIPT_LIMIT;
+  return `${text.slice(0, SHELL_TRANSCRIPT_LIMIT)}\n\n[output truncated: ${remaining} more characters]`;
+}
+
+function formatShellTranscript(result) {
+  const fence = "````";
+  const sections = [`!${result.command}`];
+
+  sections.push("");
+  sections.push(`Executed locally${result.cwd ? ` in \`${result.cwd}\`` : ""}.`);
+
+  if (!result.ok) {
+    sections.push("");
+    sections.push(`Shell error: ${result.error || "Unknown error"}`);
+    return sections.join("\n");
+  }
+
+  sections.push(`Exit code: \`${result.exitCode ?? "unknown"}\`${result.timedOut ? " (timed out)" : ""}`);
+
+  if (result.timedOut) {
+    sections.push("");
+    sections.push("Command timed out. Partial output is shown below.");
+  }
+
+  if (result.truncated) {
+    sections.push("");
+    sections.push("Captured output was truncated.");
+  }
+
+  const stdout = truncateShellText(result.stdout || "");
+  const stderr = truncateShellText(result.stderr || "");
+
+  if (stdout) {
+    sections.push("");
+    sections.push("Stdout:");
+    sections.push(`${fence}text\n${stdout}\n${fence}`);
+  }
+
+  if (stderr) {
+    sections.push("");
+    sections.push("Stderr:");
+    sections.push(`${fence}text\n${stderr}\n${fence}`);
+  }
+
+  if (!stdout && !stderr) {
+    sections.push("");
+    sections.push("No output.");
+  }
+
+  return sections.join("\n");
 }
 
 function normalizeProjectsMeta(projectsMeta) {
@@ -260,14 +324,10 @@ export default function App() {
   }, [active, conversations]);
 
   const sendMessageToConversation = useCallback(
-    async ({ conversationId, conversation, text, attachments }) => {
+    async ({ conversationId, conversation, text, attachments, titleText }) => {
       if (!conversationId || !conversation) return false;
 
-      const convoCwd = conversation.cwd;
-      // null = explicit draft → use the shared drafts dir; undefined = legacy convo → fall back to app cwd
-      const effectiveCwd = convoCwd === null
-        ? (draftsPath || undefined)
-        : (convoCwd !== undefined ? (convoCwd || undefined) : (cwd || undefined));
+      const effectiveCwd = getEffectiveConversationCwd(conversation, cwd, draftsPath);
       const thisConvoData = getConversation(conversationId);
       const isFirstMessage = thisConvoData.messages.length === 0;
       const messageIndex = thisConvoData.messages.length;
@@ -278,7 +338,7 @@ export default function App() {
 
       if (isFirstMessage) {
         setConvoList((p) =>
-          p.map((c) => c.id === conversationId ? { ...c, title: text.slice(0, 50) } : c)
+          p.map((c) => c.id === conversationId ? { ...c, title: (titleText || text).slice(0, 50) } : c)
         );
       }
 
@@ -369,6 +429,7 @@ export default function App() {
     async (text, attachments) => {
       // Handle slash commands client-side
       const trimmed = text.trim();
+      const isShellCommand = trimmed.startsWith("!") && trimmed.length > 1;
       if (trimmed.startsWith("/") && !trimmed.includes(" ")) {
         const cmd = trimmed.toLowerCase();
         if (cmd === "/clear" || cmd === "/new") {
@@ -405,14 +466,33 @@ export default function App() {
         setActive(id);
       }
 
+      let messageText = text;
+      let titleText = text;
+
+      if (isShellCommand) {
+        const command = trimmed.slice(1).trim();
+        const effectiveCwd = getEffectiveConversationCwd(convo, cwd, draftsPath);
+        const result = window.api?.shellRun
+          ? await window.api.shellRun({ command, cwd: effectiveCwd })
+          : {
+              ok: false,
+              command,
+              cwd: effectiveCwd,
+              error: "Shell mode is not available in this environment.",
+            };
+        messageText = formatShellTranscript(result);
+        titleText = trimmed;
+      }
+
       await sendMessageToConversation({
         conversationId: convoId,
         conversation: convo,
-        text,
+        text: messageText,
         attachments,
+        titleText,
       });
     },
-    [activeConvo, active, activeData, cwd, defaultModel, sendMessageToConversation]
+    [activeConvo, active, activeData, cwd, defaultModel, draftsPath, sendMessageToConversation]
   );
 
   // Process queued messages when streaming ends

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -57,14 +57,26 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
     ? COMMANDS.filter(c => c.cmd.startsWith(input.toLowerCase()))
     : [];
   const [selectedCmd, setSelectedCmd] = useState(0);
+  const trimmedInput = input.trim();
+  const shellMode = trimmedInput.startsWith("!");
+  const canRunShell = shellMode && trimmedInput.length > 1;
+  const canSend = shellMode ? canRunShell : Boolean(trimmedInput) || attachments.length > 0;
+  const shellLocation = cwd ? (() => {
+    const parts = cwd.split("/");
+    const wtIdx = parts.indexOf(".worktrees");
+    if (wtIdx >= 0 && wtIdx + 1 < parts.length) {
+      return `${parts[wtIdx - 1]} / ${parts[wtIdx + 1]}`;
+    }
+    return parts.slice(-2).join("/") || parts[parts.length - 1] || cwd;
+  })() : "current workspace";
 
   const send = useCallback(() => {
-    if (!input.trim() && attachments.length === 0) return;
-    onSend(input.trim(), attachments.length > 0 ? attachments : undefined);
+    if (!canSend) return;
+    onSend(trimmedInput, shellMode ? undefined : (attachments.length > 0 ? attachments : undefined));
     setInput("");
     setAttachments([]);
     if (inRef.current) inRef.current.style.height = "20px";
-  }, [input, attachments, convo, onSend, isStreaming]);
+  }, [attachments, canSend, onSend, shellMode, trimmedInput]);
 
   const handleInput = (e) => {
     setInput(e.target.value);
@@ -193,6 +205,8 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
       style={{
         flex: 1, display: "flex", flexDirection: "column", minWidth: 0, position: "relative", zIndex: 10,
         background: wallpaper?.dataUrl ? `rgba(0,0,0,${wallpaper.opacity / 100})` : "transparent",
+        boxShadow: dragOver ? "inset 0 0 0 1px rgba(153,214,255,0.18)" : "none",
+        transition: "box-shadow .2s ease",
       }}
       onDrop={(e) => { e.stopPropagation(); handleDrop(e); setDragOver(false); }}
       onDragOver={handleDragOver}
@@ -361,7 +375,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               <Message
                 key={m.id}
                 msg={m}
-                onEdit={m.role === "user" ? (newText) => onEdit(i, newText) : undefined}
+                onEdit={m.role === "user" && m.mode !== "shell-command" ? (newText) => onEdit(i, newText) : undefined}
                 onAnswer={m.role === "assistant" ? (text) => onSend(text) : undefined}
               />
             ))}
@@ -452,6 +466,21 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
             </div>
           )}
           <ImagePreview items={attachments} onRemove={removeAttachment} />
+          {shellMode && (
+            <div
+              style={{
+                marginBottom: 6,
+                fontSize: s(10),
+                fontFamily: "'JetBrains Mono',monospace",
+                letterSpacing: ".1em",
+                color: "rgba(255,255,255,0.35)",
+              }}
+            >
+              {canRunShell
+                ? `SHELL MODE  //  RUNS IN ${shellLocation.toUpperCase()}`
+                : "SHELL MODE  //  TYPE A COMMAND AFTER !"}
+            </div>
+          )}
 
           <div
             style={{
@@ -463,7 +492,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               borderRadius: 12,
               padding: "9px 14px",
               backdropFilter: `blur(${wallpaper?.dataUrl ? wallpaper.blur : 20}px)`,
-              transition: "border-color .25s",
+              transition: "border-color .25s, background .25s",
             }}
           >
             <textarea
@@ -474,7 +503,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               onPaste={handlePaste}
               onFocus={() => setInputFocused(true)}
               onBlur={() => setInputFocused(false)}
-              placeholder="Write something..."
+              placeholder={shellMode ? "Run a shell command locally..." : "Write something..."}
               rows={1}
               style={{
                 flex: 1,
@@ -516,24 +545,41 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
             ) : (
               <button
                 onClick={send}
-                disabled={!input.trim() && attachments.length === 0}
+                disabled={!canSend}
                 style={{
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  width: 30,
+                  gap: shellMode ? 6 : 0,
+                  width: shellMode ? "auto" : 30,
                   height: 30,
+                  padding: shellMode ? "0 12px" : 0,
                   borderRadius: 8,
                   flexShrink: 0,
-                  background: (input.trim() || attachments.length > 0) ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.02)",
+                  background: canSend ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.02)",
                   border: "none",
-                  color: (input.trim() || attachments.length > 0) ? "#000000" : "rgba(255,255,255,0.06)",
-                  cursor: (input.trim() || attachments.length > 0) ? "pointer" : "default",
+                  color: canSend ? "#000000" : "rgba(255,255,255,0.06)",
+                  cursor: canSend ? "pointer" : "default",
                   transition: "all .3s cubic-bezier(.16,1,.3,1)",
-                  transform: (input.trim() || attachments.length > 0) ? "scale(1)" : "scale(0.88)",
+                  transform: canSend ? "scale(1)" : "scale(0.88)",
                 }}
               >
-                <ArrowRight size={16} strokeWidth={1.5} />
+                {shellMode ? (
+                  <>
+                    <TerminalIcon size={14} strokeWidth={1.6} />
+                    <span
+                      style={{
+                        fontSize: s(10),
+                        fontFamily: "'JetBrains Mono',monospace",
+                        letterSpacing: ".1em",
+                      }}
+                    >
+                      RUN
+                    </span>
+                  </>
+                ) : (
+                  <ArrowRight size={16} strokeWidth={1.5} />
+                )}
               </button>
             )}
           </div>
@@ -548,7 +594,11 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               letterSpacing: ".1em",
             }}
           >
-            ENTER TO SEND  //  SHIFT+ENTER NEWLINE  //  PASTE IMAGES
+            {shellMode
+              ? (canRunShell
+                  ? "ENTER TO RUN  //  OUTPUT APPENDS BELOW  //  LOCAL SHELL"
+                  : "TYPE A COMMAND AFTER !  //  ENTER TO RUN")
+              : "ENTER TO SEND  //  SHIFT+ENTER NEWLINE  //  PASTE IMAGES"}
           </div>
         </div>
       </div>}

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { Pencil, Loader2, FileText, PauseCircle } from "lucide-react";
+import { Pencil, Loader2, FileText, PauseCircle, Terminal } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -48,6 +48,33 @@ const sanitizeSchema = {
     foreignObject: ["x", "y", "width", "height"],
   },
 };
+
+function PreBlock({ rawText, s = (x) => x, children }) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <pre
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        background: "rgba(0,0,0,0.4)",
+        border: "1px solid rgba(255,255,255,0.06)",
+        borderRadius: 8,
+        padding: "12px 14px",
+        overflow: "auto",
+        fontSize: s(12),
+        fontFamily: "'JetBrains Mono',monospace",
+        margin: "8px 0 12px",
+        lineHeight: 1.6,
+        position: "relative",
+      }}
+    >
+      <div style={{ position: "absolute", top: 6, right: 6, opacity: hovered ? 1 : 0, transition: "opacity .15s" }}>
+        <CopyBtn text={rawText} />
+      </div>
+      {children}
+    </pre>
+  );
+}
 
 const makeMdComponents = (isStreaming = false, s = (x) => x) => ({
   p: ({ children }) => <p style={{ margin: "0 0 12px" }}>{children}</p>,
@@ -110,25 +137,7 @@ const makeMdComponents = (isStreaming = false, s = (x) => x) => ({
       return <InteractiveBlock code={text.replace(/\n$/, "")} isStreaming={isStreaming} />;
     }
     const rawText = codeNode?.children?.map(c => c.value || "").join("") || "";
-    return (
-      <pre style={{
-        background: "rgba(0,0,0,0.4)",
-        border: "1px solid rgba(255,255,255,0.06)",
-        borderRadius: 8,
-        padding: "12px 14px",
-        overflow: "auto",
-        fontSize: s(12),
-        fontFamily: "'JetBrains Mono',monospace",
-        margin: "8px 0 12px",
-        lineHeight: 1.6,
-        position: "relative",
-      }}>
-        <div style={{ position: "absolute", top: 6, right: 6 }}>
-          <CopyBtn text={rawText} />
-        </div>
-        {children}
-      </pre>
-    );
+    return <PreBlock rawText={rawText} s={s}>{children}</PreBlock>;
   },
   ul: ({ children }) => <ul style={{ paddingLeft: 20, margin: "4px 0 12px" }}>{children}</ul>,
   ol: ({ children }) => <ol style={{ paddingLeft: 20, margin: "4px 0 12px" }}>{children}</ol>,
@@ -182,13 +191,14 @@ function sanitizeText(text) {
 // Cache both variants to avoid recreating components on every render
 // Default (unscaled) components for module-level fallback
 const mdComponentsStatic = makeMdComponents(false);
-const scaledMdStreaming = makeMdComponents(true);
 
 export default function Message({ msg, onEdit, onAnswer }) {
   const s = useFontScale();
   const scaledMdStatic = useMemo(() => makeMdComponents(false, s), [s]);
   const scaledMdStreaming = useMemo(() => makeMdComponents(true, s), [s]);
   const isUser = msg.role === "user";
+  const isSystem = msg.role === "system";
+  const isShellCommand = msg.mode === "shell-command";
   const hasThinkingPart = Boolean(msg.parts?.some((part) => part.type === "thinking"));
   const activeThinkingByStreamKey = msg._streamState?.activeThinking || {};
 
@@ -250,7 +260,7 @@ export default function Message({ msg, onEdit, onAnswer }) {
           letterSpacing: ".14em",
           marginBottom: 10,
         }}>
-          YOU
+          {isShellCommand ? "SHELL" : "YOU"}
         </div>
 
         {editing ? (
@@ -336,19 +346,49 @@ export default function Message({ msg, onEdit, onAnswer }) {
           </div>
         )}
 
-            <div style={{
-              color: "rgba(255,255,255,0.92)",
-              fontSize: s(15),
-              lineHeight: 1.7,
-              fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
-              fontWeight: 400,
-              textAlign: "left",
-              maxWidth: "85%",
-            }}>
-              <Markdown remarkPlugins={[remarkGfm]} components={scaledMdStatic}>
-                {displayText}
-              </Markdown>
-            </div>
+            {isShellCommand ? (
+              <div
+                style={{
+                  width: "100%",
+                  display: "flex",
+                  justifyContent: "flex-end",
+                }}
+              >
+                <div
+                  style={{
+                    width: "100%",
+                    maxWidth: "85%",
+                    padding: "10px 12px",
+                    borderRadius: 12,
+                    border: "1px solid rgba(255,255,255,0.08)",
+                    background: "linear-gradient(135deg, rgba(255,255,255,0.07), rgba(255,255,255,0.02))",
+                    color: "rgba(255,255,255,0.85)",
+                    fontSize: s(12),
+                    lineHeight: 1.6,
+                    fontFamily: "'JetBrains Mono',monospace",
+                    whiteSpace: "pre-wrap",
+                    overflowWrap: "anywhere",
+                  }}
+                >
+                  <span style={{ color: "rgba(255,255,255,0.5)" }}>$ </span>
+                  {displayText}
+                </div>
+              </div>
+            ) : (
+              <div style={{
+                color: "rgba(255,255,255,0.92)",
+                fontSize: s(15),
+                lineHeight: 1.7,
+                fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
+                fontWeight: 400,
+                textAlign: "left",
+                maxWidth: "85%",
+              }}>
+                <Markdown remarkPlugins={[remarkGfm]} components={scaledMdStatic}>
+                  {displayText}
+                </Markdown>
+              </div>
+            )}
           </>
         )}
 
@@ -360,6 +400,61 @@ export default function Message({ msg, onEdit, onAnswer }) {
             )}
           </div>
         )}
+      </div>
+    );
+  }
+
+  if (isSystem) {
+    return (
+      <div
+        style={{
+          marginBottom: 28,
+          animation: "msgIn .4s cubic-bezier(.16,1,.3,1)",
+          textAlign: "left",
+        }}
+      >
+        <div
+          style={{
+            maxWidth: "88%",
+            padding: "14px 16px 12px",
+            borderRadius: 14,
+            border: "1px solid rgba(255,255,255,0.08)",
+            background: "linear-gradient(180deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02))",
+            boxShadow: "0 20px 40px rgba(0,0,0,0.18)",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              marginBottom: 10,
+              fontSize: s(9),
+              fontFamily: "'JetBrains Mono',monospace",
+              color: "rgba(255,255,255,0.4)",
+              letterSpacing: ".14em",
+            }}
+          >
+            <Terminal size={12} strokeWidth={1.7} />
+            OUTPUT
+          </div>
+          <div
+            style={{
+              color: "rgba(255,255,255,0.82)",
+              fontSize: s(14),
+              lineHeight: 1.75,
+              fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
+              letterSpacing: "0.006em",
+            }}
+          >
+            <Markdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]} components={scaledMdStatic}>
+              {sanitizeText(displayText)}
+            </Markdown>
+          </div>
+        </div>
+        <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
+          <CopyBtn text={displayText} />
+        </div>
       </div>
     );
   }

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -366,6 +366,27 @@ export default function useAgent() {
     return pendingId;
   }, []);
 
+  const appendLocalMessages = useCallback((conversationId, messages) => {
+    if (!conversationId || !Array.isArray(messages) || messages.length === 0) return;
+
+    setConversations((prev) => {
+      const next = new Map(prev);
+      const convo = next.get(conversationId) || { messages: [], isStreaming: false, error: null };
+      const appended = messages.map((message) => ({
+        id: message.id || uid(),
+        ...message,
+      }));
+
+      next.set(conversationId, {
+        ...convo,
+        messages: [...convo.messages, ...appended],
+        isStreaming: false,
+        error: null,
+      });
+      return next;
+    });
+  }, []);
+
   const startPreparedMessage = useCallback(({ conversationId, pendingId, sessionId, prompt, model, provider, effort, cwd, images, files, resumeSessionId, forkSession }) => {
     const expectedPendingId = pendingStartsRef.current.get(conversationId);
     if (pendingId && expectedPendingId !== pendingId) {
@@ -447,6 +468,7 @@ export default function useAgent() {
     conversations,
     getConversation,
     prepareMessage,
+    appendLocalMessages,
     startPreparedMessage,
     cancelMessage,
     editAndResend,


### PR DESCRIPTION
## Summary
- execute -prefixed chat input locally through Electron instead of forwarding the raw command
- include stdout, stderr, exit code, timeout, and truncation details in the chat transcript so the agent sees the command result
- preserve the original  as the conversation title while keeping normal chat sends unchanged

## Verification
- 
> ensue@0.1.1 build
> vite build

vite v8.0.8 building client environment for production...
[2Ktransforming...✓ 4445 modules transformed.
rendering chunks...
computing gzip size...
dist/src/project-manager.html                           0.63 kB │ gzip:   0.36 kB
dist/index.html                                         2.33 kB │ gzip:   0.69 kB
dist/assets/KaTeX_Size3-Regular-CTq5MqoE.woff           4.42 kB
dist/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2          4.92 kB
dist/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2          5.20 kB
dist/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2          5.46 kB
dist/assets/KaTeX_Size4-Regular-BF-4gkZK.woff           5.98 kB
dist/assets/KaTeX_Size2-Regular-oD1tc_U0.woff           6.18 kB
dist/assets/KaTeX_Size1-Regular-C195tn64.woff           6.49 kB
dist/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2    6.90 kB
dist/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2       6.91 kB
dist/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf            7.58 kB
dist/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff     7.65 kB
dist/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff        7.71 kB
dist/assets/KaTeX_Script-Regular-D3wIWfF6.woff2         9.64 kB
dist/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2     10.34 kB
dist/assets/KaTeX_Size4-Regular-DWFBv043.ttf           10.36 kB
dist/assets/KaTeX_Script-Regular-D5yQViql.woff         10.58 kB
dist/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2       11.31 kB
dist/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2          11.34 kB
dist/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf           11.50 kB
dist/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2      12.02 kB
dist/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2        12.21 kB
dist/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf           12.22 kB
dist/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff      12.31 kB
dist/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf     12.34 kB
dist/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf        12.36 kB
dist/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff        13.20 kB
dist/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff           13.29 kB
dist/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2    13.56 kB
dist/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff       14.11 kB
dist/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff         14.40 kB
dist/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff     16.02 kB
dist/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2       16.40 kB
dist/assets/KaTeX_Math-Italic-t53AETM-.woff2           16.44 kB
dist/assets/KaTeX_Script-Regular-C5JkGWo-.ttf          16.64 kB
dist/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2       16.78 kB
dist/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2           16.98 kB
dist/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff        18.66 kB
dist/assets/KaTeX_Math-Italic-DA0__PXp.woff            18.74 kB
dist/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff        19.41 kB
dist/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf       19.43 kB
dist/assets/KaTeX_Fraktur-Regular-CB_wures.ttf         19.57 kB
dist/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf            19.58 kB
dist/assets/KaTeX_Main-Italic-BMLOBm91.woff            19.67 kB
dist/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf        22.36 kB
dist/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf          24.50 kB
dist/assets/KaTeX_Main-Bold-Cx986IdX.woff2             25.32 kB
dist/assets/KaTeX_Main-Regular-B22Nviop.woff2          26.27 kB
dist/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf      27.55 kB
dist/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2           28.07 kB
dist/assets/KaTeX_Main-Bold-Jm3AIy58.woff              29.91 kB
dist/assets/KaTeX_Main-Regular-Dr94JaBh.woff           30.77 kB
dist/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf         31.19 kB
dist/assets/KaTeX_Math-Italic-flOr_0UB.ttf             31.30 kB
dist/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf         32.96 kB
dist/assets/KaTeX_AMS-Regular-DMm9YOAa.woff            33.51 kB
dist/assets/KaTeX_Main-Italic-3WenGoN9.ttf             33.58 kB
dist/assets/KaTeX_Main-Bold-waoOVXN0.ttf               51.33 kB
dist/assets/KaTeX_Main-Regular-ypZvNtVU.ttf            53.58 kB
dist/assets/KaTeX_AMS-Regular-DRggAlZN.ttf             63.63 kB
dist/assets/pm-DcxYqYzT.css                             1.24 kB │ gzip:   0.53 kB
dist/assets/xterm-BrP-ENHg.css                          3.93 kB │ gzip:   1.01 kB
dist/assets/main-DYcTsG7j.css                          30.18 kB │ gzip:   8.57 kB
dist/assets/clone-Bsf-WcO0.js                           0.09 kB │ gzip:   0.10 kB
dist/assets/array-CwG8vNfn.js                           0.10 kB │ gzip:   0.11 kB
dist/assets/channel-BEXjJoNl.js                         0.11 kB │ gzip:   0.12 kB
dist/assets/pie-ZZUOXDRM-X9A9fgcG.js                    0.11 kB │ gzip:   0.11 kB
dist/assets/info-OMHHGYJF-BeyhF35-.js                   0.11 kB │ gzip:   0.11 kB
dist/assets/radar-PYXPWWZC-BTtLm4yg.js                  0.11 kB │ gzip:   0.12 kB
dist/assets/packet-4T2RLAQJ-Cf7xTqhc.js                 0.12 kB │ gzip:   0.12 kB
dist/assets/treemap-W4RFUUIX-BExxkfAW.js                0.12 kB │ gzip:   0.12 kB
dist/assets/wardley-RL74JXVD-BKFks_Mv.js                0.12 kB │ gzip:   0.12 kB
dist/assets/gitGraph-7Q5UKJZL-ClewUpkS.js               0.12 kB │ gzip:   0.12 kB
dist/assets/treeView-SZITEDCU-0tFmE5jO.js               0.12 kB │ gzip:   0.12 kB
dist/assets/architecture-YZFGNWBL-W0D8PDWE.js           0.12 kB │ gzip:   0.12 kB
dist/assets/init-D6KNwrax.js                            0.14 kB │ gzip:   0.12 kB
dist/assets/chunk-QZHKN3VN-B-oOF4G1.js                  0.18 kB │ gzip:   0.15 kB
dist/assets/chunk-4BX2VUAB-CQ-Hn3Yz.js                  0.21 kB │ gzip:   0.16 kB
dist/assets/chunk-55IACEB6-qpBCIrUF.js                  0.22 kB │ gzip:   0.19 kB
dist/assets/chunk-426QAEUC-xL1Wagiy.js                  0.27 kB │ gzip:   0.23 kB
dist/assets/chunk-FMBD7UC4-D87WrHOT.js                  0.35 kB │ gzip:   0.26 kB
dist/assets/chunk-FOC6F5B3-b3MeCuh-.js                  0.45 kB │ gzip:   0.31 kB
dist/assets/chunk-2KRD3SAO-B8zfameq.js                  0.45 kB │ gzip:   0.31 kB
dist/assets/chunk-67CJDMHE-BVpGEhhI.js                  0.46 kB │ gzip:   0.31 kB
dist/assets/chunk-KGLVRYIC-BVQvYEqE.js                  0.46 kB │ gzip:   0.31 kB
dist/assets/chunk-CIAEETIT-BMldDXF_.js                  0.50 kB │ gzip:   0.35 kB
dist/assets/chunk-EDXVE4YY-Dvqe2URB.js                  0.53 kB │ gzip:   0.37 kB
dist/assets/flatten-B1JAduaA.js                         0.57 kB │ gzip:   0.34 kB
dist/assets/chunk-AA7GKIK3-BVdsXsvN.js                  0.60 kB │ gzip:   0.39 kB
dist/assets/infoDiagram-42DDH7IO-Cs_mcXZe.js            0.61 kB │ gzip:   0.40 kB
dist/assets/chunk-ORNJ4GCN-DA06lMwk.js                  0.65 kB │ gzip:   0.40 kB
dist/assets/stateDiagram-v2-QKLJ7IA2-CCu_ZhhG.js        0.67 kB │ gzip:   0.40 kB
dist/assets/classDiagram-6PBFFD2Q-CVStjZHq.js           0.74 kB │ gzip:   0.43 kB
dist/assets/classDiagram-v2-HSJHXN6E-B8EwRCAR.js        0.74 kB │ gzip:   0.43 kB
dist/assets/chunk-Be6NvmcD.js                           0.87 kB │ gzip:   0.48 kB
dist/assets/chunk-7N4EOEYR-Ca4UCot2.js                  0.90 kB │ gzip:   0.49 kB
dist/assets/line-BrFYpX_l.js                            0.94 kB │ gzip:   0.47 kB
dist/assets/chunk-ZZ45TVLE-CHRLnHAQ.js                  0.95 kB │ gzip:   0.58 kB
dist/assets/isEmpty-DmISAPZC.js                         1.16 kB │ gzip:   0.63 kB
dist/assets/ordinal-jM7S0YHN.js                         1.17 kB │ gzip:   0.56 kB
dist/assets/addon-fit-BoPZvRoj.js                       1.21 kB │ gzip:   0.50 kB
dist/assets/chunk-LIHQZDEY-CFLm6K8v.js                  1.46 kB │ gzip:   0.78 kB
dist/assets/chunk-X2U36JSP-7xFFDCqi.js                  1.83 kB │ gzip:   0.90 kB
dist/assets/chunk-YZCP3GAM-D88KWupT.js                  1.93 kB │ gzip:   0.87 kB
dist/assets/chunk-BSJP7CBP-BqWTcSBS.js                  2.09 kB │ gzip:   0.81 kB
dist/assets/dist-D3-ALJMI.js                            2.16 kB │ gzip:   0.97 kB
dist/assets/path-DNPd7Py7.js                            2.31 kB │ gzip:   0.99 kB
dist/assets/diagram-5BDNPKRD-D8EsicLo.js                2.78 kB │ gzip:   1.34 kB
dist/assets/chunk-336JU56O-CPMsbKmI.js                  3.26 kB │ gzip:   1.47 kB
dist/assets/arc-CHPGULe1.js                             3.47 kB │ gzip:   1.46 kB
dist/assets/diagram-TYMM5635-CZJDX0Ex.js                4.24 kB │ gzip:   1.83 kB
dist/assets/mermaid-parser.core-DC9W_aj-.js             4.55 kB │ gzip:   1.44 kB
dist/assets/defaultLocale-Dda4OpKy.js                   4.64 kB │ gzip:   2.12 kB
dist/assets/pieDiagram-DEJITSTG-WOjND7bZ.js             5.22 kB │ gzip:   2.27 kB
dist/assets/linear-CWYc8Ar7.js                          5.52 kB │ gzip:   2.25 kB
dist/assets/diagram-MMDJMWI5-OFPv8yo2.js                5.77 kB │ gzip:   2.39 kB
dist/assets/identity-dm669Xw2.js                        7.51 kB │ gzip:   2.82 kB
dist/assets/reduce-D_9krJHY.js                          8.59 kB │ gzip:   3.57 kB
dist/assets/graphlib-2SWo6eMa.js                        9.36 kB │ gzip:   3.18 kB
dist/assets/stateDiagram-FHFEXIEX-C1dtNzG2.js          10.52 kB │ gzip:   3.66 kB
dist/assets/dagre-KV5264BT-DPzWQcLx.js                 11.07 kB │ gzip:   4.13 kB
dist/assets/diagram-G4DWMVQ6-DGKKZGdj.js               15.51 kB │ gzip:   5.42 kB
dist/assets/ishikawaDiagram-UXIWVN3A-ltcdXsOp.js       17.30 kB │ gzip:   6.51 kB
dist/assets/kanban-definition-6JOO6SKY-Qfvgsvu4.js     20.22 kB │ gzip:   7.15 kB
dist/assets/sankeyDiagram-XADWPNL6-ChmNM0S1.js         21.69 kB │ gzip:   7.83 kB
dist/assets/journeyDiagram-VCZTEJTY-D-ny4buG.js        23.16 kB │ gzip:   8.13 kB
dist/assets/mindmap-definition-QFDTVHPH-BYgan57-.js    23.65 kB │ gzip:   8.07 kB
dist/assets/wardleyDiagram-NUSXRM2D-BTc0uvO7.js        23.87 kB │ gzip:   6.29 kB
dist/assets/erDiagram-SMLLAGMA-B_3hRh0i.js             26.80 kB │ gzip:   9.33 kB
dist/assets/rough.esm-CmtQZpzn.js                      27.10 kB │ gzip:   8.85 kB
dist/assets/chunk-5PVQY5BW-BO8BXttC.js                 28.17 kB │ gzip:   8.11 kB
dist/assets/gitGraphDiagram-UUTBAWPF-Db1ZBN8A.js       28.96 kB │ gzip:   8.51 kB
dist/assets/timeline-definition-GMOUNBTQ-DpPH9wQC.js   30.39 kB │ gzip:   9.94 kB
dist/assets/dagre-Ca-y5s2m.js                          30.42 kB │ gzip:  10.94 kB
dist/assets/requirementDiagram-MS252O5E-B46YGNf9.js    30.95 kB │ gzip:   9.75 kB
dist/assets/quadrantDiagram-34T5L4WZ-C_5VPRka.js       33.34 kB │ gzip:   9.71 kB
dist/assets/chunk-ENJZ2VHE-HND5ufiY.js                 33.40 kB │ gzip:   7.06 kB
dist/assets/chunk-OYMX7WX6--mtx-PA6.js                 36.58 kB │ gzip:  11.79 kB
dist/assets/xychartDiagram-5P7HB3ND-Bzt05esp.js        40.04 kB │ gzip:  11.20 kB
dist/assets/vennDiagram-DHZGUBPP-Bc3i87FB.js           40.62 kB │ gzip:  14.89 kB
dist/assets/chunk-XPW4576I-DTzc2Ru4.js                 41.85 kB │ gzip:  14.22 kB
dist/assets/pm-s1dTTh5S.js                             45.06 kB │ gzip:   9.90 kB
dist/assets/src-COhTm8Vn.js                            45.80 kB │ gzip:  16.04 kB
dist/assets/chunk-4TB4RGXK-DwB3cXMg.js                 46.88 kB │ gzip:  15.12 kB
dist/assets/chunk-U2HBQHQK-DvoF36kp.js                 52.52 kB │ gzip:  17.15 kB
dist/assets/flowDiagram-DWJPFMVM-CzWiqpn2.js           60.23 kB │ gzip:  19.51 kB
dist/assets/ganttDiagram-T4ZO3ILL-BPGA3Pn4.js          69.13 kB │ gzip:  22.61 kB
dist/assets/c4Diagram-AHTNJAMY-oUhqa5QX.js             69.16 kB │ gzip:  19.33 kB
dist/assets/blockDiagram-DXYQGD6D-BDf2t05C.js          69.86 kB │ gzip:  19.56 kB
dist/assets/cose-bilkent-S5V4N54A-DjBhWtqN.js          81.39 kB │ gzip:  21.56 kB
dist/assets/chunk-5FUZZQ4R-DwkRH3p6.js                 97.91 kB │ gzip:  23.41 kB
dist/assets/sequenceDiagram-FGHM5R23-BOEXc4co.js      115.51 kB │ gzip:  30.41 kB
dist/assets/architectureDiagram-Q4EWVU46-CEaYRWuw.js  146.77 kB │ gzip:  40.23 kB
dist/assets/chunk-ICPOFSXX-wrbkz_-N.js                216.05 kB │ gzip:  34.31 kB
dist/assets/katex-WguvS412.js                         257.04 kB │ gzip:  76.96 kB
dist/assets/xterm-DLqvPZgD.js                         340.34 kB │ gzip:  86.29 kB
dist/assets/lib-B_KCWner.js                           348.44 kB │ gzip: 107.22 kB
dist/assets/cytoscape.esm-C-8uvfDg.js                 434.14 kB │ gzip: 137.50 kB
dist/assets/chunk-K5T4RW27-D9KtxImF.js                474.01 kB │ gzip: 102.19 kB
dist/assets/main-C8T_YEP2.js                          989.50 kB │ gzip: 329.30 kB

✓ built in 1.40s
- 
> ensue@0.1.1 lint
> eslint .


/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/chat.jsx
  69:21  error  'dots' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/App.jsx
  145:24  error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  143 |   // Load state from file on mount
  144 |   useEffect(() => {
> 145 |     if (!window.api) { setStateLoaded(true); return; }
      |                        ^^^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  146 |     window.api.loadState().then((state) => {
  147 |       if (state) {
  148 |         if (state.convos) {                                     react-hooks/set-state-in-effect
  191:9   warning  The 'activeData' conditional could make the dependencies of useCallback Hook (at line 495) change on every render. To fix this, wrap the initialization of 'activeData' in its own useMemo() Hook                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 react-hooks/exhaustive-deps
  231:17  error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  229 |   useEffect(() => {
  230 |     if (!stateLoaded) return;
> 231 |     if (active) handleSelect(active);
      |                 ^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  232 |   }, [stateLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
  233 |
  234 |   // Load previews for conversations missing them (runs after state load)              react-hooks/set-state-in-effect
  256:17  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             no-empty
  319:9   error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  317 |       const convo = convoList.find(c => c.id === active);
  318 |       if (convo && convo.sessionId !== data._codexThreadId) {
> 319 |         setConvoList((p) =>
      |         ^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  320 |           p.map((c) => c.id === active ? { ...c, sessionId: data._codexThreadId } : c)
  321 |         );
  322 |       }  react-hooks/set-state-in-effect
  324:6   warning  React Hook useEffect has missing dependencies: 'convoList' and 'getConversation'. Either include them or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              react-hooks/exhaustive-deps
  650:9   error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  648 |       const preview = msgText.slice(0, 60);
  649 |       if (preview) {
> 650 |         setConvoList((p) =>
      |         ^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  651 |           p.map((c) => c.id === active ? { ...c, lastPreview: preview } : c)
  652 |         );
  653 |       }                                                                   react-hooks/set-state-in-effect
  655:6   warning  React Hook useEffect has a missing dependency: 'activeData.messages'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/ProjectManager.jsx
  163:6  warning  React Hook useEffect has a missing dependency: 'stateLoaded'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/ChatArea.jsx
   67:6   warning  React Hook useCallback has unnecessary dependencies: 'convo' and 'isStreaming'. Either exclude them or remove the dependency array  react-hooks/exhaustive-deps
  148:10  error    'dragOver' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u                                            no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/InteractiveBlock.jsx
  7:9   error  'iframeRef' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars
  8:10  error  'height' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u     no-unused-vars
  8:18  error  'setHeight' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars
  9:10  error  'loaded' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u     no-unused-vars
  9:18  error  'setLoaded' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/MermaidBlock.jsx
  134:61  error    Empty block statement                                                                                                         no-empty
  139:6   warning  React Hook useEffect has a missing dependency: 'svg'. Either include it or remove the dependency array                        react-hooks/exhaustive-deps
  161:3   error    React Hook "useEffect" is called conditionally. React Hooks must be called in the exact same order in every component render  react-hooks/rules-of-hooks

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/Message.jsx
  185:7  error  'scaledMdStreaming' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/SelectionToolbar.jsx
  8:9  error  's' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/Settings.jsx
  14:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  12 |   // Sync from parent when wallpaper prop changes externally
  13 |   useEffect(() => {
> 14 |     setLocal(wallpaper ?? { ...DEFAULTS });
     |     ^^^^^^^^ Avoid calling setState() directly within an effect
  15 |   }, [wallpaper]);
  16 |
  17 |   // Load data URL when path is set but dataUrl is missing (e.g. after app restart)  react-hooks/set-state-in-effect

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/ThinkingBlock.jsx
  9:28  error  Error: Cannot call impure function during render

`Date.now` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).

   7 |   const s = useFontScale();
   8 |   const hasText = Boolean(text && text.trim().length > 0);
>  9 |   const startTime = useRef(Date.now());
     |                            ^^^^^^^^^^ Cannot call impure function
  10 |   const [elapsed, setElapsed] = useState(0);
  11 |
  12 |   // Track thinking duration  react-hooks/purity

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/components/ToolCallBlock.jsx
  36:34  error  Unnecessary escape character: \/  no-useless-escape
  36:42  error  Unnecessary escape character: \/  no-useless-escape

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/hooks/useAgent.js
  135:62  error  Empty block statement  no-empty

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/pm-components/CommentBox.jsx
  14:13  error  Empty block statement  no-empty

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/pm-components/CreateForm.jsx
  59:6  warning  React Hook useEffect has a missing dependency: 'head'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/pm-components/IssueList.jsx
  68:17  error    Empty block statement                                                                                           no-empty
  72:6   warning  React Hook useEffect has a missing dependency: 'fetchIssues'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/pm-components/ItemDetail.jsx
  130:5   error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  128 |
  129 |   useEffect(() => {
> 130 |     fetchAll();
      |     ^^^^^^^^ Avoid calling setState() directly within an effect
  131 |     const interval = setInterval(async () => {
  132 |       try {
  133 |         const fetchItem = type === "pr"  react-hooks/set-state-in-effect
  142:15  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  145:6   warning  React Hook useEffect has a missing dependency: 'fetchAll'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        react-hooks/exhaustive-deps
  166:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  175:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  185:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  193:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/pm-components/PRList.jsx
  66:17  error    Empty block statement                                                                                        no-empty
  70:6   warning  React Hook useEffect has a missing dependency: 'fetchPRs'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/pm-components/RepoManager.jsx
  26:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  24 |
  25 |   useEffect(() => {
> 26 |     fetchRepos();
     |     ^^^^^^^^^^ Avoid calling setState() directly within an effect
  27 |   }, []);
  28 |
  29 |   const filtered = userRepos.filter((r) =>  react-hooks/set-state-in-effect

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/src/pm-components/SearchableSelect.jsx
  40:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  38 |   // Reset highlight when filtered list changes
  39 |   useEffect(() => {
> 40 |     setHighlightIdx(0);
     |     ^^^^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  41 |   }, [filtered.length]);
  42 |
  43 |   // Scroll highlighted item into view  react-hooks/set-state-in-effect

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/81672b2d/workdir/Ensue-Chat/vite.config.js
  12:23  error  '__dirname' is not defined  no-undef
  13:21  error  '__dirname' is not defined  no-undef

✖ 44 problems (34 errors, 10 warnings) *(fails on pre-existing repo-wide lint issues unrelated to this change)*

Closes #60