### PR TITLE
fix: preserve chat history when sending from restored conversations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -913,10 +913,17 @@ export default function App() {
         : (convoCwd !== undefined ? (convoCwd || undefined) : (cwd || undefined));
       const thisConvoData = getConversation(conversationId);
       const normalizedConversation = normalizeConversationState(conversation);
+      const persistedMessages = Array.isArray(normalizedConversation.archivedMessages)
+        ? normalizedConversation.archivedMessages
+        : [];
+      const availableMessages =
+        thisConvoData.messages.length > 0
+          ? thisConvoData.messages
+          : persistedMessages;
       const activeSession = getActiveConversationSession(normalizedConversation);
-      const isFirstMessage = thisConvoData.messages.length === 0;
-      const messageIndex = thisConvoData.messages.length;
-      const syncedMessageCount = thisConvoData.messages.length;
+      const isFirstMessage = availableMessages.length === 0;
+      const messageIndex = availableMessages.length;
+      const syncedMessageCount = availableMessages.length;
       const images = attachments?.filter((a) => a.type === "image").map((a) => a.dataUrl);
       const files = attachments?.filter((a) => a.type === "file");
       const m = getM(normalizedConversation.model);
@@ -965,9 +972,9 @@ export default function App() {
           ? seededSession?.nativeSessionId || undefined
           : undefined;
       const prime = providerSwitched
-        ? buildCrossProviderPrime(thisConvoData.messages)
+        ? buildCrossProviderPrime(availableMessages)
         : needsHistoryPrimeFallback
-          ? buildConversationPrime(thisConvoData.messages)
+          ? buildConversationPrime(availableMessages)
           : null;
       const wirePrompt = prime ? decoratePromptWithPrime(text, prime) : text;
       const sendStartedAt = Date.now();
@@ -1000,6 +1007,7 @@ export default function App() {
       const pendingId = prepareMessage({
         conversationId,
         prompt: text,
+        existingMessages: availableMessages,
         images: images?.length ? images : undefined,
         files: files?.length ? files : undefined,
       });

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -363,14 +363,18 @@ export default function useAgent() {
     return () => cleanupRefs.current.forEach((fn) => fn?.());
   }, []);
 
-  const prepareMessage = useCallback(({ conversationId, prompt, images, files }) => {
+  const prepareMessage = useCallback(({ conversationId, prompt, images, files, existingMessages }) => {
     const pendingId = uid();
     pendingStartsRef.current.set(conversationId, pendingId);
     setConversations((prev) => {
       const next = new Map(prev);
       const convo = next.get(conversationId) || { messages: [], isStreaming: false, error: null };
+      const baseMessages =
+        convo.messages.length > 0
+          ? convo.messages
+          : (Array.isArray(existingMessages) ? existingMessages : []);
       const msgs = [
-        ...convo.messages,
+        ...baseMessages,
         { id: uid(), role: "user", text: prompt, images, files },
         { id: uid(), role: "assistant", parts: [], isStreaming: true, isThinking: false },
       ];


### PR DESCRIPTION
## Summary
- fall back to archived conversation messages when the live in-memory buffer has not been loaded yet
- seed the renderer conversation state with that archived history before appending the new user turn
- use the same recovered history when deciding whether to resume an existing session or prime a fresh one

Closes #68

## Verification
- 
> ensue@0.1.1 build
> vite build

vite v8.0.8 building client environment for production...
[2Ktransforming...✓ 4446 modules transformed.
rendering chunks...
computing gzip size...
dist/src/project-manager.html                             0.63 kB │ gzip:   0.36 kB
dist/index.html                                           2.33 kB │ gzip:   0.69 kB
dist/assets/KaTeX_Size3-Regular-CTq5MqoE.woff             4.42 kB
dist/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2            4.92 kB
dist/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2            5.20 kB
dist/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2            5.46 kB
dist/assets/KaTeX_Size4-Regular-BF-4gkZK.woff             5.98 kB
dist/assets/KaTeX_Size2-Regular-oD1tc_U0.woff             6.18 kB
dist/assets/KaTeX_Size1-Regular-C195tn64.woff             6.49 kB
dist/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2      6.90 kB
dist/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2         6.91 kB
dist/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf              7.58 kB
dist/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff       7.65 kB
dist/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff          7.71 kB
dist/assets/KaTeX_Script-Regular-D3wIWfF6.woff2           9.64 kB
dist/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2       10.34 kB
dist/assets/KaTeX_Size4-Regular-DWFBv043.ttf             10.36 kB
dist/assets/KaTeX_Script-Regular-D5yQViql.woff           10.58 kB
dist/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2         11.31 kB
dist/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2            11.34 kB
dist/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf             11.50 kB
dist/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2        12.02 kB
dist/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2          12.21 kB
dist/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf             12.22 kB
dist/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff        12.31 kB
dist/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf       12.34 kB
dist/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf          12.36 kB
dist/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff          13.20 kB
dist/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff             13.29 kB
dist/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2      13.56 kB
dist/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff         14.11 kB
dist/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff           14.40 kB
dist/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff       16.02 kB
dist/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2         16.40 kB
dist/assets/KaTeX_Math-Italic-t53AETM-.woff2             16.44 kB
dist/assets/KaTeX_Script-Regular-C5JkGWo-.ttf            16.64 kB
dist/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2         16.78 kB
dist/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2             16.98 kB
dist/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff          18.66 kB
dist/assets/KaTeX_Math-Italic-DA0__PXp.woff              18.74 kB
dist/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff          19.41 kB
dist/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf         19.43 kB
dist/assets/KaTeX_Fraktur-Regular-CB_wures.ttf           19.57 kB
dist/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf              19.58 kB
dist/assets/KaTeX_Main-Italic-BMLOBm91.woff              19.67 kB
dist/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf          22.36 kB
dist/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf            24.50 kB
dist/assets/KaTeX_Main-Bold-Cx986IdX.woff2               25.32 kB
dist/assets/KaTeX_Main-Regular-B22Nviop.woff2            26.27 kB
dist/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf        27.55 kB
dist/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2             28.07 kB
dist/assets/KaTeX_Main-Bold-Jm3AIy58.woff                29.91 kB
dist/assets/KaTeX_Main-Regular-Dr94JaBh.woff             30.77 kB
dist/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf           31.19 kB
dist/assets/KaTeX_Math-Italic-flOr_0UB.ttf               31.30 kB
dist/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf           32.96 kB
dist/assets/KaTeX_AMS-Regular-DMm9YOAa.woff              33.51 kB
dist/assets/KaTeX_Main-Italic-3WenGoN9.ttf               33.58 kB
dist/assets/KaTeX_Main-Bold-waoOVXN0.ttf                 51.33 kB
dist/assets/KaTeX_Main-Regular-ypZvNtVU.ttf              53.58 kB
dist/assets/KaTeX_AMS-Regular-DRggAlZN.ttf               63.63 kB
dist/assets/pm-DcxYqYzT.css                               1.24 kB │ gzip:   0.53 kB
dist/assets/xterm-BrP-ENHg.css                            3.93 kB │ gzip:   1.01 kB
dist/assets/main-DYcTsG7j.css                            30.18 kB │ gzip:   8.57 kB
dist/assets/clone-Bsf-WcO0.js                             0.09 kB │ gzip:   0.10 kB
dist/assets/array-CwG8vNfn.js                             0.10 kB │ gzip:   0.11 kB
dist/assets/channel-BEXjJoNl.js                           0.11 kB │ gzip:   0.12 kB
dist/assets/pie-ZZUOXDRM-X9A9fgcG.js                      0.11 kB │ gzip:   0.11 kB
dist/assets/info-OMHHGYJF-BeyhF35-.js                     0.11 kB │ gzip:   0.11 kB
dist/assets/radar-PYXPWWZC-BTtLm4yg.js                    0.11 kB │ gzip:   0.12 kB
dist/assets/packet-4T2RLAQJ-Cf7xTqhc.js                   0.12 kB │ gzip:   0.12 kB
dist/assets/treemap-W4RFUUIX-BExxkfAW.js                  0.12 kB │ gzip:   0.12 kB
dist/assets/wardley-RL74JXVD-BKFks_Mv.js                  0.12 kB │ gzip:   0.12 kB
dist/assets/gitGraph-7Q5UKJZL-ClewUpkS.js                 0.12 kB │ gzip:   0.12 kB
dist/assets/treeView-SZITEDCU-0tFmE5jO.js                 0.12 kB │ gzip:   0.12 kB
dist/assets/architecture-YZFGNWBL-W0D8PDWE.js             0.12 kB │ gzip:   0.12 kB
dist/assets/init-D6KNwrax.js                              0.14 kB │ gzip:   0.12 kB
dist/assets/chunk-QZHKN3VN-B-oOF4G1.js                    0.18 kB │ gzip:   0.15 kB
dist/assets/chunk-4BX2VUAB-CQ-Hn3Yz.js                    0.21 kB │ gzip:   0.16 kB
dist/assets/chunk-55IACEB6-qpBCIrUF.js                    0.22 kB │ gzip:   0.19 kB
dist/assets/chunk-426QAEUC-xL1Wagiy.js                    0.27 kB │ gzip:   0.23 kB
dist/assets/chunk-FMBD7UC4-D87WrHOT.js                    0.35 kB │ gzip:   0.26 kB
dist/assets/chunk-FOC6F5B3-b3MeCuh-.js                    0.45 kB │ gzip:   0.31 kB
dist/assets/chunk-2KRD3SAO-B8zfameq.js                    0.45 kB │ gzip:   0.31 kB
dist/assets/chunk-67CJDMHE-BVpGEhhI.js                    0.46 kB │ gzip:   0.31 kB
dist/assets/chunk-KGLVRYIC-BVQvYEqE.js                    0.46 kB │ gzip:   0.31 kB
dist/assets/chunk-CIAEETIT-BMldDXF_.js                    0.50 kB │ gzip:   0.35 kB
dist/assets/chunk-EDXVE4YY-Dvqe2URB.js                    0.53 kB │ gzip:   0.37 kB
dist/assets/flatten-B1JAduaA.js                           0.57 kB │ gzip:   0.34 kB
dist/assets/chunk-AA7GKIK3-BVdsXsvN.js                    0.60 kB │ gzip:   0.39 kB
dist/assets/infoDiagram-42DDH7IO-Cs_mcXZe.js              0.61 kB │ gzip:   0.40 kB
dist/assets/chunk-ORNJ4GCN-DA06lMwk.js                    0.65 kB │ gzip:   0.40 kB
dist/assets/stateDiagram-v2-QKLJ7IA2-CCu_ZhhG.js          0.67 kB │ gzip:   0.40 kB
dist/assets/classDiagram-6PBFFD2Q-CVStjZHq.js             0.74 kB │ gzip:   0.43 kB
dist/assets/classDiagram-v2-HSJHXN6E-B8EwRCAR.js          0.74 kB │ gzip:   0.43 kB
dist/assets/chunk-Be6NvmcD.js                             0.87 kB │ gzip:   0.48 kB
dist/assets/chunk-7N4EOEYR-Ca4UCot2.js                    0.90 kB │ gzip:   0.49 kB
dist/assets/line-BrFYpX_l.js                              0.94 kB │ gzip:   0.47 kB
dist/assets/chunk-ZZ45TVLE-CHRLnHAQ.js                    0.95 kB │ gzip:   0.58 kB
dist/assets/isEmpty-DmISAPZC.js                           1.16 kB │ gzip:   0.63 kB
dist/assets/ordinal-jM7S0YHN.js                           1.17 kB │ gzip:   0.56 kB
dist/assets/addon-fit-BoPZvRoj.js                         1.21 kB │ gzip:   0.50 kB
dist/assets/chunk-LIHQZDEY-CFLm6K8v.js                    1.46 kB │ gzip:   0.78 kB
dist/assets/chunk-X2U36JSP-7xFFDCqi.js                    1.83 kB │ gzip:   0.90 kB
dist/assets/chunk-YZCP3GAM-D88KWupT.js                    1.93 kB │ gzip:   0.87 kB
dist/assets/chunk-BSJP7CBP-BqWTcSBS.js                    2.09 kB │ gzip:   0.81 kB
dist/assets/dist-D3-ALJMI.js                              2.16 kB │ gzip:   0.97 kB
dist/assets/path-DNPd7Py7.js                              2.31 kB │ gzip:   0.99 kB
dist/assets/diagram-5BDNPKRD-D8EsicLo.js                  2.78 kB │ gzip:   1.34 kB
dist/assets/chunk-336JU56O-CPMsbKmI.js                    3.26 kB │ gzip:   1.47 kB
dist/assets/arc-CHPGULe1.js                               3.47 kB │ gzip:   1.46 kB
dist/assets/diagram-TYMM5635-CZJDX0Ex.js                  4.24 kB │ gzip:   1.83 kB
dist/assets/mermaid-parser.core-DC9W_aj-.js               4.55 kB │ gzip:   1.44 kB
dist/assets/defaultLocale-Dda4OpKy.js                     4.64 kB │ gzip:   2.12 kB
dist/assets/pieDiagram-DEJITSTG-WOjND7bZ.js               5.22 kB │ gzip:   2.27 kB
dist/assets/linear-CWYc8Ar7.js                            5.52 kB │ gzip:   2.25 kB
dist/assets/diagram-MMDJMWI5-OFPv8yo2.js                  5.77 kB │ gzip:   2.39 kB
dist/assets/identity-dm669Xw2.js                          7.51 kB │ gzip:   2.82 kB
dist/assets/reduce-D_9krJHY.js                            8.59 kB │ gzip:   3.57 kB
dist/assets/graphlib-2SWo6eMa.js                          9.36 kB │ gzip:   3.18 kB
dist/assets/stateDiagram-FHFEXIEX-C1dtNzG2.js            10.52 kB │ gzip:   3.66 kB
dist/assets/dagre-KV5264BT-DPzWQcLx.js                   11.07 kB │ gzip:   4.13 kB
dist/assets/diagram-G4DWMVQ6-DGKKZGdj.js                 15.51 kB │ gzip:   5.42 kB
dist/assets/ishikawaDiagram-UXIWVN3A-ltcdXsOp.js         17.30 kB │ gzip:   6.51 kB
dist/assets/kanban-definition-6JOO6SKY-Qfvgsvu4.js       20.22 kB │ gzip:   7.15 kB
dist/assets/sankeyDiagram-XADWPNL6-ChmNM0S1.js           21.69 kB │ gzip:   7.83 kB
dist/assets/journeyDiagram-VCZTEJTY-D-ny4buG.js          23.16 kB │ gzip:   8.13 kB
dist/assets/mindmap-definition-QFDTVHPH-BYgan57-.js      23.65 kB │ gzip:   8.07 kB
dist/assets/wardleyDiagram-NUSXRM2D-BTc0uvO7.js          23.87 kB │ gzip:   6.29 kB
dist/assets/erDiagram-SMLLAGMA-B_3hRh0i.js               26.80 kB │ gzip:   9.33 kB
dist/assets/rough.esm-CmtQZpzn.js                        27.10 kB │ gzip:   8.85 kB
dist/assets/chunk-5PVQY5BW-BO8BXttC.js                   28.17 kB │ gzip:   8.11 kB
dist/assets/gitGraphDiagram-UUTBAWPF-Db1ZBN8A.js         28.96 kB │ gzip:   8.51 kB
dist/assets/timeline-definition-GMOUNBTQ-DpPH9wQC.js     30.39 kB │ gzip:   9.94 kB
dist/assets/dagre-Ca-y5s2m.js                            30.42 kB │ gzip:  10.94 kB
dist/assets/requirementDiagram-MS252O5E-B46YGNf9.js      30.95 kB │ gzip:   9.75 kB
dist/assets/quadrantDiagram-34T5L4WZ-C_5VPRka.js         33.34 kB │ gzip:   9.71 kB
dist/assets/chunk-ENJZ2VHE-HND5ufiY.js                   33.40 kB │ gzip:   7.06 kB
dist/assets/chunk-OYMX7WX6--mtx-PA6.js                   36.58 kB │ gzip:  11.79 kB
dist/assets/xychartDiagram-5P7HB3ND-Bzt05esp.js          40.04 kB │ gzip:  11.20 kB
dist/assets/vennDiagram-DHZGUBPP-Bc3i87FB.js             40.62 kB │ gzip:  14.89 kB
dist/assets/chunk-XPW4576I-DTzc2Ru4.js                   41.85 kB │ gzip:  14.22 kB
dist/assets/pm-s1dTTh5S.js                               45.06 kB │ gzip:   9.90 kB
dist/assets/src-COhTm8Vn.js                              45.80 kB │ gzip:  16.04 kB
dist/assets/chunk-4TB4RGXK-DwB3cXMg.js                   46.88 kB │ gzip:  15.12 kB
dist/assets/chunk-U2HBQHQK-DvoF36kp.js                   52.52 kB │ gzip:  17.15 kB
dist/assets/flowDiagram-DWJPFMVM-CzWiqpn2.js             60.23 kB │ gzip:  19.51 kB
dist/assets/ganttDiagram-T4ZO3ILL-BPGA3Pn4.js            69.13 kB │ gzip:  22.61 kB
dist/assets/c4Diagram-AHTNJAMY-oUhqa5QX.js               69.16 kB │ gzip:  19.33 kB
dist/assets/blockDiagram-DXYQGD6D-BDf2t05C.js            69.86 kB │ gzip:  19.56 kB
dist/assets/cose-bilkent-S5V4N54A-DjBhWtqN.js            81.39 kB │ gzip:  21.56 kB
dist/assets/chunk-5FUZZQ4R-DwkRH3p6.js                   97.91 kB │ gzip:  23.41 kB
dist/assets/sequenceDiagram-FGHM5R23-BOEXc4co.js        115.51 kB │ gzip:  30.41 kB
dist/assets/architectureDiagram-Q4EWVU46-CEaYRWuw.js    146.77 kB │ gzip:  40.23 kB
dist/assets/chunk-ICPOFSXX-wrbkz_-N.js                  216.05 kB │ gzip:  34.31 kB
dist/assets/katex-WguvS412.js                           257.04 kB │ gzip:  76.96 kB
dist/assets/xterm-DLqvPZgD.js                           340.34 kB │ gzip:  86.29 kB
dist/assets/lib-B_KCWner.js                             348.44 kB │ gzip: 107.22 kB
dist/assets/cytoscape.esm-C-8uvfDg.js                   434.14 kB │ gzip: 137.50 kB
dist/assets/chunk-K5T4RW27-D9KtxImF.js                  474.01 kB │ gzip: 102.19 kB
dist/assets/main-BMoO1xOE.js                          1,001.65 kB │ gzip: 332.40 kB

✓ built in 1.34s
- 
> ensue@0.1.1 lint
> eslint .


/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/chat.jsx
  69:21  error  'dots' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/App.jsx
   413:24  error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  411 |   // Load state from file on mount
  412 |   useEffect(() => {
> 413 |     if (!window.api) { setStateLoaded(true); return; }
      |                        ^^^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  414 |     window.api.loadState().then((state) => {
  415 |       if (state) {
  416 |         if (state.convos) {                            react-hooks/set-state-in-effect
   653:17  error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  651 |   useEffect(() => {
  652 |     if (!stateLoaded) return;
> 653 |     if (active) handleSelect(active);
      |                 ^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  654 |   }, [stateLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
  655 |
  656 |   // Load previews for conversations missing them (runs after state load)     react-hooks/set-state-in-effect
   733:17  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    no-empty
   848:5   error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  846 |     });
  847 |
> 848 |     setConvoList((p) =>
      |     ^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  849 |       p.map((c) => {
  850 |         if (c.id !== active) return c;
  851 |         let next = normalizeConversationState(c);                                                                                                             react-hooks/set-state-in-effect
  1165:5   warning  React Hook useCallback has a missing dependency: 'createConversationDraft'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             react-hooks/exhaustive-deps
  1420:9   error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  1418 |       const syncedMessageCount = activeData.messages.length;
  1419 |       if (preview) {
> 1420 |         setConvoList((p) =>
       |         ^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  1421 |           p.map((c) => {
  1422 |             if (c.id !== active) return c;
  1423 |             const normalized = normalizeConversationState({  react-hooks/set-state-in-effect

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/ProjectManager.jsx
  163:6  warning  React Hook useEffect has a missing dependency: 'stateLoaded'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/ChatArea.jsx
   67:6   warning  React Hook useCallback has unnecessary dependencies: 'convo' and 'isStreaming'. Either exclude them or remove the dependency array  react-hooks/exhaustive-deps
  148:10  error    'dragOver' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u                                            no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/InteractiveBlock.jsx
  7:9   error  'iframeRef' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars
  8:10  error  'height' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u     no-unused-vars
  8:18  error  'setHeight' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars
  9:10  error  'loaded' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u     no-unused-vars
  9:18  error  'setLoaded' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/MermaidBlock.jsx
  134:61  error    Empty block statement                                                                                                         no-empty
  139:6   warning  React Hook useEffect has a missing dependency: 'svg'. Either include it or remove the dependency array                        react-hooks/exhaustive-deps
  161:3   error    React Hook "useEffect" is called conditionally. React Hooks must be called in the exact same order in every component render  react-hooks/rules-of-hooks

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/Message.jsx
  185:7  error  'scaledMdStreaming' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/SelectionToolbar.jsx
  8:9  error  's' is assigned a value but never used. Allowed unused vars must match /^[A-Z_]/u  no-unused-vars

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/Settings.jsx
  14:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  12 |   // Sync from parent when wallpaper prop changes externally
  13 |   useEffect(() => {
> 14 |     setLocal(wallpaper ?? { ...DEFAULTS });
     |     ^^^^^^^^ Avoid calling setState() directly within an effect
  15 |   }, [wallpaper]);
  16 |
  17 |   // Load data URL when path is set but dataUrl is missing (e.g. after app restart)  react-hooks/set-state-in-effect

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/ThinkingBlock.jsx
  9:28  error  Error: Cannot call impure function during render

`Date.now` is an impure function. Calling an impure function can produce unstable results that update unpredictably when the component happens to re-render. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#components-and-hooks-must-be-idempotent).

   7 |   const s = useFontScale();
   8 |   const hasText = Boolean(text && text.trim().length > 0);
>  9 |   const startTime = useRef(Date.now());
     |                            ^^^^^^^^^^ Cannot call impure function
  10 |   const [elapsed, setElapsed] = useState(0);
  11 |
  12 |   // Track thinking duration  react-hooks/purity

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/components/ToolCallBlock.jsx
  36:34  error  Unnecessary escape character: \/  no-useless-escape
  36:42  error  Unnecessary escape character: \/  no-useless-escape

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/hooks/useAgent.js
  145:62  error  Empty block statement  no-empty

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/pm-components/CommentBox.jsx
  14:13  error  Empty block statement  no-empty

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/pm-components/CreateForm.jsx
  59:6  warning  React Hook useEffect has a missing dependency: 'head'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/pm-components/IssueList.jsx
  68:17  error    Empty block statement                                                                                           no-empty
  72:6   warning  React Hook useEffect has a missing dependency: 'fetchIssues'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/pm-components/ItemDetail.jsx
  130:5   error    Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  128 |
  129 |   useEffect(() => {
> 130 |     fetchAll();
      |     ^^^^^^^^ Avoid calling setState() directly within an effect
  131 |     const interval = setInterval(async () => {
  132 |       try {
  133 |         const fetchItem = type === "pr"  react-hooks/set-state-in-effect
  142:15  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  145:6   warning  React Hook useEffect has a missing dependency: 'fetchAll'. Either include it or remove the dependency array                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        react-hooks/exhaustive-deps
  166:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  175:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  185:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty
  193:13  error    Empty block statement                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              no-empty

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/pm-components/PRList.jsx
  66:17  error    Empty block statement                                                                                        no-empty
  70:6   warning  React Hook useEffect has a missing dependency: 'fetchPRs'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/pm-components/RepoManager.jsx
  26:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  24 |
  25 |   useEffect(() => {
> 26 |     fetchRepos();
     |     ^^^^^^^^^^ Avoid calling setState() directly within an effect
  27 |   }, []);
  28 |
  29 |   const filtered = userRepos.filter((r) =>  react-hooks/set-state-in-effect

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/src/pm-components/SearchableSelect.jsx
  40:5  error  Error: Calling setState synchronously within an effect can trigger cascading renders

Effects are intended to synchronize state between React and external systems such as manually updating the DOM, state management libraries, or other platform APIs. In general, the body of an effect should do one or both of the following:
* Update external systems with the latest state from React.
* Subscribe for updates from some external system, calling setState in a callback function when external state changes.

Calling setState synchronously within an effect body causes cascading renders that can hurt performance, and is not recommended. (https://react.dev/learn/you-might-not-need-an-effect).

  38 |   // Reset highlight when filtered list changes
  39 |   useEffect(() => {
> 40 |     setHighlightIdx(0);
     |     ^^^^^^^^^^^^^^^ Avoid calling setState() directly within an effect
  41 |   }, [filtered.length]);
  42 |
  43 |   // Scroll highlighted item into view  react-hooks/set-state-in-effect

/home/claude-code/multica_workspaces/4f1e09a3-9252-4b49-b455-73163ff633df/fdcd3d86/workdir/Ensue-Chat/vite.config.js
  12:23  error  '__dirname' is not defined  no-undef
  13:21  error  '__dirname' is not defined  no-undef

✖ 42 problems (34 errors, 8 warnings) *(fails due pre-existing repo-wide ESLint errors unrelated to this change)*