### PR TITLE
feat: add copy as image for assistant responses

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, nativeImage, shell } = require("electron");
+const { app, BrowserWindow, ipcMain, dialog, nativeImage, shell, clipboard } = require("electron");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
@@ -217,6 +217,24 @@ ipcMain.handle("set-window-opacity", (event, opacity) => {
   if (!Number.isFinite(v)) return false;
   win.setOpacity(Math.max(0.2, Math.min(1, v)));
   return true;
+});
+
+ipcMain.handle("clipboard-write-image", (_event, dataUrl) => {
+  if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:image/")) {
+    return false;
+  }
+
+  try {
+    const image = nativeImage.createFromDataURL(dataUrl);
+    if (image.isEmpty()) {
+      return false;
+    }
+    clipboard.writeImage(image);
+    return true;
+  } catch (error) {
+    console.error("[clipboard-write-image] Failed to write image", error);
+    return false;
+  }
 });
 
 // IPC: open path in Finder / file manager

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -99,4 +99,5 @@ contextBridge.exposeInMainWorld("api", {
 
   // Window appearance
   setWindowOpacity: (opacity) => ipcRenderer.invoke("set-window-opacity", opacity),
+  writeClipboardImage: (dataUrl) => ipcRenderer.invoke("clipboard-write-image", dataUrl),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
+        "html-to-image": "^1.11.13",
         "katex": "^0.16.45",
         "lucide-react": "^1.8.0",
         "mermaid": "^11.14.0",
@@ -6231,6 +6232,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
+    "html-to-image": "^1.11.13",
     "katex": "^0.16.45",
     "lucide-react": "^1.8.0",
     "mermaid": "^11.14.0",

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -401,6 +401,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
                 onAnswer={m.role === "assistant" ? (text) => onSend(text) : undefined}
                 onControlChange={m.role === "assistant" ? onControlChange : undefined}
                 canControlTarget={m.role === "assistant" ? canControlTarget : undefined}
+                wallpaper={wallpaper}
               />
             ))}
             <div ref={endRef} />

--- a/src/components/CopyBtn.jsx
+++ b/src/components/CopyBtn.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Copy, Check } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
 
