### PR TITLE
fix: create a terminal when opening the drawer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1490,6 +1490,22 @@ export default function App() {
     return [...roots];
   }, [convoList, projects]);
 
+  const terminalCwd = activeConvo?.cwd === null ? (draftsPath || undefined) : (activeConvo?.cwd || cwd);
+
+  const handleToggleTerminal = async () => {
+    if (terminal.drawerOpen) {
+      terminal.setDrawerOpen(false);
+      return;
+    }
+
+    if (terminal.sessions.length === 0) {
+      await terminal.createSession({ name: `shell-${Date.now()}`, cwd: terminalCwd });
+      return;
+    }
+
+    terminal.setDrawerOpen(true);
+  };
+
   // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
@@ -1583,11 +1599,11 @@ export default function App() {
           onModelChange={handleModelChange}
           defaultModel={defaultModel}
           queuedMessages={queuedMessages}
-          onToggleTerminal={() => terminal.setDrawerOpen((o) => !o)}
+          onToggleTerminal={handleToggleTerminal}
           terminalOpen={terminal.drawerOpen}
           terminalCount={terminal.sessions.length}
           wallpaper={wallpaper}
-          cwd={activeConvo?.cwd === null ? (draftsPath || undefined) : (activeConvo?.cwd || cwd)}
+          cwd={terminalCwd}
           onRefocusTerminal={terminal.focusActiveSession}
           onCwdChange={(newCwd) => {
             setCwd(newCwd);
@@ -1613,7 +1629,7 @@ export default function App() {
         activeSession={terminal.activeSession}
         onSelectSession={terminal.setActiveSession}
         onCreateSession={terminal.createSession}
-        cwd={activeConvo?.cwd === null ? (draftsPath || undefined) : (activeConvo?.cwd || cwd)}
+        cwd={terminalCwd}
         onKillSession={terminal.killSession}
         onSendInput={terminal.sendInput}
         onResizeSession={terminal.resizeSession}


### PR DESCRIPTION
## Summary
- create a terminal immediately when the terminal drawer is opened with no sessions
- reuse the active conversation cwd for the auto-created session
- keep the existing drawer toggle behavior when sessions already exist

## Testing
- npm run build

Fixes #70