### PR TITLE
fix: project modals close only on X/ESC; resolve list refresh race (#71)

### DIFF
--- a/src/ProjectManager.jsx
+++ b/src/ProjectManager.jsx
@@ -140,7 +140,9 @@ export default function ProjectManager() {
   const [wallpaper, setWallpaper] = useState(null);
   const [stateLoaded, setStateLoaded] = useState(false);
   const [showCreate, setShowCreate] = useState(null); // null | "issue" | "pr"
-  const [refreshKey, setRefreshKey] = useState(0);
+  const [refreshSignal, setRefreshSignal] = useState(0);
+  const [freshIssue, setFreshIssue] = useState(null);
+  const [freshPR, setFreshPR] = useState(null);
 
   useEffect(() => {
     window.ghApi.checkAuth().then(({ ok }) => setAuthOk(ok));
@@ -446,19 +448,21 @@ export default function ProjectManager() {
             />
           ) : activeTab === "issues" ? (
             <IssueList
-              key={`issues-${refreshKey}`}
               repos={repos}
               stateFilter={stateFilter}
               repoFilter={repoFilter}
               onSelectItem={setSelectedItem}
+              refreshSignal={refreshSignal}
+              freshItem={freshIssue}
             />
           ) : (
             <PRList
-              key={`prs-${refreshKey}`}
               repos={repos}
               stateFilter={stateFilter}
               repoFilter={repoFilter}
               onSelectItem={setSelectedItem}
+              refreshSignal={refreshSignal}
+              freshItem={freshPR}
             />
           )}
         </div>
@@ -470,7 +474,11 @@ export default function ProjectManager() {
           repos={repos}
           type={showCreate}
           onClose={() => setShowCreate(null)}
-          onCreated={() => setRefreshKey((k) => k + 1)}
+          onCreated={(item) => {
+            if (showCreate === "issue") setFreshIssue(item);
+            else setFreshPR(item);
+            setRefreshSignal((k) => k + 1);
+          }}
         />
       )}
 

--- a/src/pm-components/CreateForm.jsx
+++ b/src/pm-components/CreateForm.jsx
@@ -58,6 +58,14 @@ export default function CreateForm({ repos, type, onClose, onCreated }) {
     }
   }, [repo, type]);
 
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   const canSubmit = Boolean(title.trim()) && (type !== "pr" || (head && base));
 
   const handlePaste = (e) => {
@@ -84,18 +92,32 @@ export default function CreateForm({ repos, type, onClose, onCreated }) {
     setSubmitting(true);
     setError(null);
     try {
-      let finalBody = body.trim();
+      const finalBody = body.trim();
+      let created;
       if (type === "issue") {
-        await window.ghApi.createIssue(repo, title.trim(), finalBody);
+        const issue = await window.ghApi.createIssue(repo, title.trim(), finalBody);
+        created = { ...issue, _repo: repo };
       } else {
-        await window.ghApi.createPR(repo, title.trim(), finalBody, head, base);
+        const res = await window.ghApi.createPR(repo, title.trim(), finalBody, head, base);
+        const match = (res?.url || "").match(/\/pull\/(\d+)/);
+        const number = match ? parseInt(match[1], 10) : null;
+        created = {
+          number,
+          title: title.trim(),
+          state: "open",
+          draft: false,
+          merged_at: null,
+          updated_at: new Date().toISOString(),
+          user: { login: "" },
+          _repo: repo,
+        };
       }
+      onCreated(created);
       onClose();
-      setTimeout(() => onCreated(), 500);
     } catch (e) {
       setError(e.message);
+      setSubmitting(false);
     }
-    setSubmitting(false);
   };
 
   const handleContinueInGitHub = () => {
@@ -112,7 +134,6 @@ export default function CreateForm({ repos, type, onClose, onCreated }) {
 
   return (
     <div
-      onClick={onClose}
       style={{
         position: "fixed", inset: 0, zIndex: 200,
         background: "rgba(0,0,0,0.7)", backdropFilter: "blur(8px)",
@@ -120,7 +141,6 @@ export default function CreateForm({ repos, type, onClose, onCreated }) {
       }}
     >
       <div
-        onClick={(e) => e.stopPropagation()}
         style={{
           width: 440, background: "rgba(20,20,20,0.95)",
           border: "1px solid rgba(255,255,255,0.06)", borderRadius: 12,

--- a/src/pm-components/IssueList.jsx
+++ b/src/pm-components/IssueList.jsx
@@ -15,15 +15,15 @@ function timeAgo(dateStr) {
   return `${months}mo ago`;
 }
 
-export default function IssueList({ repos, stateFilter, repoFilter, onSelectItem }) {
+export default function IssueList({ repos, stateFilter, repoFilter, onSelectItem, refreshSignal, freshItem }) {
   const [issues, setIssues] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [initialLoad, setInitialLoad] = useState(true);
   const [error, setError] = useState(null);
   const [copiedId, setCopiedId] = useState(null);
   const [linkedPRs, setLinkedPRs] = useState({});
 
-  async function fetchIssues() {
-    setLoading(true);
+  async function fetchIssues({ silent = false } = {}) {
+    if (!silent) setInitialLoad(true);
     setError(null);
     try {
       const targetRepos = repoFilter ? [repoFilter] : repos;
@@ -36,40 +36,49 @@ export default function IssueList({ repos, stateFilter, repoFilter, onSelectItem
       const merged = results.flat().sort(
         (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
       );
-      setIssues(merged);
+      setIssues((prev) => {
+        // Preserve any optimistic items that the server hasn't returned yet
+        const mergedKeys = new Set(merged.map((i) => `${i._repo}-${i.number}`));
+        const stillPending = prev.filter(
+          (i) => i.__optimistic && !mergedKeys.has(`${i._repo}-${i.number}`)
+        );
+        return [...stillPending, ...merged].sort(
+          (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+        );
+      });
     } catch (err) {
       setError(err.message || "Failed to load issues");
     } finally {
-      setLoading(false);
+      setInitialLoad(false);
     }
   }
 
   useEffect(() => {
-    if (repos.length > 0) fetchIssues();
-    else {
+    if (repos.length === 0) {
       setIssues([]);
-      setLoading(false);
+      setInitialLoad(false);
+      return;
     }
-    // Auto-refresh every 30s (silent, no loading spinner)
-    if (repos.length > 0) {
-      const interval = setInterval(async () => {
-        try {
-          const targetRepos = repoFilter ? [repoFilter] : repos;
-          const results = await Promise.all(
-            targetRepos.map(async (repo) => {
-              const items = await window.ghApi.listIssues(repo, stateFilter);
-              return items.map((item) => ({ ...item, _repo: repo }));
-            })
-          );
-          const merged = results.flat().sort(
-            (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-          );
-          setIssues(merged);
-        } catch {}
-      }, 30000);
-      return () => clearInterval(interval);
-    }
-  }, [repos, stateFilter, repoFilter]);
+    fetchIssues({ silent: !initialLoad });
+    const interval = setInterval(() => {
+      fetchIssues({ silent: true }).catch(() => {});
+    }, 30000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repos, stateFilter, repoFilter, refreshSignal]);
+
+  useEffect(() => {
+    if (!freshItem || freshItem.number == null) return;
+    const itemState = freshItem.state || "open";
+    if (itemState !== stateFilter) return;
+    if (repoFilter && freshItem._repo !== repoFilter) return;
+    if (!repos.includes(freshItem._repo)) return;
+    setIssues((prev) => {
+      const key = `${freshItem._repo}-${freshItem.number}`;
+      if (prev.some((i) => `${i._repo}-${i.number}` === key)) return prev;
+      return [{ ...freshItem, __optimistic: true }, ...prev];
+    });
+  }, [freshItem, stateFilter, repoFilter, repos]);
 
   useEffect(() => {
     if (issues.length === 0) return;
@@ -95,7 +104,7 @@ export default function IssueList({ repos, stateFilter, repoFilter, onSelectItem
     return () => { cancelled = true; };
   }, [issues]);
 
-  if (loading) {
+  if (initialLoad && issues.length === 0) {
     return (
       <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: 40, color: "rgba(255,255,255,0.4)", fontFamily: "system-ui", fontSize: 13 }}>
         Loading issues...
@@ -103,12 +112,12 @@ export default function IssueList({ repos, stateFilter, repoFilter, onSelectItem
     );
   }
 
-  if (error) {
+  if (error && issues.length === 0) {
     return (
       <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", padding: 40, gap: 12 }}>
         <span style={{ color: "rgba(255,100,100,0.7)", fontFamily: "system-ui", fontSize: 13 }}>{error}</span>
         <button
-          onClick={fetchIssues}
+          onClick={() => fetchIssues()}
           style={{ background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 6, color: "rgba(255,255,255,0.5)", padding: "6px 16px", cursor: "pointer", fontFamily: "system-ui", fontSize: 12 }}
         >
           Retry

--- a/src/pm-components/PRList.jsx
+++ b/src/pm-components/PRList.jsx
@@ -15,14 +15,14 @@ function timeAgo(dateStr) {
   return `${months}mo ago`;
 }
 
-export default function PRList({ repos, stateFilter, repoFilter, onSelectItem }) {
+export default function PRList({ repos, stateFilter, repoFilter, onSelectItem, refreshSignal, freshItem }) {
   const [prs, setPrs] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [initialLoad, setInitialLoad] = useState(true);
   const [error, setError] = useState(null);
   const [copiedAction, setCopiedAction] = useState(null);
 
-  async function fetchPRs() {
-    setLoading(true);
+  async function fetchPRs({ silent = false } = {}) {
+    if (!silent) setInitialLoad(true);
     setError(null);
     try {
       const targetRepos = repoFilter ? [repoFilter] : repos;
@@ -35,41 +35,50 @@ export default function PRList({ repos, stateFilter, repoFilter, onSelectItem })
       const merged = results.flat().sort(
         (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
       );
-      setPrs(merged);
+      setPrs((prev) => {
+        const mergedKeys = new Set(merged.map((i) => `${i._repo}-${i.number}`));
+        const stillPending = prev.filter(
+          (i) => i.__optimistic && !mergedKeys.has(`${i._repo}-${i.number}`)
+        );
+        return [...stillPending, ...merged].sort(
+          (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+        );
+      });
     } catch (err) {
       setError(err.message || "Failed to load pull requests");
     } finally {
-      setLoading(false);
+      setInitialLoad(false);
     }
   }
 
   useEffect(() => {
-    if (repos.length > 0) fetchPRs();
-    else {
+    if (repos.length === 0) {
       setPrs([]);
-      setLoading(false);
+      setInitialLoad(false);
+      return;
     }
-    if (repos.length > 0) {
-      const interval = setInterval(async () => {
-        try {
-          const targetRepos = repoFilter ? [repoFilter] : repos;
-          const results = await Promise.all(
-            targetRepos.map(async (repo) => {
-              const items = await window.ghApi.listPRs(repo, stateFilter);
-              return items.map((item) => ({ ...item, _repo: repo }));
-            })
-          );
-          const merged = results.flat().sort(
-            (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-          );
-          setPrs(merged);
-        } catch {}
-      }, 30000);
-      return () => clearInterval(interval);
-    }
-  }, [repos, stateFilter, repoFilter]);
+    fetchPRs({ silent: !initialLoad });
+    const interval = setInterval(() => {
+      fetchPRs({ silent: true }).catch(() => {});
+    }, 30000);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repos, stateFilter, repoFilter, refreshSignal]);
 
-  if (loading) {
+  useEffect(() => {
+    if (!freshItem || freshItem.number == null) return;
+    const itemState = freshItem.state || "open";
+    if (itemState !== stateFilter) return;
+    if (repoFilter && freshItem._repo !== repoFilter) return;
+    if (!repos.includes(freshItem._repo)) return;
+    setPrs((prev) => {
+      const key = `${freshItem._repo}-${freshItem.number}`;
+      if (prev.some((i) => `${i._repo}-${i.number}` === key)) return prev;
+      return [{ ...freshItem, __optimistic: true }, ...prev];
+    });
+  }, [freshItem, stateFilter, repoFilter, repos]);
+
+  if (initialLoad && prs.length === 0) {
     return (
       <div style={{ display: "flex", justifyContent: "center", alignItems: "center", padding: 40, color: "rgba(255,255,255,0.4)", fontFamily: "system-ui", fontSize: 13 }}>
         Loading pull requests...
@@ -77,12 +86,12 @@ export default function PRList({ repos, stateFilter, repoFilter, onSelectItem })
     );
   }
 
-  if (error) {
+  if (error && prs.length === 0) {
     return (
       <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", alignItems: "center", padding: 40, gap: 12 }}>
         <span style={{ color: "rgba(255,100,100,0.7)", fontFamily: "system-ui", fontSize: 13 }}>{error}</span>
         <button
-          onClick={fetchPRs}
+          onClick={() => fetchPRs()}
           style={{ background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.1)", borderRadius: 6, color: "rgba(255,255,255,0.5)", padding: "6px 16px", cursor: "pointer", fontFamily: "system-ui", fontSize: 12 }}
         >
           Retry


### PR DESCRIPTION
## Summary
- New issue / new PR modals no longer dismiss when clicking the backdrop. They close only via the X button or ESC key.
- Replaces the 500ms timed remount pattern with a `refreshSignal` prop + optimistic insert. When `CreateForm` finishes, it passes the created item back and `IssueList`/`PRList` prepend it immediately, so the new issue shows up even if GitHub's listing endpoint hasn't caught up yet. Subsequent fetches reconcile the optimistic entry with the server copy.
- Lists no longer show the full-page "Loading..." state on a refetch when items are already visible.

Fixes #71

## Test plan
- [ ] Open the project page, click NEW, click outside the modal → modal stays open.
- [ ] Press ESC → modal closes.
- [ ] Click X or Cancel → modal closes.
- [ ] Create a new issue → it appears at the top of the issue list immediately (no 500ms blank flash).
- [ ] Create a new PR → it appears at the top of the PR list immediately.
- [ ] Retry button on a failed list still works.