-export default function CopyBtn({ text }) {
+export default function CopyBtn({ text, title = "Copy" }) {
   const [ok, set] = useState(false);
   const s = useFontScale();
 
@@ -17,6 +17,8 @@ export default function CopyBtn({ text }) {
   return (
     <button
       onClick={handleCopy}
+      title={ok ? "Copied" : title}
+      data-copy-image-ignore="true"
       style={{
         background: "none",
         border: "none",

--- a/src/components/CopyImageBtn.jsx
+++ b/src/components/CopyImageBtn.jsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, Image, X } from "lucide-react";
+import { toBlob } from "html-to-image";
+import { useFontScale } from "../contexts/FontSizeContext";
+
+const CAPTURE_BACKGROUND = "linear-gradient(180deg, rgba(18,20,26,0.98), rgba(9,10,14,0.98))";
+
+function blobToDataUrl(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = () => reject(new Error("Failed to read image data."));
+    reader.readAsDataURL(blob);
+  });
+}
+
+export default function CopyImageBtn({ targetRef, title = "Copy as image" }) {
+  const [status, setStatus] = useState("idle");
+  const resetTimerRef = useRef(null);
+  const s = useFontScale();
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const queueReset = () => {
+    if (resetTimerRef.current) {
+      window.clearTimeout(resetTimerRef.current);
+    }
+    resetTimerRef.current = window.setTimeout(() => setStatus("idle"), 1600);
+  };
+
+  const handleCopy = async () => {
+    const target = targetRef?.current;
+    if (!target) {
+      setStatus("error");
+      queueReset();
+      return;
+    }
+
+    try {
+      const blob = await toBlob(target, {
+        backgroundColor: "#0D0D10",
+        cacheBust: true,
+        pixelRatio: Math.min(window.devicePixelRatio || 1, 2),
+        width: target.scrollWidth,
+        height: target.scrollHeight,
+        filter: (node) => !(node instanceof HTMLElement && node.dataset.copyImageIgnore === "true"),
+        style: {
+          background: CAPTURE_BACKGROUND,
+          border: "1px solid rgba(255,255,255,0.08)",
+          borderRadius: "18px",
+          boxShadow: "0 20px 44px rgba(0,0,0,0.28)",
+          padding: "16px 18px 14px",
+        },
+      });
+
+      if (!blob) {
+        throw new Error("Image capture returned no data.");
+      }
+
+      const dataUrl = await blobToDataUrl(blob);
+      const copied = await window.api?.writeClipboardImage?.(dataUrl);
+      if (!copied) {
+        throw new Error("Clipboard write failed.");
+      }
+
+      setStatus("success");
+    } catch (error) {
+      console.error("[CopyImageBtn] Failed to copy image", error);
+      setStatus("error");
+    }
+
+    queueReset();
+  };
+
+  const color = status === "success"
+    ? "rgba(160,200,140,0.65)"
+    : status === "error"
+      ? "rgba(255,160,160,0.7)"
+      : "rgba(255,255,255,0.3)";
+
+  return (
+    <button
+      onClick={handleCopy}
+      title={status === "success" ? "Copied image" : status === "error" ? "Copy failed" : title}
+      data-copy-image-ignore="true"
+      style={{
+        background: "none",
+        border: "none",
+        color,
+        cursor: "pointer",
+        padding: "2px 4px",
+        borderRadius: 3,
+        transition: "color .2s",
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 3,
+        fontSize: s(10),
+        fontFamily: "'JetBrains Mono',monospace",
+      }}
+      onMouseEnter={(e) => {
+        if (status === "idle") {
+          e.currentTarget.style.color = "rgba(255,255,255,0.5)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (status === "idle") {
+          e.currentTarget.style.color = "rgba(255,255,255,0.3)";
+        }
+      }}
+    >
+      {status === "success"
+        ? <Check size={12} strokeWidth={1.5} />
+        : status === "error"
+          ? <X size={12} strokeWidth={1.5} />
+          : <Image size={12} strokeWidth={1.5} />}
+      {status === "success" ? "copied" : status === "error" ? "failed" : ""}
+    </button>
+  );
+}

--- a/src/components/CopyImageBtn.jsx
+++ b/src/components/CopyImageBtn.jsx
@@ -1,9 +1,13 @@
 import { useEffect, useRef, useState } from "react";
-import { Check, Image, X } from "lucide-react";
+import { Check, Image, Loader2, X } from "lucide-react";
 import { toBlob } from "html-to-image";
 import { useFontScale } from "../contexts/FontSizeContext";
 
-const CAPTURE_BACKGROUND = "linear-gradient(180deg, rgba(18,20,26,0.98), rgba(9,10,14,0.98))";
+const CAPTURE_BG_SOLID = "#0D0D10";
+const CAPTURE_BACKGROUND = "linear-gradient(180deg, #121622 0%, #0A0B10 100%)";
+const CAPTURE_PADDING_X = 24;
+const CAPTURE_PADDING_TOP = 20;
+const CAPTURE_PADDING_BOTTOM = 18;
 
 function blobToDataUrl(blob) {
   return new Promise((resolve, reject) => {
@@ -14,7 +18,7 @@ function blobToDataUrl(blob) {
   });
 }
 
-export default function CopyImageBtn({ targetRef, title = "Copy as image" }) {
+export default function CopyImageBtn({ targetRef, title = "Copy as image", wallpaper }) {
   const [status, setStatus] = useState("idle");
   const resetTimerRef = useRef(null);
   const s = useFontScale();
@@ -42,21 +46,50 @@ export default function CopyImageBtn({ targetRef, title = "Copy as image" }) {
       return;
     }
 
+    if (resetTimerRef.current) {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+    setStatus("loading");
+
     try {
+      const contentWidth = target.scrollWidth;
+      const contentHeight = target.scrollHeight;
+      const totalWidth = contentWidth + CAPTURE_PADDING_X * 2;
+      const totalHeight = contentHeight + CAPTURE_PADDING_TOP + CAPTURE_PADDING_BOTTOM;
+
+      const hasWallpaper = Boolean(wallpaper?.dataUrl);
+      const wallpaperOpacity = Number.isFinite(wallpaper?.imgOpacity)
+        ? Math.min(1, Math.max(0, wallpaper.imgOpacity / 100))
+        : 1;
+      const overlayAlpha = 0.68 + (1 - wallpaperOpacity) * 0.25;
+      const captureStyle = {
+        border: "1px solid rgba(255,255,255,0.08)",
+        borderRadius: "18px",
+        boxShadow: "0 20px 44px rgba(0,0,0,0.28)",
+        padding: `${CAPTURE_PADDING_TOP}px ${CAPTURE_PADDING_X}px ${CAPTURE_PADDING_BOTTOM}px`,
+        boxSizing: "content-box",
+        width: `${contentWidth}px`,
+      };
+
+      if (hasWallpaper) {
+        captureStyle.backgroundColor = CAPTURE_BG_SOLID;
+        captureStyle.backgroundImage = `linear-gradient(rgba(13,13,16,${overlayAlpha.toFixed(2)}), rgba(13,13,16,${(overlayAlpha + 0.1).toFixed(2)})), url(${wallpaper.dataUrl})`;
+        captureStyle.backgroundSize = "cover, cover";
+        captureStyle.backgroundPosition = "center, center";
+        captureStyle.backgroundRepeat = "no-repeat, no-repeat";
+      } else {
+        captureStyle.background = CAPTURE_BACKGROUND;
+      }
+
       const blob = await toBlob(target, {
-        backgroundColor: "#0D0D10",
+        backgroundColor: CAPTURE_BG_SOLID,
         cacheBust: true,
         pixelRatio: Math.min(window.devicePixelRatio || 1, 2),
-        width: target.scrollWidth,
-        height: target.scrollHeight,
+        width: totalWidth,
+        height: totalHeight,
         filter: (node) => !(node instanceof HTMLElement && node.dataset.copyImageIgnore === "true"),
-        style: {
-          background: CAPTURE_BACKGROUND,
-          border: "1px solid rgba(255,255,255,0.08)",
-          borderRadius: "18px",
-          boxShadow: "0 20px 44px rgba(0,0,0,0.28)",
-          padding: "16px 18px 14px",
-        },
+        style: captureStyle,
       });
 
       if (!blob) {
@@ -78,22 +111,35 @@ export default function CopyImageBtn({ targetRef, title = "Copy as image" }) {
     queueReset();
   };
 
-  const color = status === "success"
-    ? "rgba(160,200,140,0.65)"
-    : status === "error"
-      ? "rgba(255,160,160,0.7)"
-      : "rgba(255,255,255,0.3)";
+  const color = status === "error"
+    ? "rgba(255,160,160,0.7)"
+    : status === "success"
+      ? "rgba(255,255,255,0.55)"
+      : status === "loading"
+        ? "rgba(255,255,255,0.55)"
+        : "rgba(255,255,255,0.3)";
+
+  const isBusy = status === "loading";
 
   return (
     <button
       onClick={handleCopy}
-      title={status === "success" ? "Copied image" : status === "error" ? "Copy failed" : title}
+      disabled={isBusy}
+      title={
+        status === "success"
+          ? "Copied image"
+          : status === "error"
+            ? "Copy failed"
+            : status === "loading"
+              ? "Capturing image…"
+              : title
+      }
       data-copy-image-ignore="true"
       style={{
         background: "none",
         border: "none",
         color,
-        cursor: "pointer",
+        cursor: isBusy ? "progress" : "pointer",
         padding: "2px 4px",
         borderRadius: 3,
         transition: "color .2s",
@@ -118,8 +164,16 @@ export default function CopyImageBtn({ targetRef, title = "Copy as image" }) {
         ? <Check size={12} strokeWidth={1.5} />
         : status === "error"
           ? <X size={12} strokeWidth={1.5} />
-          : <Image size={12} strokeWidth={1.5} />}
-      {status === "success" ? "copied" : status === "error" ? "failed" : ""}
+          : status === "loading"
+            ? <Loader2 size={12} strokeWidth={1.5} style={{ animation: "spin 1s linear infinite" }} />
+            : <Image size={12} strokeWidth={1.5} />}
+      {status === "success"
+        ? "copied"
+        : status === "error"
+          ? "failed"
+          : status === "loading"
+            ? "copying"
+            : ""}
     </button>
   );
 }

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef } from "react";
 import { Pencil, Loader2, FileText, PauseCircle, Terminal } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -10,6 +10,7 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import "katex/dist/katex.min.css";
 import CopyBtn from "./CopyBtn";
+import CopyImageBtn from "./CopyImageBtn";
 import ToolCallBlock from "./ToolCallBlock";
 import AskUserQuestionBlock from "./AskUserQuestionBlock";
 import MermaidBlock from "./MermaidBlock";
@@ -278,6 +279,16 @@ export default function Message({ msg, onEdit, onAnswer, onControlChange, canCon
   const isShellCommand = msg.mode === "shell-command";
   const hasThinkingPart = Boolean(msg.parts?.some((part) => part.type === "thinking"));
   const activeThinkingByStreamKey = msg._streamState?.activeThinking || {};
+  const assistantCaptureRef = useRef(null);
+  const assistantText = useMemo(() => {
+    if (msg.parts) {
+      return msg.parts
+        .filter((part) => part.type === "text" && part.text)
+        .map((part) => part.text)
+        .join("\n");
+    }
+    return msg.text || "";
+  }, [msg.parts, msg.text]);
 
   // Strip [Attached files/images: ...] prefix from display text and extract file names
   let displayText = msg.text || "";
@@ -552,166 +563,177 @@ export default function Message({ msg, onEdit, onAnswer, onControlChange, canCon
         paddingTop: 8,
       }}
     >
-      <div style={{
-        fontSize: s(9),
-        fontFamily: "'JetBrains Mono',monospace",
-        color: "rgba(255,255,255,0.38)",
-        letterSpacing: ".14em",
-        marginBottom: 12,
-        display: "flex",
-        alignItems: "center",
-        gap: 8,
-      }}>
-        ASSISTANT
-      </div>
+      <div ref={assistantCaptureRef}>
+        <div style={{
+          fontSize: s(9),
+          fontFamily: "'JetBrains Mono',monospace",
+          color: "rgba(255,255,255,0.38)",
+          letterSpacing: ".14em",
+          marginBottom: 12,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}>
+          ASSISTANT
+        </div>
 
-      {/* Render parts in order — text and tool calls interleaved */}
-      {(msg.parts || []).map((part, i) => {
-        if (part.type === "text" && part.text) {
-          const isLastPart = i === (msg.parts || []).length - 1;
-          return (
-            <div key={i} style={{
-              color: "rgba(255,255,255,0.75)",
-              fontSize: s(15),
-              lineHeight: 1.85,
-              fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
-              letterSpacing: "0.008em",
-              marginBottom: 4,
-            }}>
-              {renderControlAwareMarkdown({
-                text: part.text,
-                blockKey: `part-${part.id || i}`,
-                markdownProps: {
-                  remarkPlugins: [remarkGfm, remarkMath],
-                  rehypePlugins: [rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex],
-                },
-                components: (msg.isStreaming && isLastPart) ? scaledMdStreaming : scaledMdStatic,
-                isStreaming: msg.isStreaming && isLastPart,
-                onAnswer,
-                onControlChange,
-                canControlTarget,
-              })}
-              {msg.isStreaming && isLastPart && (
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 4, color: "rgba(255,255,255,0.2)", marginLeft: 4, verticalAlign: "middle" }}>
-                  <Loader2 size={12} strokeWidth={2} style={{ animation: "spin 1s linear infinite" }} />
-                </span>
-              )}
-            </div>
-          );
-        }
-        if (part.type === "thinking") {
-          const isPartThinking = part._streamKey
-            ? Boolean(activeThinkingByStreamKey[part._streamKey])
-            : msg.isThinking;
-          return <ThinkingBlock key={"think-" + i} text={part.text} isThinking={isPartThinking} />;
-        }
-        if (part.type === "tool") {
-          if (part.name === "AskUserQuestion") {
-            return <AskUserQuestionBlock key={part.id || i} tool={part} onAnswer={onAnswer} />;
+        {/* Render parts in order — text and tool calls interleaved */}
+        {(msg.parts || []).map((part, i) => {
+          if (part.type === "text" && part.text) {
+            const isLastPart = i === (msg.parts || []).length - 1;
+            return (
+              <div key={i} style={{
+                color: "rgba(255,255,255,0.75)",
+                fontSize: s(15),
+                lineHeight: 1.85,
+                fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
+                letterSpacing: "0.008em",
+                marginBottom: 4,
+              }}>
+                {renderControlAwareMarkdown({
+                  text: part.text,
+                  blockKey: `part-${part.id || i}`,
+                  markdownProps: {
+                    remarkPlugins: [remarkGfm, remarkMath],
+                    rehypePlugins: [rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex],
+                  },
+                  components: (msg.isStreaming && isLastPart) ? scaledMdStreaming : scaledMdStatic,
+                  isStreaming: msg.isStreaming && isLastPart,
+                  onAnswer,
+                  onControlChange,
+                  canControlTarget,
+                })}
+                {msg.isStreaming && isLastPart && (
+                  <span style={{ display: "inline-flex", alignItems: "center", gap: 4, color: "rgba(255,255,255,0.2)", marginLeft: 4, verticalAlign: "middle" }}>
+                    <Loader2 size={12} strokeWidth={2} style={{ animation: "spin 1s linear infinite" }} />
+                  </span>
+                )}
+              </div>
+            );
           }
-          return <ToolCallBlock key={part.id || i} tool={part} />;
-        }
-        if (part.type === "status") {
-          const isPaused = part.kind === "paused";
-          return (
-            <div
-              key={`status-${i}`}
-              style={{
-                margin: "10px 0 14px",
-                padding: "10px 12px",
-                borderRadius: 12,
-                border: "1px solid rgba(255,255,255,0.08)",
-                background: isPaused ? "rgba(255,214,153,0.08)" : "rgba(255,255,255,0.04)",
-                color: "rgba(255,255,255,0.72)",
-                maxWidth: "80%",
-              }}
-            >
+          if (part.type === "thinking") {
+            const isPartThinking = part._streamKey
+              ? Boolean(activeThinkingByStreamKey[part._streamKey])
+              : msg.isThinking;
+            return (
+              <div key={"think-" + i} data-copy-image-ignore="true">
+                <ThinkingBlock text={part.text} isThinking={isPartThinking} />
+              </div>
+            );
+          }
+          if (part.type === "tool") {
+            return (
+              <div key={part.id || i} data-copy-image-ignore="true">
+                {part.name === "AskUserQuestion"
+                  ? <AskUserQuestionBlock tool={part} onAnswer={onAnswer} />
+                  : <ToolCallBlock tool={part} />}
+              </div>
+            );
+          }
+          if (part.type === "status") {
+            const isPaused = part.kind === "paused";
+            return (
               <div
+                key={`status-${i}`}
+                data-copy-image-ignore="true"
                 style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  fontSize: s(11),
-                  fontFamily: "'JetBrains Mono',monospace",
-                  letterSpacing: ".04em",
-                  textTransform: "uppercase",
-                  color: isPaused ? "rgba(255,220,170,0.9)" : "rgba(255,255,255,0.6)",
+                  margin: "10px 0 14px",
+                  padding: "10px 12px",
+                  borderRadius: 12,
+                  border: "1px solid rgba(255,255,255,0.08)",
+                  background: isPaused ? "rgba(255,214,153,0.08)" : "rgba(255,255,255,0.04)",
+                  color: "rgba(255,255,255,0.72)",
+                  maxWidth: "80%",
                 }}
               >
-                {isPaused && <PauseCircle size={14} strokeWidth={1.8} />}
-                <span>{part.title || "Status"}</span>
-              </div>
-              {part.text && (
                 <div
                   style={{
-                    marginTop: 6,
-                    fontSize: s(13),
-                    lineHeight: 1.65,
-                    fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
-                    color: "rgba(255,255,255,0.66)",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    fontSize: s(11),
+                    fontFamily: "'JetBrains Mono',monospace",
+                    letterSpacing: ".04em",
+                    textTransform: "uppercase",
+                    color: isPaused ? "rgba(255,220,170,0.9)" : "rgba(255,255,255,0.6)",
                   }}
                 >
-                  {part.text}
+                  {isPaused && <PauseCircle size={14} strokeWidth={1.8} />}
+                  <span>{part.title || "Status"}</span>
                 </div>
-              )}
-            </div>
-          );
-        }
-        return null;
-      })}
+                {part.text && (
+                  <div
+                    style={{
+                      marginTop: 6,
+                      fontSize: s(13),
+                      lineHeight: 1.65,
+                      fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
+                      color: "rgba(255,255,255,0.66)",
+                    }}
+                  >
+                    {part.text}
+                  </div>
+                )}
+              </div>
+            );
+          }
+          return null;
+        })}
 
-      {msg.isThinking && !hasThinkingPart && (
-        <ThinkingBlock text="" isThinking={true} />
-      )}
+        {msg.isThinking && !hasThinkingPart && (
+          <div data-copy-image-ignore="true">
+            <ThinkingBlock text="" isThinking={true} />
+          </div>
+        )}
 
-      {msg.isStreaming && !msg.isThinking && (msg.parts || []).length === 0 && (
-        <div style={{ display: "flex", gap: 5, alignItems: "center", padding: "4px 0" }}>
-          {[0, 1, 2].map(i => (
-            <span key={i} style={{
-              width: 5, height: 5,
-              borderRadius: "50%",
-              background: "rgba(255,255,255,0.25)",
-              display: "inline-block",
-              animation: `dotPulse 1.2s ease-in-out ${i * 0.2}s infinite`,
-            }} />
-          ))}
-        </div>
-      )}
+        {msg.isStreaming && !msg.isThinking && (msg.parts || []).length === 0 && (
+          <div style={{ display: "flex", gap: 5, alignItems: "center", padding: "4px 0" }}>
+            {[0, 1, 2].map(i => (
+              <span key={i} style={{
+                width: 5, height: 5,
+                borderRadius: "50%",
+                background: "rgba(255,255,255,0.25)",
+                display: "inline-block",
+                animation: `dotPulse 1.2s ease-in-out ${i * 0.2}s infinite`,
+              }} />
+            ))}
+          </div>
+        )}
 
-      {/* Fallback for old format messages (text + toolCalls) */}
-      {!msg.parts && msg.text && (
-        <div style={{
-          color: "rgba(255,255,255,0.75)",
-          fontSize: s(15),
-          lineHeight: 1.85,
-          fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
-          letterSpacing: "0.008em",
-        }}>
-          {renderControlAwareMarkdown({
-            text: msg.text,
-            blockKey: `legacy-${msg.id}`,
-            markdownProps: {
-              remarkPlugins: [remarkGfm, remarkMath],
-              rehypePlugins: [rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex],
-            },
-            components: scaledMdStatic,
-            onAnswer,
-            onControlChange,
-            canControlTarget,
-          })}
-        </div>
-      )}
-      {!msg.parts && msg.toolCalls && msg.toolCalls.map((tc) => (
-        <ToolCallBlock key={tc.id} tool={tc} />
-      ))}
+        {/* Fallback for old format messages (text + toolCalls) */}
+        {!msg.parts && msg.text && (
+          <div style={{
+            color: "rgba(255,255,255,0.75)",
+            fontSize: s(15),
+            lineHeight: 1.85,
+            fontFamily: "'Newsreader','Iowan Old Style',Georgia,serif",
+            letterSpacing: "0.008em",
+          }}>
+            {renderControlAwareMarkdown({
+              text: msg.text,
+              blockKey: `legacy-${msg.id}`,
+              markdownProps: {
+                remarkPlugins: [remarkGfm, remarkMath],
+                rehypePlugins: [rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex],
+              },
+              components: scaledMdStatic,
+              onAnswer,
+              onControlChange,
+              canControlTarget,
+            })}
+          </div>
+        )}
+        {!msg.parts && msg.toolCalls && msg.toolCalls.map((tc) => (
+          <div key={tc.id} data-copy-image-ignore="true">
+            <ToolCallBlock tool={tc} />
+          </div>
+        ))}
+      </div>
 
-      {!msg.isStreaming && (msg.parts?.some(p => p.type === "text" && p.text) || msg.text) && (
-        <div style={{ marginTop: 8, display: "flex", gap: 6 }}>
-          <CopyBtn text={
-            msg.parts
-              ? msg.parts.filter(p => p.type === "text").map(p => p.text).join("\n")
-              : msg.text
-          } />
+      {!msg.isStreaming && assistantText && (
+        <div data-copy-image-ignore="true" style={{ marginTop: 8, display: "flex", gap: 6 }}>
+          <CopyBtn text={assistantText} title="Copy markdown" />
+          <CopyImageBtn targetRef={assistantCaptureRef} />
         </div>
       )}
     </div>

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -270,7 +270,7 @@ function renderControlAwareMarkdown({
   });
 }
 
-export default function Message({ msg, onEdit, onAnswer, onControlChange, canControlTarget }) {
+export default function Message({ msg, onEdit, onAnswer, onControlChange, canControlTarget, wallpaper }) {
   const s = useFontScale();
   const scaledMdStatic = useMemo(() => makeMdComponents(false, s, onAnswer, onControlChange, canControlTarget), [canControlTarget, onAnswer, onControlChange, s]);
   const scaledMdStreaming = useMemo(() => makeMdComponents(true, s, onAnswer, onControlChange, canControlTarget), [canControlTarget, onAnswer, onControlChange, s]);
@@ -733,7 +733,7 @@ export default function Message({ msg, onEdit, onAnswer, onControlChange, canCon
       {!msg.isStreaming && assistantText && (
         <div data-copy-image-ignore="true" style={{ marginTop: 8, display: "flex", gap: 6 }}>
           <CopyBtn text={assistantText} title="Copy markdown" />
-          <CopyImageBtn targetRef={assistantCaptureRef} />
+          <CopyImageBtn targetRef={assistantCaptureRef} wallpaper={wallpaper} />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add a dedicated assistant-only copy-as-image action next to the existing markdown copy button
- render assistant responses to PNG while filtering out action chrome and non-response blocks
- write the generated image to the system clipboard through Electron

## Testing
- npm run build
- npx eslint electron/main.cjs electron/preload.cjs src/components/CopyBtn.jsx src/components/CopyImageBtn.jsx src/components/Message.jsx

Closes #81