### PR TITLE
feat/agent loading status

### DIFF
--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -4,6 +4,7 @@ const fs = require("fs");
 const os = require("os");
 const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
 const { findSessionCwd } = require("./session-reader.cjs");
+const { fetchClaudeUsage } = require("./claude-usage-fetcher.cjs");
 
 const activeAgents = new Map();
 
@@ -347,6 +348,25 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
         }
 
         webContents.send("agent-stream", { conversationId, event });
+
+        // After the turn ends, fetch Claude Code 5h/7d plan quota and emit a
+        // synthetic event so the loading status can show it. Cached aggressively
+        // (180s TTL + 30s lock) so this is essentially free per-turn.
+        if (event.type === "result") {
+          fetchClaudeUsage()
+            .then((rateLimits) => {
+              if (!rateLimits) return;
+              if (state.cancelled || activeAgents.get(conversationId) !== state) {
+                // Conversation moved on — still emit so the now-frozen message updates.
+              }
+              if (webContents.isDestroyed?.()) return;
+              webContents.send("agent-stream", {
+                conversationId,
+                event: { type: "rate_limits", rate_limits: rateLimits },
+              });
+            })
+            .catch((err) => log("fetchClaudeUsage failed:", err?.message || err));
+        }
       } catch (e) {
         log("Failed to parse JSON line:", line.slice(0, 200), "error:", e.message);
       }

--- a/electron/claude-usage-fetcher.cjs
+++ b/electron/claude-usage-fetcher.cjs
@@ -1,0 +1,304 @@
+// Claude Code 5h/7d plan-quota fetcher.
+//
+// Source: GET https://api.anthropic.com/api/oauth/usage with the user's
+// Claude Code OAuth token. This is the same endpoint ccstatusline uses
+// (sirmalloc/ccstatusline:src/utils/usage-fetch.ts) — it's the only known
+// way to get plan utilization for Claude Code, and it's only populated for
+// Pro/Max subscribers (API-key users will have no token, so we return null
+// silently and the renderer hides the line).
+//
+// The endpoint aggressively 429s, so we cache hard: 180s memory+file TTL,
+// 30s lock-out after any failure, honor `Retry-After` on 429.
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const https = require("https");
+const { execFileSync } = require("child_process");
+
+const CACHE_DIR = path.join(os.homedir(), ".cache", "rayline");
+const CACHE_FILE = path.join(CACHE_DIR, "claude-usage.json");
+const LOCK_FILE = path.join(CACHE_DIR, "claude-usage.lock");
+const CACHE_MAX_AGE_S = 180;
+const LOCK_MAX_AGE_S = 30;
+const DEFAULT_RATE_LIMIT_BACKOFF_S = 300;
+const REQUEST_TIMEOUT_MS = 5000;
+
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+
+let memCache = null; // { ts, data } — data is the normalized shape or null
+let memCacheTime = 0;
+let memCacheMaxAge = CACHE_MAX_AGE_S;
+
+function log(...args) {
+  console.log("[claude-usage]", ...args);
+}
+
+function ensureCacheDir() {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
+  } catch {}
+}
+
+function nowSec() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function readTokenFromCredentialsFile() {
+  try {
+    const credPath = path.join(os.homedir(), ".claude", ".credentials.json");
+    const raw = fs.readFileSync(credPath, "utf8");
+    const parsed = parseJson(raw);
+    return parsed?.claudeAiOauth?.accessToken || null;
+  } catch {
+    return null;
+  }
+}
+
+function readTokenFromKeychain() {
+  if (process.platform !== "darwin") return null;
+  try {
+    const out = execFileSync(
+      "security",
+      ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+      { encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] }
+    ).trim();
+    if (!out) return null;
+    const parsed = parseJson(out);
+    return parsed?.claudeAiOauth?.accessToken || null;
+  } catch {
+    return null;
+  }
+}
+
+function getOAuthToken() {
+  // macOS: keychain first (Claude Code stores there), then credentials.json fallback.
+  if (process.platform === "darwin") {
+    return readTokenFromKeychain() || readTokenFromCredentialsFile();
+  }
+  return readTokenFromCredentialsFile();
+}
+
+// Convert API response into the same shape `useAgent.normalizeCodexRateLimits`
+// produces, so the renderer is provider-agnostic. Codex shape:
+//   { five_hour: { used_percent, resets_at: <unix s>, window_minutes }, seven_day: ... }
+function normalizeApiResponse(json) {
+  if (!json || typeof json !== "object") return null;
+  const pickWindow = (w, windowMinutes) => {
+    if (!w || typeof w !== "object") return null;
+    if (!Number.isFinite(w.utilization)) return null;
+    let resetsAt = null;
+    if (typeof w.resets_at === "string") {
+      const ms = Date.parse(w.resets_at);
+      if (Number.isFinite(ms)) resetsAt = Math.floor(ms / 1000);
+    } else if (Number.isFinite(w.resets_at)) {
+      resetsAt = w.resets_at;
+    }
+    return {
+      used_percent: w.utilization,
+      resets_at: resetsAt,
+      window_minutes: windowMinutes,
+    };
+  };
+  const five = pickWindow(json.five_hour, 300);
+  const seven = pickWindow(json.seven_day, 10080);
+  if (!five && !seven) return null;
+  return {
+    ...(five ? { five_hour: five } : {}),
+    ...(seven ? { seven_day: seven } : {}),
+  };
+}
+
+function readFileCache() {
+  try {
+    const stat = fs.statSync(CACHE_FILE);
+    const age = nowSec() - Math.floor(stat.mtimeMs / 1000);
+    if (age >= CACHE_MAX_AGE_S) return null;
+    const raw = fs.readFileSync(CACHE_FILE, "utf8");
+    const parsed = parseJson(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeFileCache(data) {
+  try {
+    ensureCacheDir();
+    fs.writeFileSync(CACHE_FILE, JSON.stringify(data));
+  } catch {}
+}
+
+function readActiveLock() {
+  try {
+    const stat = fs.statSync(LOCK_FILE);
+    const age = nowSec() - Math.floor(stat.mtimeMs / 1000);
+    if (age < LOCK_MAX_AGE_S) {
+      const raw = fs.readFileSync(LOCK_FILE, "utf8");
+      const parsed = parseJson(raw);
+      const blockedUntil = Number.isFinite(parsed?.blockedUntil)
+        ? parsed.blockedUntil
+        : Math.floor(stat.mtimeMs / 1000) + LOCK_MAX_AGE_S;
+      if (blockedUntil > nowSec()) return blockedUntil;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLock(blockedUntil) {
+  try {
+    ensureCacheDir();
+    fs.writeFileSync(LOCK_FILE, JSON.stringify({ blockedUntil }));
+  } catch {}
+}
+
+function parseRetryAfter(headerValue) {
+  if (!headerValue) return null;
+  const v = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  if (!v) return null;
+  const trimmed = v.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = parseInt(trimmed, 10);
+    return seconds > 0 ? seconds : null;
+  }
+  const ms = Date.parse(trimmed);
+  if (Number.isNaN(ms)) return null;
+  const s = Math.ceil((ms - Date.now()) / 1000);
+  return s > 0 ? s : null;
+}
+
+function httpGetUsage(token) {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (val) => {
+      if (settled) return;
+      settled = true;
+      resolve(val);
+    };
+
+    const req = https.request(
+      {
+        hostname: "api.anthropic.com",
+        path: "/api/oauth/usage",
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+        timeout: REQUEST_TIMEOUT_MS,
+      },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          if (res.statusCode === 200) {
+            finish({ kind: "ok", body });
+          } else if (res.statusCode === 429) {
+            finish({
+              kind: "rate-limited",
+              retryAfter: parseRetryAfter(res.headers["retry-after"]) ?? DEFAULT_RATE_LIMIT_BACKOFF_S,
+            });
+          } else {
+            finish({ kind: "error", status: res.statusCode });
+          }
+        });
+      }
+    );
+
+    req.on("error", () => finish({ kind: "error" }));
+    req.on("timeout", () => {
+      req.destroy();
+      finish({ kind: "error" });
+    });
+    req.end();
+  });
+}
+
+// Returns normalized rate-limits object, or null if unavailable (no token,
+// rate-limited, error, etc.). Always resolves — never throws.
+async function fetchClaudeUsage() {
+  const t = nowSec();
+
+  // Memory cache fast path
+  if (memCache !== null && t - memCacheTime < memCacheMaxAge) {
+    return memCache;
+  }
+
+  // File cache (cross-process — multiple Electron windows reuse the same data)
+  const fileCached = readFileCache();
+  if (fileCached) {
+    const normalized = normalizeApiResponse(fileCached);
+    memCache = normalized;
+    memCacheTime = t;
+    memCacheMaxAge = CACHE_MAX_AGE_S;
+    return normalized;
+  }
+
+  // Lock check — recent failure means don't hammer the endpoint
+  if (readActiveLock()) {
+    memCache = null;
+    memCacheTime = t;
+    memCacheMaxAge = LOCK_MAX_AGE_S;
+    return null;
+  }
+
+  const token = getOAuthToken();
+  if (!token) {
+    // No token = API-key user or unconfigured. Cache the null briefly so we
+    // don't re-scan keychain on every turn.
+    memCache = null;
+    memCacheTime = t;
+    memCacheMaxAge = CACHE_MAX_AGE_S;
+    return null;
+  }
+
+  const result = await httpGetUsage(token);
+  if (result.kind === "ok") {
+    const parsed = parseJson(result.body);
+    if (!parsed) {
+      writeLock(t + LOCK_MAX_AGE_S);
+      memCache = null;
+      memCacheTime = t;
+      memCacheMaxAge = LOCK_MAX_AGE_S;
+      return null;
+    }
+    writeFileCache(parsed);
+    const normalized = normalizeApiResponse(parsed);
+    memCache = normalized;
+    memCacheTime = t;
+    memCacheMaxAge = CACHE_MAX_AGE_S;
+    return normalized;
+  }
+
+  if (result.kind === "rate-limited") {
+    const blockedUntil = t + result.retryAfter;
+    writeLock(blockedUntil);
+    log("Rate-limited by usage endpoint, backing off", { seconds: result.retryAfter });
+    memCache = null;
+    memCacheTime = t;
+    memCacheMaxAge = result.retryAfter;
+    return null;
+  }
+
+  // Generic error — short cooldown
+  writeLock(t + LOCK_MAX_AGE_S);
+  memCache = null;
+  memCacheTime = t;
+  memCacheMaxAge = LOCK_MAX_AGE_S;
+  return null;
+}
+
+module.exports = { fetchClaudeUsage };

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -293,7 +293,10 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, f
     if (!line.trim()) return;
     try {
       const event = JSON.parse(line);
-      if (event.type === "turn.completed") {
+      if (
+        event.type === "turn.completed" ||
+        (event.type === "event_msg" && event.payload?.type === "task_complete")
+      ) {
         state.sawTurnCompleted = true;
       }
       log("Parsed event type:", event.type);

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -3,9 +3,11 @@ const path = require("path");
 const fs = require("fs");
 const os = require("os");
 const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
+const { loadSessionMessages } = require("./session-reader.cjs");
 
 const activeAgents = new Map();
 const TERMINAL_CLI_PATH = path.join(__dirname, "../scripts/claudi-terminal.cjs");
+const SESSION_SNAPSHOT_RETRY_DELAYS_MS = [0, 150, 500, 1200, 2500];
 
 function log(...args) {
   console.log("[codex-agent-manager]", ...args);
@@ -24,6 +26,46 @@ function shouldEmitStderrError({ stderrBuffer, exitCode, signal, cancelled, sawT
   if (cancelled) return false;
   if (sawTurnCompleted && exitCode === 0 && !signal) return false;
   return exitCode !== 0 || Boolean(signal) || !sawTurnCompleted;
+}
+
+function scheduleSessionSnapshot(webContents, conversationId, threadId, attempt = 0) {
+  if (!threadId) return;
+
+  const delay = SESSION_SNAPSHOT_RETRY_DELAYS_MS[attempt];
+  if (delay == null) return;
+
+  setTimeout(() => {
+    loadSessionMessages(threadId)
+      .then((result) => {
+        const usage = result?.usageSnapshot || null;
+        const rateLimits = result?.rateLimitsSnapshot || null;
+        if (usage || rateLimits) {
+          if (webContents.isDestroyed?.()) return;
+          log("Emitting Codex session snapshot:", {
+            conversationId,
+            threadId,
+            hasUsage: Boolean(usage),
+            hasRateLimits: Boolean(rateLimits),
+          });
+          webContents.send("agent-stream", {
+            conversationId,
+            event: {
+              type: "session_snapshot",
+              provider: "codex",
+              thread_id: threadId,
+              usage,
+              rate_limits: rateLimits,
+            },
+          });
+          return;
+        }
+
+        scheduleSessionSnapshot(webContents, conversationId, threadId, attempt + 1);
+      })
+      .catch(() => {
+        scheduleSessionSnapshot(webContents, conversationId, threadId, attempt + 1);
+      });
+  }, delay);
 }
 
 let cachedCodexBin = null;
@@ -282,6 +324,7 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, f
     child,
     cancelled: false,
     sawTurnCompleted: false,
+    threadId: null,
   };
 
   activeAgents.set(conversationId, state);
@@ -293,6 +336,11 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, f
     if (!line.trim()) return;
     try {
       const event = JSON.parse(line);
+      if (event.type === "thread.started" && typeof event.thread_id === "string" && event.thread_id) {
+        state.threadId = event.thread_id;
+      } else if (event.type === "session_meta" && typeof event.payload?.id === "string" && event.payload.id) {
+        state.threadId = event.payload.id;
+      }
       if (
         event.type === "turn.completed" ||
         (event.type === "event_msg" && event.payload?.type === "task_complete")
@@ -337,7 +385,13 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, f
     if (state.cancelled) {
       if (isCurrentState) {
         activeAgents.delete(conversationId);
-        webContents.send("agent-done", { conversationId, exitCode, signal });
+        webContents.send("agent-done", {
+          conversationId,
+          exitCode,
+          signal,
+          provider: "codex",
+          threadId: state.threadId,
+        });
       }
       return;
     }
@@ -358,8 +412,16 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, f
       webContents.send("agent-error", { conversationId, error: stderrBuffer.trim() });
     }
 
+    scheduleSessionSnapshot(webContents, conversationId, state.threadId);
+
     activeAgents.delete(conversationId);
-    webContents.send("agent-done", { conversationId, exitCode, signal });
+    webContents.send("agent-done", {
+      conversationId,
+      exitCode,
+      signal,
+      provider: "codex",
+      threadId: state.threadId,
+    });
   });
 
   child.on("error", (err) => {

--- a/electron/session-reader.cjs
+++ b/electron/session-reader.cjs
@@ -136,11 +136,58 @@ function stripCodexSystemContext(text) {
   return trimmed.slice(markerIndex + CODEX_USER_PROMPT_MARKER.length).trim();
 }
 
+function stripCodexImagePreamble(text) {
+  if (typeof text !== "string") return "";
+  return text.replace(/^(?:<image\b[^>]*><\/image>\s*)+/i, "").trim();
+}
+
+function cleanCodexUserMessage(text) {
+  const withoutImages = stripCodexImagePreamble(text);
+  const stripped = stripCodexSystemContext(withoutImages);
+  const cleaned = stripCodexImagePreamble(stripped);
+
+  if (!cleaned || cleaned.startsWith("<environment_context>")) {
+    return "";
+  }
+
+  return cleaned;
+}
+
+function appendCodexUserMessage(messages, text) {
+  const cleaned = cleanCodexUserMessage(text);
+  if (!cleaned) return;
+
+  const lastMsg = messages[messages.length - 1];
+  if (lastMsg?.role === "user" && lastMsg.text === cleaned) return;
+
+  messages.push({
+    id: "u" + Date.now() + Math.random(),
+    role: "user",
+    text: cleaned,
+  });
+}
+
+function normalizeCodexUsageSnapshot(info) {
+  const usage = info?.last_token_usage;
+  if (!usage) return null;
+  return {
+    input_tokens: usage.input_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? 0,
+    total_tokens: usage.total_tokens ?? null,
+    cache_read_input_tokens: usage.cached_input_tokens ?? 0,
+    cache_creation_input_tokens: 0,
+    ...(Number.isFinite(info?.model_context_window)
+      ? { context_window: info.model_context_window }
+      : {}),
+  };
+}
+
 function loadCodexSessionMessages(filePath) {
   const content = fs.readFileSync(filePath, "utf-8");
   const lines = content.split("\n");
   const messages = [];
   let sessionCwd = null;
+  let usageSnapshot = null;
 
   for (const line of lines) {
     if (!line.trim()) continue;
@@ -152,7 +199,16 @@ function loadCodexSessionMessages(filePath) {
       continue;
     }
 
-    if (evt.type === "event_msg") continue;
+    if (evt.type === "event_msg") {
+      if (evt.payload?.type === "token_count" && evt.payload?.info) {
+        const snapshot = normalizeCodexUsageSnapshot(evt.payload.info);
+        if (snapshot) usageSnapshot = snapshot;
+      }
+      if (evt.payload?.type === "user_message" && typeof evt.payload.message === "string") {
+        appendCodexUserMessage(messages, evt.payload.message);
+      }
+      continue;
+    }
 
     if (evt.type === "response_item" && evt.payload?.role === "user") {
       let text = "";
@@ -163,15 +219,7 @@ function loadCodexSessionMessages(filePath) {
           }
         }
       }
-      // Skip system injections
-      const trimmed = stripCodexSystemContext(text);
-      if (!trimmed || trimmed.startsWith("<") || trimmed.startsWith("#")) continue;
-
-      messages.push({
-        id: "u" + Date.now() + Math.random(),
-        role: "user",
-        text: trimmed,
-      });
+      appendCodexUserMessage(messages, text);
     } else if (
       evt.type === "response_item" &&
       evt.payload?.type === "message" &&
@@ -204,7 +252,15 @@ function loadCodexSessionMessages(filePath) {
   }
 
   const result = messages.length > MAX_MESSAGES ? messages.slice(-MAX_MESSAGES) : messages;
-  return { messages: result, cwd: sessionCwd, provider: "codex" };
+  if (usageSnapshot) {
+    for (let i = result.length - 1; i >= 0; i -= 1) {
+      if (result[i]?.role === "assistant") {
+        result[i] = { ...result[i], _usage: usageSnapshot };
+        break;
+      }
+    }
+  }
+  return { messages: result, cwd: sessionCwd, provider: "codex", usageSnapshot };
 }
 
 async function listSessions(cwd) {

--- a/electron/session-reader.cjs
+++ b/electron/session-reader.cjs
@@ -168,17 +168,29 @@ function appendCodexUserMessage(messages, text) {
 }
 
 function normalizeCodexUsageSnapshot(info) {
-  const usage = info?.last_token_usage;
+  const usage = info?.last_token_usage || info?.total_token_usage;
   if (!usage) return null;
   return {
     input_tokens: usage.input_tokens ?? 0,
     output_tokens: usage.output_tokens ?? 0,
     total_tokens: usage.total_tokens ?? null,
-    cache_read_input_tokens: usage.cached_input_tokens ?? 0,
-    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: usage.cached_input_tokens ?? usage.cache_read_input_tokens ?? 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
     ...(Number.isFinite(info?.model_context_window)
       ? { context_window: info.model_context_window }
       : {}),
+  };
+}
+
+function normalizeLegacyCodexTurnUsage(usage, contextWindow) {
+  if (!usage) return null;
+  return {
+    input_tokens: usage.input_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? 0,
+    total_tokens: usage.total_tokens ?? null,
+    cache_read_input_tokens: usage.cached_input_tokens ?? usage.cache_read_input_tokens ?? 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+    ...(Number.isFinite(contextWindow) ? { context_window: contextWindow } : {}),
   };
 }
 
@@ -188,6 +200,7 @@ function loadCodexSessionMessages(filePath) {
   const messages = [];
   let sessionCwd = null;
   let usageSnapshot = null;
+  let modelContextWindow = null;
 
   for (const line of lines) {
     if (!line.trim()) continue;
@@ -200,14 +213,25 @@ function loadCodexSessionMessages(filePath) {
     }
 
     if (evt.type === "event_msg") {
+      if (evt.payload?.type === "task_started" && Number.isFinite(evt.payload?.model_context_window)) {
+        modelContextWindow = evt.payload.model_context_window;
+      }
       if (evt.payload?.type === "token_count" && evt.payload?.info) {
         const snapshot = normalizeCodexUsageSnapshot(evt.payload.info);
         if (snapshot) usageSnapshot = snapshot;
+        if (Number.isFinite(evt.payload.info?.model_context_window)) {
+          modelContextWindow = evt.payload.info.model_context_window;
+        }
       }
       if (evt.payload?.type === "user_message" && typeof evt.payload.message === "string") {
         appendCodexUserMessage(messages, evt.payload.message);
       }
       continue;
+    }
+
+    if (evt.type === "turn.completed" && !usageSnapshot && evt.usage) {
+      const snapshot = normalizeLegacyCodexTurnUsage(evt.usage, modelContextWindow);
+      if (snapshot) usageSnapshot = snapshot;
     }
 
     if (evt.type === "response_item" && evt.payload?.role === "user") {

--- a/electron/session-reader.cjs
+++ b/electron/session-reader.cjs
@@ -182,6 +182,27 @@ function normalizeCodexUsageSnapshot(info) {
   };
 }
 
+function normalizeCodexRateLimitsSnapshot(rateLimits) {
+  if (!rateLimits || typeof rateLimits !== "object") return null;
+  const pickWindow = (window) => {
+    if (!window || typeof window !== "object") return null;
+    if (!Number.isFinite(window.used_percent)) return null;
+    return {
+      used_percent: window.used_percent,
+      resets_at: Number.isFinite(window.resets_at) ? window.resets_at : null,
+      window_minutes: Number.isFinite(window.window_minutes) ? window.window_minutes : null,
+    };
+  };
+  const five = pickWindow(rateLimits.primary);
+  const seven = pickWindow(rateLimits.secondary);
+  if (!five && !seven) return null;
+  return {
+    ...(five ? { five_hour: five } : {}),
+    ...(seven ? { seven_day: seven } : {}),
+    ...(rateLimits.plan_type ? { plan_type: rateLimits.plan_type } : {}),
+  };
+}
+
 function normalizeLegacyCodexTurnUsage(usage, contextWindow) {
   if (!usage) return null;
   return {
@@ -200,6 +221,7 @@ function loadCodexSessionMessages(filePath) {
   const messages = [];
   let sessionCwd = null;
   let usageSnapshot = null;
+  let rateLimitsSnapshot = null;
   let modelContextWindow = null;
 
   for (const line of lines) {
@@ -222,6 +244,10 @@ function loadCodexSessionMessages(filePath) {
         if (Number.isFinite(evt.payload.info?.model_context_window)) {
           modelContextWindow = evt.payload.info.model_context_window;
         }
+      }
+      if (evt.payload?.type === "token_count" && evt.payload?.rate_limits) {
+        const snapshot = normalizeCodexRateLimitsSnapshot(evt.payload.rate_limits);
+        if (snapshot) rateLimitsSnapshot = snapshot;
       }
       if (evt.payload?.type === "user_message" && typeof evt.payload.message === "string") {
         appendCodexUserMessage(messages, evt.payload.message);
@@ -276,15 +302,19 @@ function loadCodexSessionMessages(filePath) {
   }
 
   const result = messages.length > MAX_MESSAGES ? messages.slice(-MAX_MESSAGES) : messages;
-  if (usageSnapshot) {
+  if (usageSnapshot || rateLimitsSnapshot) {
     for (let i = result.length - 1; i >= 0; i -= 1) {
       if (result[i]?.role === "assistant") {
-        result[i] = { ...result[i], _usage: usageSnapshot };
+        result[i] = {
+          ...result[i],
+          ...(usageSnapshot ? { _usage: usageSnapshot } : {}),
+          ...(rateLimitsSnapshot ? { _rateLimits: rateLimitsSnapshot } : {}),
+        };
         break;
       }
     }
   }
-  return { messages: result, cwd: sessionCwd, provider: "codex", usageSnapshot };
+  return { messages: result, cwd: sessionCwd, provider: "codex", usageSnapshot, rateLimitsSnapshot };
 }
 
 async function listSessions(cwd) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -338,11 +338,17 @@ function buildProviderSessionLookup(sessions) {
   return providerSessions;
 }
 
+function stripTransientMessageState(message) {
+  if (!message || typeof message !== "object") return message;
+  const { _rateLimits, ...next } = message;
+  return next;
+}
+
 function normalizeConversationState(conversation) {
   if (!conversation) return conversation;
 
   const archivedMessages = Array.isArray(conversation.archivedMessages)
-    ? conversation.archivedMessages
+    ? conversation.archivedMessages.map(stripTransientMessageState)
     : [];
   const archivedMessageCount = archivedMessages.length;
   const sessionMap = new Map();
@@ -621,21 +627,8 @@ function serializeMessagesForState(messages) {
     if (Array.isArray(message.images) && message.images.length > 0) next.images = message.images;
     if (Array.isArray(message.files) && message.files.length > 0) next.files = message.files;
     if (message.claudeUuid) next.claudeUuid = message.claudeUuid;
+    if (message._usage) next._usage = message._usage;
     if (message._elapsedMs != null) next._elapsedMs = message._elapsedMs;
-    if (message._usage && typeof message._usage === "object") {
-      const usage = {};
-      for (const key of [
-        "input_tokens",
-        "output_tokens",
-        "total_tokens",
-        "cache_creation_input_tokens",
-        "cache_read_input_tokens",
-        "context_window",
-      ]) {
-        if (Number.isFinite(message._usage[key])) usage[key] = message._usage[key];
-      }
-      if (Object.keys(usage).length > 0) next._usage = usage;
-    }
     return next;
   });
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -621,8 +621,74 @@ function serializeMessagesForState(messages) {
     if (Array.isArray(message.images) && message.images.length > 0) next.images = message.images;
     if (Array.isArray(message.files) && message.files.length > 0) next.files = message.files;
     if (message.claudeUuid) next.claudeUuid = message.claudeUuid;
+    if (message._elapsedMs != null) next._elapsedMs = message._elapsedMs;
+    if (message._usage && typeof message._usage === "object") {
+      const usage = {};
+      for (const key of [
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "context_window",
+      ]) {
+        if (Number.isFinite(message._usage[key])) usage[key] = message._usage[key];
+      }
+      if (Object.keys(usage).length > 0) next._usage = usage;
+    }
     return next;
   });
+}
+
+function getArchivedMessageText(message) {
+  if (!message) return "";
+  if (typeof message.text === "string") return message.text.trim();
+  if (!Array.isArray(message.parts)) return "";
+  return message.parts
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n")
+    .trim();
+}
+
+function getArchivedMessageSignature(message) {
+  const normalizedText = getArchivedMessageText(message).replace(/\s+/g, " ").slice(0, 400);
+  return [
+    message?.role || "",
+    message?.mode || "",
+    message?.command || "",
+    message?.exitCode ?? "",
+    Array.isArray(message?.images) ? message.images.length : 0,
+    Array.isArray(message?.files) ? message.files.length : 0,
+    normalizedText,
+  ].join("|");
+}
+
+function mergeArchivedMessages(existingMessages, loadedMessages) {
+  const existing = Array.isArray(existingMessages) ? existingMessages : [];
+  const loaded = Array.isArray(loadedMessages) ? loadedMessages : [];
+
+  if (loaded.length === 0) return existing;
+  if (existing.length === 0) return loaded;
+
+  const existingSignatures = existing.map(getArchivedMessageSignature);
+  const loadedSignatures = loaded.map(getArchivedMessageSignature);
+  const maxOverlap = Math.min(existingSignatures.length, loadedSignatures.length);
+
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    let matches = true;
+    for (let i = 0; i < overlap; i += 1) {
+      if (existingSignatures[existingSignatures.length - overlap + i] !== loadedSignatures[i]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return [...existing, ...loaded.slice(overlap)];
+    }
+  }
+
+  return loaded.length > existing.length ? loaded : existing;
 }
 
 export default function App() {
@@ -940,6 +1006,7 @@ export default function App() {
           providerSessions: convo.providerSessions || null,
         });
         if (msgs && msgs.length > 0) {
+          const serializedSessionMessages = serializeMessagesForState(msgs);
           if (data.messages.length === 0) {
             // For forked conversations, only load messages up to the fork point
             loadMessages(id, msgs);
@@ -975,7 +1042,7 @@ export default function App() {
                 ...next,
                 ...(previewText ? { lastPreview: previewText.slice(0, 60) } : {}),
                 ...(sessionCwd ? { cwd: sessionCwd } : {}),
-                archivedMessages: serializeMessagesForState(msgs),
+                archivedMessages: mergeArchivedMessages(c.archivedMessages, serializedSessionMessages),
               });
             })
           );
@@ -1033,6 +1100,7 @@ export default function App() {
           const result = await window.api.loadSession(sessionIdToLoad);
           const { msgs, sessionCwd, sessionProvider } = extractLoadedSessionMeta(result);
           if (msgs && msgs.length > 0) {
+            const serializedSessionMessages = serializeMessagesForState(msgs);
             const lastMsg = msgs[msgs.length - 1];
             const previewText = lastMsg?.parts
               ? lastMsg.parts.filter(p => p.type === "text").map(p => p.text).join(" ")
@@ -1064,7 +1132,7 @@ export default function App() {
                   ...next,
                   ...(previewText ? { lastPreview: previewText.slice(0, 60) } : {}),
                   ...(sessionCwd && !cv.cwd ? { cwd: sessionCwd } : {}),
-                  archivedMessages: serializeMessagesForState(msgs),
+                  archivedMessages: mergeArchivedMessages(cv.archivedMessages, serializedSessionMessages),
                 });
               })
             );

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -397,6 +397,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               <Message
                 key={m.id}
                 msg={m}
+                modelId={convo?.model || defaultModel}
                 onEdit={m.role === "user" && m.mode !== "shell-command" ? (newText) => onEdit(i, newText) : undefined}
                 onAnswer={m.role === "assistant" ? (text) => onSend(text) : undefined}
                 onControlChange={m.role === "assistant" ? onControlChange : undefined}

--- a/src/components/LoadingStatus.jsx
+++ b/src/components/LoadingStatus.jsx
@@ -44,6 +44,25 @@ function formatDuration(ms) {
   return `${m}:${String(r).padStart(2, "0")}`;
 }
 
+// Coarse "resets in" label for plan-quota windows (5h / 7d).
+// resetsAtSec is unix epoch seconds; nowMs is wall clock (param so the
+// component can re-render against its existing `now` tick).
+function formatResetIn(resetsAtSec, nowMs) {
+  if (!Number.isFinite(resetsAtSec)) return null;
+  const remaining = resetsAtSec * 1000 - nowMs;
+  if (remaining <= 0) return "now";
+  const min = Math.floor(remaining / 60000);
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  if (h < 24) {
+    const m = min % 60;
+    return m ? `${h}h ${m}m` : `${h}h`;
+  }
+  const d = Math.floor(h / 24);
+  const r = h % 24;
+  return r ? `${d}d ${r}h` : `${d}d`;
+}
+
 // Slash+dot spinner — keeps the RayLine logo's "/•" geometry but in a muted
 // whitish ink so it doesn't clash with the message ambiance. Both elements
 // pulse out of phase to keep a live feel while staying quiet.
@@ -93,7 +112,7 @@ function SlashSpinner() {
   );
 }
 
-export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, usage, isStreaming, modelId, compacting }) {
+export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, usage, rateLimits, isStreaming, modelId, compacting }) {
   const s = useFontScale();
   const [now, setNow] = useState(() => Date.now());
   const [phraseIdx, setPhraseIdx] = useState(0);
@@ -151,8 +170,13 @@ export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, u
 
   const hasUsage = contextUsed > 0 && !isLikelyCumulativeCodexUsage;
 
+  const fiveHour = rateLimits?.five_hour;
+  const sevenDay = rateLimits?.seven_day;
+  const hasRateLimits =
+    Number.isFinite(fiveHour?.used_percent) || Number.isFinite(sevenDay?.used_percent);
+
   // Nothing to say after completion if we never captured any stats.
-  if (!isStreaming && !hasUsage && !startedAt && frozenElapsedMs == null) return null;
+  if (!isStreaming && !hasUsage && !hasRateLimits && !startedAt && frozenElapsedMs == null) return null;
 
   const elapsedLabel = formatDuration(elapsedMs);
   const pctLabel = contextPct.toFixed(contextPct >= 10 || contextPct === 0 ? 0 : 1) + "%";
@@ -257,6 +281,42 @@ export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, u
           </span>
         </div>
       )}
+
+      {/* Line 3: plan quota windows (5h rolling + 7d weekly).
+          Codex sourced from `event_msg.token_count.rate_limits`. Claude Code
+          sourced from `api.anthropic.com/api/oauth/usage` (Pro/Max only —
+          API-key users have no token, so the line silently hides). */}
+      {hasRateLimits && (
+        <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", color: secondaryColor, fontVariantNumeric: "tabular-nums" }}>
+          {Number.isFinite(fiveHour?.used_percent) && (
+            <PlanQuota label="5h" pct={fiveHour.used_percent} resetIn={formatResetIn(fiveHour.resets_at, now)} />
+          )}
+          {Number.isFinite(fiveHour?.used_percent) && Number.isFinite(sevenDay?.used_percent) && sep}
+          {Number.isFinite(sevenDay?.used_percent) && (
+            <PlanQuota label="7d" pct={sevenDay.used_percent} resetIn={formatResetIn(sevenDay.resets_at, now)} />
+          )}
+        </div>
+      )}
     </div>
+  );
+}
+
+// Single plan-quota chip: "5h 100% · resets 4h 12m"
+// Saturated quota (≥95%) gets a warmer ink so it reads at a glance, but stays
+// within the existing muted palette — no full red.
+function PlanQuota({ label, pct, resetIn }) {
+  const saturated = pct >= 95;
+  const pctInk = saturated ? "rgba(255,180,180,0.78)" : "rgba(255,255,255,0.55)";
+  const pctLabel = pct.toFixed(pct >= 10 || pct === 0 ? 0 : 1) + "%";
+  return (
+    <span>
+      <span style={{ color: "rgba(255,255,255,0.22)" }}>{label} </span>
+      <span style={{ color: pctInk }}>{pctLabel}</span>
+      {resetIn && (
+        <span style={{ color: "rgba(255,255,255,0.22)", marginLeft: 6 }}>
+          resets {resetIn}
+        </span>
+      )}
+    </span>
   );
 }

--- a/src/components/LoadingStatus.jsx
+++ b/src/components/LoadingStatus.jsx
@@ -20,6 +20,10 @@ const CONTEXT_WINDOW = 200_000;
 
 const PHRASE_INTERVAL_MS = 2400;
 
+// Muted spinner ink — keeps the logo's slash+dot geometry but drops the red
+// accent so the indicator stays quiet in the message vibe.
+const SPINNER_INK = "rgba(255,255,255,0.55)";
+
 function formatCompact(n) {
   if (!n && n !== 0) return "0";
   if (n < 1000) return String(n);
@@ -39,28 +43,56 @@ function formatDuration(ms) {
   return `${m}:${String(r).padStart(2, "0")}`;
 }
 
-// Inline dot spinner — three dots pulsing in sequence.
-function DotSpinner() {
+// Slash+dot spinner — keeps the RayLine logo's "/•" geometry but in a muted
+// whitish ink so it doesn't clash with the message ambiance. Both elements
+// pulse out of phase to keep a live feel while staying quiet.
+function SlashSpinner() {
   return (
-    <span style={{ display: "inline-flex", gap: 3, alignItems: "center", flexShrink: 0 }}>
-      {[0, 1, 2].map((i) => (
-        <span
-          key={i}
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        flexShrink: 0,
+        width: 16,
+        height: 14,
+      }}
+      aria-hidden="true"
+    >
+      <svg
+        width="16"
+        height="14"
+        viewBox="0 0 16 14"
+        style={{ overflow: "visible" }}
+      >
+        {/* Slash — same angle as the logo (upper-right to lower-left). */}
+        <line
+          x1="8"
+          y1="1.5"
+          x2="2"
+          y2="12.5"
+          stroke={SPINNER_INK}
+          strokeWidth="2"
+          strokeLinecap="square"
+          style={{ animation: "slashPulse 1.4s ease-in-out infinite" }}
+        />
+        {/* Dot — trailing accent that echoes the logo's period. */}
+        <circle
+          cx="13"
+          cy="11.5"
+          r="1.5"
+          fill={SPINNER_INK}
           style={{
-            width: 4,
-            height: 4,
-            borderRadius: "50%",
-            background: "rgba(255,255,255,0.55)",
-            display: "inline-block",
-            animation: `dotPulse 1.2s ease-in-out ${i * 0.2}s infinite`,
+            animation: "slashDot 1.4s ease-in-out 0.35s infinite",
+            transformOrigin: "center",
+            transformBox: "fill-box",
           }}
         />
-      ))}
+      </svg>
     </span>
   );
 }
 
-export default function LoadingStatus({ startedAt, usage, isStreaming }) {
+export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, usage, isStreaming }) {
   const s = useFontScale();
   const [now, setNow] = useState(() => Date.now());
   const [phraseIdx, setPhraseIdx] = useState(0);
@@ -80,16 +112,18 @@ export default function LoadingStatus({ startedAt, usage, isStreaming }) {
     };
   }, [isStreaming]);
 
-  // Freeze elapsed at stream end so the persistent footer shows total runtime.
+  // Freeze elapsed at stream end (same mount) so the footer shows total runtime.
   useEffect(() => {
     if (!isStreaming && startedAt && finalElapsedRef.current == null) {
       finalElapsedRef.current = Date.now() - startedAt;
     }
   }, [isStreaming, startedAt]);
 
+  // Prefer a persisted elapsed value from the message itself — this survives
+  // reloads, whereas `Date.now() - _startedAt` would drift across sessions.
   const elapsedMs = isStreaming
     ? (startedAt ? now - startedAt : 0)
-    : (finalElapsedRef.current ?? (startedAt ? Date.now() - startedAt : 0));
+    : (frozenElapsedMs ?? finalElapsedRef.current ?? 0);
 
   const inputTokens = usage?.input_tokens || 0;
   const outputTokens = usage?.output_tokens || 0;
@@ -103,7 +137,7 @@ export default function LoadingStatus({ startedAt, usage, isStreaming }) {
   const hasUsage = contextUsed > 0;
 
   // Nothing to say after completion if we never captured any stats.
-  if (!isStreaming && !hasUsage && !startedAt) return null;
+  if (!isStreaming && !hasUsage && !startedAt && frozenElapsedMs == null) return null;
 
   const elapsedLabel = formatDuration(elapsedMs);
   const pctLabel = contextPct.toFixed(contextPct >= 10 || contextPct === 0 ? 0 : 1) + "%";
@@ -111,8 +145,19 @@ export default function LoadingStatus({ startedAt, usage, isStreaming }) {
   const primary = isStreaming ? PHRASES[phraseIdx] : "Done";
   const primaryColor = isStreaming ? "rgba(255,255,255,0.72)" : "rgba(255,255,255,0.38)";
   const secondaryColor = "rgba(255,255,255,0.32)";
+  // Stat separator — subtle skewed slash glyph in neutral dim.
   const sep = (
-    <span style={{ color: "rgba(255,255,255,0.18)", margin: "0 6px" }}>·</span>
+    <span
+      aria-hidden="true"
+      style={{
+        color: "rgba(255,255,255,0.22)",
+        margin: "0 6px",
+        transform: "skewX(-18deg)",
+        display: "inline-block",
+      }}
+    >
+      /
+    </span>
   );
 
   return (
@@ -130,9 +175,19 @@ export default function LoadingStatus({ startedAt, usage, isStreaming }) {
         lineHeight: 1.55,
       }}
     >
-      {/* Line 1: spinner + phrase + elapsed */}
+      <style>{`
+        @keyframes slashPulse {
+          0%, 100% { opacity: 1; }
+          50%      { opacity: 0.35; }
+        }
+        @keyframes slashDot {
+          0%, 100% { opacity: 1; transform: scale(1); }
+          50%      { opacity: 0.35; transform: scale(0.7); }
+        }
+      `}</style>
+      {/* Line 1: slash spinner + phrase + elapsed */}
       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-        {isStreaming && <DotSpinner />}
+        {isStreaming && <SlashSpinner />}
         <span style={{ color: primaryColor }}>
           {primary}
           {isStreaming && (

--- a/src/components/LoadingStatus.jsx
+++ b/src/components/LoadingStatus.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useFontScale } from "../contexts/FontSizeContext";
+import { getM } from "../data/models";
 
 // Hard-coded rotating status phrases — cycles while the agent is working.
 const PHRASES = [
@@ -15,8 +16,8 @@ const PHRASES = [
   "Synthesizing",
 ];
 
-// Context window size in tokens. Claude Sonnet/Opus default to 200k.
-const CONTEXT_WINDOW = 200_000;
+// Fallback context window when no model is known. Claude Sonnet/Opus defaults.
+const DEFAULT_CONTEXT_WINDOW = 200_000;
 
 const PHRASE_INTERVAL_MS = 2400;
 
@@ -92,7 +93,7 @@ function SlashSpinner() {
   );
 }
 
-export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, usage, isStreaming }) {
+export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, usage, isStreaming, modelId, compacting }) {
   const s = useFontScale();
   const [now, setNow] = useState(() => Date.now());
   const [phraseIdx, setPhraseIdx] = useState(0);
@@ -125,16 +126,30 @@ export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, u
     ? (startedAt ? now - startedAt : 0)
     : (frozenElapsedMs ?? finalElapsedRef.current ?? 0);
 
+  const model = modelId ? getM(modelId) : null;
+  const isCodex = model?.provider === "codex";
   const inputTokens = usage?.input_tokens || 0;
   const outputTokens = usage?.output_tokens || 0;
   const cacheRead = usage?.cache_read_input_tokens || 0;
   const cacheCreate = usage?.cache_creation_input_tokens || 0;
-  const contextUsed = inputTokens + cacheRead + cacheCreate + outputTokens;
+  const derivedContextUsed = isCodex
+    ? inputTokens + outputTokens
+    : inputTokens + cacheRead + cacheCreate + outputTokens;
+  const contextUsed = Number.isFinite(usage?.total_tokens) && usage.total_tokens > 0
+    ? usage.total_tokens
+    : derivedContextUsed;
+  const configuredContextWindow = model?.contextWindow || DEFAULT_CONTEXT_WINDOW;
+  const contextWindow = usage?.context_window || configuredContextWindow;
+  const hasExplicitContextWindow = Number.isFinite(usage?.context_window);
+  const isLikelyCumulativeCodexUsage =
+    isCodex &&
+    !hasExplicitContextWindow &&
+    contextUsed > configuredContextWindow * 1.2;
   const contextPct = contextUsed
-    ? Math.max(0, Math.min(100, (contextUsed / CONTEXT_WINDOW) * 100))
+    ? Math.max(0, Math.min(100, (contextUsed / contextWindow) * 100))
     : 0;
 
-  const hasUsage = contextUsed > 0;
+  const hasUsage = contextUsed > 0 && !isLikelyCumulativeCodexUsage;
 
   // Nothing to say after completion if we never captured any stats.
   if (!isStreaming && !hasUsage && !startedAt && frozenElapsedMs == null) return null;
@@ -184,6 +199,10 @@ export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, u
           0%, 100% { opacity: 1; transform: scale(1); }
           50%      { opacity: 0.35; transform: scale(0.7); }
         }
+        @keyframes compactSpin {
+          from { transform: rotate(0deg); }
+          to   { transform: rotate(360deg); }
+        }
       `}</style>
       {/* Line 1: slash spinner + phrase + elapsed */}
       <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
@@ -197,6 +216,15 @@ export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, u
         <span style={{ color: secondaryColor, fontVariantNumeric: "tabular-nums" }}>
           {elapsedLabel}
         </span>
+        {isStreaming && compacting && (
+          <span
+            title="Claude Code is auto-compacting earlier context."
+            style={{ display: "inline-flex", alignItems: "center", gap: 4, color: "rgba(255,255,255,0.55)" }}
+          >
+            <span style={{ display: "inline-block", animation: "compactSpin 1.6s linear infinite" }}>↻</span>
+            compacting
+          </span>
+        )}
       </div>
 
       {/* Line 2: token breakdown + context */}
@@ -224,7 +252,7 @@ export default function LoadingStatus({ startedAt, elapsedMs: frozenElapsedMs, u
           <span>
             <span style={{ color: "rgba(255,255,255,0.22)" }}>ctx </span>
             {formatCompact(contextUsed)}
-            <span style={{ color: "rgba(255,255,255,0.22)" }}>/{formatCompact(CONTEXT_WINDOW)}</span>
+            <span style={{ color: "rgba(255,255,255,0.22)" }}>/{formatCompact(contextWindow)}</span>
             <span style={{ marginLeft: 5, color: "rgba(255,255,255,0.42)" }}>{pctLabel}</span>
           </span>
         </div>

--- a/src/components/LoadingStatus.jsx
+++ b/src/components/LoadingStatus.jsx
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState } from "react";
+import { useFontScale } from "../contexts/FontSizeContext";
+
+// Hard-coded rotating status phrases — cycles while the agent is working.
+const PHRASES = [
+  "Thinking",
+  "Pondering",
+  "Wrangling context",
+  "Connecting dots",
+  "Cross-referencing",
+  "Weighing options",
+  "Drafting",
+  "Composing",
+  "Tracing logic",
+  "Synthesizing",
+];
+
+// Context window size in tokens. Claude Sonnet/Opus default to 200k.
+const CONTEXT_WINDOW = 200_000;
+
+const PHRASE_INTERVAL_MS = 2400;
+
+function formatCompact(n) {
+  if (!n && n !== 0) return "0";
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) {
+    const v = n / 1000;
+    return (v >= 100 ? v.toFixed(0) : v.toFixed(1)) + "k";
+  }
+  const v = n / 1_000_000;
+  return (v >= 100 ? v.toFixed(0) : v.toFixed(1)) + "M";
+}
+
+function formatDuration(ms) {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${String(r).padStart(2, "0")}`;
+}
+
+// Inline dot spinner — three dots pulsing in sequence.
+function DotSpinner() {
+  return (
+    <span style={{ display: "inline-flex", gap: 3, alignItems: "center", flexShrink: 0 }}>
+      {[0, 1, 2].map((i) => (
+        <span
+          key={i}
+          style={{
+            width: 4,
+            height: 4,
+            borderRadius: "50%",
+            background: "rgba(255,255,255,0.55)",
+            display: "inline-block",
+            animation: `dotPulse 1.2s ease-in-out ${i * 0.2}s infinite`,
+          }}
+        />
+      ))}
+    </span>
+  );
+}
+
+export default function LoadingStatus({ startedAt, usage, isStreaming }) {
+  const s = useFontScale();
+  const [now, setNow] = useState(() => Date.now());
+  const [phraseIdx, setPhraseIdx] = useState(0);
+  const phraseRef = useRef(0);
+  const finalElapsedRef = useRef(null);
+
+  useEffect(() => {
+    if (!isStreaming) return;
+    const tick = setInterval(() => setNow(Date.now()), 250);
+    const cycle = setInterval(() => {
+      phraseRef.current = (phraseRef.current + 1) % PHRASES.length;
+      setPhraseIdx(phraseRef.current);
+    }, PHRASE_INTERVAL_MS);
+    return () => {
+      clearInterval(tick);
+      clearInterval(cycle);
+    };
+  }, [isStreaming]);
+
+  // Freeze elapsed at stream end so the persistent footer shows total runtime.
+  useEffect(() => {
+    if (!isStreaming && startedAt && finalElapsedRef.current == null) {
+      finalElapsedRef.current = Date.now() - startedAt;
+    }
+  }, [isStreaming, startedAt]);
+
+  const elapsedMs = isStreaming
+    ? (startedAt ? now - startedAt : 0)
+    : (finalElapsedRef.current ?? (startedAt ? Date.now() - startedAt : 0));
+
+  const inputTokens = usage?.input_tokens || 0;
+  const outputTokens = usage?.output_tokens || 0;
+  const cacheRead = usage?.cache_read_input_tokens || 0;
+  const cacheCreate = usage?.cache_creation_input_tokens || 0;
+  const contextUsed = inputTokens + cacheRead + cacheCreate + outputTokens;
+  const contextPct = contextUsed
+    ? Math.max(0, Math.min(100, (contextUsed / CONTEXT_WINDOW) * 100))
+    : 0;
+
+  const hasUsage = contextUsed > 0;
+
+  // Nothing to say after completion if we never captured any stats.
+  if (!isStreaming && !hasUsage && !startedAt) return null;
+
+  const elapsedLabel = formatDuration(elapsedMs);
+  const pctLabel = contextPct.toFixed(contextPct >= 10 || contextPct === 0 ? 0 : 1) + "%";
+
+  const primary = isStreaming ? PHRASES[phraseIdx] : "Done";
+  const primaryColor = isStreaming ? "rgba(255,255,255,0.72)" : "rgba(255,255,255,0.38)";
+  const secondaryColor = "rgba(255,255,255,0.32)";
+  const sep = (
+    <span style={{ color: "rgba(255,255,255,0.18)", margin: "0 6px" }}>·</span>
+  );
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        margin: "6px 0 2px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        fontFamily: "'JetBrains Mono',monospace",
+        fontSize: s(11),
+        letterSpacing: ".02em",
+        lineHeight: 1.55,
+      }}
+    >
+      {/* Line 1: spinner + phrase + elapsed */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        {isStreaming && <DotSpinner />}
+        <span style={{ color: primaryColor }}>
+          {primary}
+          {isStreaming && (
+            <span style={{ color: "rgba(255,255,255,0.35)", marginLeft: 2 }}>…</span>
+          )}
+        </span>
+        <span style={{ color: secondaryColor, fontVariantNumeric: "tabular-nums" }}>
+          {elapsedLabel}
+        </span>
+      </div>
+
+      {/* Line 2: token breakdown + context */}
+      {hasUsage && (
+        <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", color: secondaryColor, fontVariantNumeric: "tabular-nums" }}>
+          <span>
+            <span style={{ color: "rgba(255,255,255,0.22)" }}>in </span>
+            {formatCompact(inputTokens)}
+          </span>
+          {sep}
+          <span>
+            <span style={{ color: "rgba(255,255,255,0.22)" }}>out </span>
+            {formatCompact(outputTokens)}
+          </span>
+          {(cacheRead + cacheCreate) > 0 && (
+            <>
+              {sep}
+              <span>
+                <span style={{ color: "rgba(255,255,255,0.22)" }}>cached </span>
+                {formatCompact(cacheRead + cacheCreate)}
+              </span>
+            </>
+          )}
+          {sep}
+          <span>
+            <span style={{ color: "rgba(255,255,255,0.22)" }}>ctx </span>
+            {formatCompact(contextUsed)}
+            <span style={{ color: "rgba(255,255,255,0.22)" }}>/{formatCompact(CONTEXT_WINDOW)}</span>
+            <span style={{ marginLeft: 5, color: "rgba(255,255,255,0.42)" }}>{pctLabel}</span>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -16,6 +16,7 @@ import MermaidBlock from "./MermaidBlock";
 import InteractiveBlock from "./InteractiveBlock";
 import ThinkingBlock from "./ThinkingBlock";
 import ValueControlBlock from "./ValueControlBlock";
+import LoadingStatus from "./LoadingStatus";
 import { useFontScale } from "../contexts/FontSizeContext";
 
 // Allow SVG tags in markdown (rehype-sanitize schema)
@@ -664,18 +665,12 @@ export default function Message({ msg, onEdit, onAnswer, onControlChange, canCon
         <ThinkingBlock text="" isThinking={true} />
       )}
 
-      {msg.isStreaming && !msg.isThinking && (msg.parts || []).length === 0 && (
-        <div style={{ display: "flex", gap: 5, alignItems: "center", padding: "4px 0" }}>
-          {[0, 1, 2].map(i => (
-            <span key={i} style={{
-              width: 5, height: 5,
-              borderRadius: "50%",
-              background: "rgba(255,255,255,0.25)",
-              display: "inline-block",
-              animation: `dotPulse 1.2s ease-in-out ${i * 0.2}s infinite`,
-            }} />
-          ))}
-        </div>
+      {(msg.isStreaming || msg._usage || msg._startedAt) && (
+        <LoadingStatus
+          startedAt={msg._startedAt}
+          usage={msg._usage}
+          isStreaming={Boolean(msg.isStreaming)}
+        />
       )}
 
       {/* Fallback for old format messages (text + toolCalls) */}

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -270,7 +270,7 @@ function renderControlAwareMarkdown({
   });
 }
 
-export default function Message({ msg, onEdit, onAnswer, onControlChange, canControlTarget }) {
+export default function Message({ msg, modelId, onEdit, onAnswer, onControlChange, canControlTarget }) {
   const s = useFontScale();
   const scaledMdStatic = useMemo(() => makeMdComponents(false, s, onAnswer, onControlChange, canControlTarget), [canControlTarget, onAnswer, onControlChange, s]);
   const scaledMdStreaming = useMemo(() => makeMdComponents(true, s, onAnswer, onControlChange, canControlTarget), [canControlTarget, onAnswer, onControlChange, s]);
@@ -666,6 +666,8 @@ export default function Message({ msg, onEdit, onAnswer, onControlChange, canCon
           elapsedMs={msg._elapsedMs}
           usage={msg._usage}
           isStreaming={Boolean(msg.isStreaming)}
+          modelId={modelId}
+          compacting={Boolean(msg._compacting)}
         />
       )}
 

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -660,11 +660,12 @@ export default function Message({ msg, modelId, onEdit, onAnswer, onControlChang
         <ThinkingBlock text="" isThinking={true} />
       )}
 
-      {(msg.isStreaming || msg._usage || msg._startedAt || msg._elapsedMs != null) && (
+      {(msg.isStreaming || msg._usage || msg._rateLimits || msg._startedAt || msg._elapsedMs != null) && (
         <LoadingStatus
           startedAt={msg._startedAt}
           elapsedMs={msg._elapsedMs}
           usage={msg._usage}
+          rateLimits={msg._rateLimits}
           isStreaming={Boolean(msg.isStreaming)}
           modelId={modelId}
           compacting={Boolean(msg._compacting)}

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { Pencil, Loader2, FileText, PauseCircle, Terminal } from "lucide-react";
+import { Pencil, FileText, PauseCircle, Terminal } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -592,11 +592,6 @@ export default function Message({ msg, onEdit, onAnswer, onControlChange, canCon
                 onControlChange,
                 canControlTarget,
               })}
-              {msg.isStreaming && isLastPart && (
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 4, color: "rgba(255,255,255,0.2)", marginLeft: 4, verticalAlign: "middle" }}>
-                  <Loader2 size={12} strokeWidth={2} style={{ animation: "spin 1s linear infinite" }} />
-                </span>
-              )}
             </div>
           );
         }
@@ -665,9 +660,10 @@ export default function Message({ msg, onEdit, onAnswer, onControlChange, canCon
         <ThinkingBlock text="" isThinking={true} />
       )}
 
-      {(msg.isStreaming || msg._usage || msg._startedAt) && (
+      {(msg.isStreaming || msg._usage || msg._startedAt || msg._elapsedMs != null) && (
         <LoadingStatus
           startedAt={msg._startedAt}
+          elapsedMs={msg._elapsedMs}
           usage={msg._usage}
           isStreaming={Boolean(msg.isStreaming)}
         />

--- a/src/data/models.js
+++ b/src/data/models.js
@@ -4,12 +4,14 @@ const LEGACY_MODEL_IDS = {
   haiku: DEFAULT_MODEL_ID,
 };
 
+// `contextWindow` is the model's total usable context in tokens — used by the
+// loading footer to turn raw usage counts into a "% of window full" reading.
 export const MODELS = [
-  { id: "opus",   name: "Claude Opus",   tag: "OPUS",   cliFlag: "opus",   provider: "claude" },
-  { id: "sonnet", name: "Claude Sonnet", tag: "SONNET", cliFlag: "sonnet", provider: "claude" },
-  { id: "gpt54-med",   name: "GPT-5.4",         tag: "GPT-5.4",        cliFlag: "gpt-5.4", provider: "codex", effort: "medium" },
-  { id: "gpt54-high",  name: "GPT-5.4 high",    tag: "GPT-5.4 high",   cliFlag: "gpt-5.4", provider: "codex", effort: "high" },
-  { id: "gpt54-xhigh", name: "GPT-5.4 xhigh",   tag: "GPT-5.4 xhigh",  cliFlag: "gpt-5.4", provider: "codex", effort: "xhigh" },
+  { id: "opus",   name: "Claude Opus",   tag: "OPUS",   cliFlag: "opus",   provider: "claude", contextWindow: 1_000_000 },
+  { id: "sonnet", name: "Claude Sonnet", tag: "SONNET", cliFlag: "sonnet", provider: "claude", contextWindow: 200_000 },
+  { id: "gpt54-med",   name: "GPT-5.4",         tag: "GPT-5.4",        cliFlag: "gpt-5.4", provider: "codex", effort: "medium", contextWindow: 1_050_000 },
+  { id: "gpt54-high",  name: "GPT-5.4 high",    tag: "GPT-5.4 high",   cliFlag: "gpt-5.4", provider: "codex", effort: "high",   contextWindow: 1_050_000 },
+  { id: "gpt54-xhigh", name: "GPT-5.4 xhigh",   tag: "GPT-5.4 xhigh",  cliFlag: "gpt-5.4", provider: "codex", effort: "xhigh",  contextWindow: 1_050_000 },
 ];
 
 export const normalizeModelId = (id) => LEGACY_MODEL_IDS[id] || id;

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -91,13 +91,18 @@ function normalizeCodexRateLimits(rl) {
   };
 }
 
-function extractUsageFromSessionResult(result) {
+function extractSessionStatsFromResult(result) {
   const fallbackAssistantIdx = findLatestAssistantIndex(result?.messages || []);
-  return (
-    result?.usageSnapshot ||
-    (fallbackAssistantIdx >= 0 ? result.messages[fallbackAssistantIdx]?._usage : null) ||
-    null
-  );
+  return {
+    usage:
+      result?.usageSnapshot ||
+      (fallbackAssistantIdx >= 0 ? result.messages[fallbackAssistantIdx]?._usage : null) ||
+      null,
+    rateLimits:
+      result?.rateLimitsSnapshot ||
+      (fallbackAssistantIdx >= 0 ? result.messages[fallbackAssistantIdx]?._rateLimits : null) ||
+      null,
+  };
 }
 
 function findLatestAssistantIndex(messages) {
@@ -177,8 +182,8 @@ export default function useAgent() {
       if (!window.api?.loadSession) return;
 
       void window.api.loadSession(codexThreadId).then((result) => {
-        const fallbackUsage = extractUsageFromSessionResult(result);
-        if (fallbackUsage) {
+        const { usage: fallbackUsage, rateLimits: fallbackRateLimits } = extractSessionStatsFromResult(result);
+        if (fallbackUsage || fallbackRateLimits) {
           setConversations((prev) => {
             const next = new Map(prev);
             const convo = next.get(conversationId);
@@ -186,11 +191,20 @@ export default function useAgent() {
 
             const msgs = [...convo.messages];
             const latestAssistantIdx = findLatestAssistantIndex(msgs);
-            if (latestAssistantIdx < 0 || msgs[latestAssistantIdx]?._usage) return prev;
+            if (latestAssistantIdx < 0) return prev;
+
+            const currentAssistant = msgs[latestAssistantIdx];
+            const nextUsage = currentAssistant?._usage || fallbackUsage || null;
+            const nextRateLimits = currentAssistant?._rateLimits || fallbackRateLimits || null;
+
+            if (nextUsage === currentAssistant?._usage && nextRateLimits === currentAssistant?._rateLimits) {
+              return prev;
+            }
 
             msgs[latestAssistantIdx] = {
-              ...msgs[latestAssistantIdx],
-              _usage: fallbackUsage,
+              ...currentAssistant,
+              ...(nextUsage ? { _usage: nextUsage } : {}),
+              ...(nextRateLimits ? { _rateLimits: nextRateLimits } : {}),
             };
             next.set(conversationId, { ...convo, messages: msgs });
             return next;
@@ -477,6 +491,23 @@ export default function useAgent() {
           }
         }
 
+        else if (event.type === "session_snapshot" && event.provider === "codex") {
+          if (event.thread_id) {
+            convo._codexThreadId = event.thread_id;
+          }
+          const idx = findLatestAssistantIndex(msgs);
+          if (idx >= 0) {
+            msgs[idx] = {
+              ...msgs[idx],
+              ...(event.usage
+                ? { _usage: mergeUsage(msgs[idx]._usage, event.usage) }
+                : {}),
+              ...(event.rate_limits ? { _rateLimits: event.rate_limits } : {}),
+            };
+            if (idx === msgs.length - 1) lastMsg = msgs[idx];
+          }
+        }
+
         // Claude Code emits a top-level `system` event with
         // `subtype: "compact_boundary"` whenever auto-compaction runs. Flag
         // the message transiently so the live status can show "compacting…";
@@ -681,7 +712,7 @@ export default function useAgent() {
       });
     });
 
-    const offDone = window.api.onAgentDone(({ conversationId }) => {
+    const offDone = window.api.onAgentDone(({ conversationId, provider, threadId }) => {
       pendingStartsRef.current.delete(conversationId);
       let codexThreadId = null;
       let needsUsageHydration = false;
@@ -689,15 +720,26 @@ export default function useAgent() {
         const next = new Map(prev);
         const convo = next.get(conversationId);
         if (convo) {
-          codexThreadId = convo._codexThreadId || null;
+          codexThreadId =
+            convo._codexThreadId ||
+            (provider === "codex" && typeof threadId === "string" && threadId ? threadId : null);
           const msgs = convo.messages.map((m) =>
             m.role === "assistant" ? freezeElapsed({ ...m, isStreaming: false, isThinking: false }) : m
           );
           const latestAssistantIdx = findLatestAssistantIndex(msgs);
-          if (latestAssistantIdx >= 0 && !msgs[latestAssistantIdx]?._usage && codexThreadId) {
+          if (
+            latestAssistantIdx >= 0 &&
+            codexThreadId &&
+            (!msgs[latestAssistantIdx]?._usage || !msgs[latestAssistantIdx]?._rateLimits)
+          ) {
             needsUsageHydration = true;
           }
-          next.set(conversationId, { ...convo, messages: msgs, isStreaming: false });
+          next.set(conversationId, {
+            ...convo,
+            ...(codexThreadId ? { _codexThreadId: codexThreadId } : {}),
+            messages: msgs,
+            isStreaming: false,
+          });
         }
         return next;
       });

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -18,6 +18,19 @@ function cloneStreamState(streamState) {
   };
 }
 
+function mergeUsage(prev, incoming) {
+  if (!incoming) return prev || null;
+  const base = prev || {};
+  return {
+    input_tokens: incoming.input_tokens ?? base.input_tokens ?? 0,
+    output_tokens: incoming.output_tokens ?? base.output_tokens ?? 0,
+    cache_creation_input_tokens:
+      incoming.cache_creation_input_tokens ?? base.cache_creation_input_tokens ?? 0,
+    cache_read_input_tokens:
+      incoming.cache_read_input_tokens ?? base.cache_read_input_tokens ?? 0,
+  };
+}
+
 function buildBlockKey(turn, blockIndex) {
   return `${turn}:${blockIndex}`;
 }
@@ -69,8 +82,13 @@ export default function useAgent() {
               isStreaming: true,
               isThinking: false,
               _streamState: cloneStreamState(),
+              _startedAt: Date.now(),
+              _usage: null,
             };
             msgs.push(lastMsg);
+          } else if (!lastMsg._startedAt) {
+            lastMsg = { ...lastMsg, _startedAt: Date.now() };
+            msgs[msgs.length - 1] = lastMsg;
           }
           return lastMsg;
         };
@@ -85,6 +103,15 @@ export default function useAgent() {
             msgs[msgs.length - 1] = merged;
             lastMsg = merged;
           };
+
+          // Capture usage deltas so the loading indicator can show live token counts.
+          if (inner.type === "message_start" && inner.message?.usage) {
+            ensureAssistant();
+            updateAssistant({ _usage: mergeUsage(lastMsg._usage, inner.message.usage) });
+          } else if (inner.type === "message_delta" && inner.usage) {
+            ensureAssistant();
+            updateAssistant({ _usage: mergeUsage(lastMsg._usage, inner.usage) });
+          }
 
           if (inner.type === "content_block_start") {
             const block = inner.content_block;
@@ -175,7 +202,12 @@ export default function useAgent() {
           // With --include-partial-messages, assistant events contain full accumulated text.
           // Only use these if we have NO stream_event parts yet (fallback for non-streaming).
           const am = ensureAssistant();
-          const parts = cloneParts(am.parts);
+          if (event.message?.usage) {
+            const merged = { ...am, _usage: mergeUsage(am._usage, event.message.usage) };
+            msgs[msgs.length - 1] = merged;
+            lastMsg = merged;
+          }
+          const parts = cloneParts(lastMsg.parts);
           const hasStreamParts = parts.length > 0;
           if (!hasStreamParts && event.message?.content) {
             for (const block of event.message.content) {
@@ -195,7 +227,8 @@ export default function useAgent() {
                 }
               }
             }
-            msgs[msgs.length - 1] = { ...am, parts, isThinking: false };
+            msgs[msgs.length - 1] = { ...lastMsg, parts, isThinking: false };
+            lastMsg = msgs[msgs.length - 1];
           }
         } else if (event.type === "user") {
           // Capture the UUID from user events — needed for rewind/edit
@@ -230,6 +263,11 @@ export default function useAgent() {
           }
         } else if (event.type === "result") {
           if (lastMsg && lastMsg.role === "assistant") {
+            if (event.usage) {
+              const merged = { ...lastMsg, _usage: mergeUsage(lastMsg._usage, event.usage) };
+              msgs[msgs.length - 1] = merged;
+              lastMsg = merged;
+            }
             if (event.is_error || event.subtype === "error_during_execution") {
               // Surface the error as text in the assistant message
               const errorText = event.result || event.error
@@ -372,7 +410,7 @@ export default function useAgent() {
       const msgs = [
         ...convo.messages,
         { id: uid(), role: "user", text: prompt, images, files },
-        { id: uid(), role: "assistant", parts: [], isStreaming: true, isThinking: false },
+        { id: uid(), role: "assistant", parts: [], isStreaming: true, isThinking: false, _startedAt: Date.now(), _usage: null },
       ];
       next.set(conversationId, { messages: msgs, isStreaming: true, error: null });
       return next;
@@ -443,7 +481,7 @@ export default function useAgent() {
       if (convo) {
         const msgs = convo.messages.slice(0, messageIndex);
         msgs.push({ id: uid(), role: "user", text: newText });
-        msgs.push({ id: uid(), role: "assistant", parts: [], isStreaming: true, isThinking: false });
+        msgs.push({ id: uid(), role: "assistant", parts: [], isStreaming: true, isThinking: false, _startedAt: Date.now(), _usage: null });
         next.set(conversationId, { messages: msgs, isStreaming: true, error: null });
       }
       return next;

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -91,12 +91,23 @@ function normalizeCodexRateLimits(rl) {
   };
 }
 
+function extractUsageFromSessionResult(result) {
+  const fallbackAssistantIdx = findLatestAssistantIndex(result?.messages || []);
+  return (
+    result?.usageSnapshot ||
+    (fallbackAssistantIdx >= 0 ? result.messages[fallbackAssistantIdx]?._usage : null) ||
+    null
+  );
+}
+
 function findLatestAssistantIndex(messages) {
   for (let i = (messages?.length || 0) - 1; i >= 0; i -= 1) {
     if (messages[i]?.role === "assistant") return i;
   }
   return -1;
 }
+
+const CODEX_USAGE_HYDRATION_RETRY_DELAYS_MS = [0, 150, 500, 1200, 2500];
 
 function buildBlockKey(turn, blockIndex) {
   return `${turn}:${blockIndex}`;
@@ -115,13 +126,97 @@ function findToolPart(parts, toolId) {
   return null;
 }
 
+function extractCodexResponseText(content) {
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((item) => item?.type === "output_text" && typeof item.text === "string")
+    .map((item) => item.text)
+    .join("");
+}
+
+function normalizeCodexToolArgs(payload) {
+  const raw = payload?.arguments ?? payload?.input;
+  if (raw == null) return {};
+  if (typeof raw === "object") {
+    return raw.cmd && !raw.command ? { ...raw, command: raw.cmd } : raw;
+  }
+  if (typeof raw !== "string") return { value: raw };
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return parsed.cmd && !parsed.command ? { ...parsed, command: parsed.cmd } : parsed;
+    }
+  } catch {}
+
+  return payload?.type === "custom_tool_call" ? { input: raw } : { value: raw };
+}
+
+function normalizeCodexToolResult(output) {
+  if (typeof output !== "string") return output;
+  const trimmed = output.trim();
+  if (!trimmed) return output;
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return output;
+  try {
+    return JSON.parse(output);
+  } catch {
+    return output;
+  }
+}
+
 export default function useAgent() {
   const [conversations, setConversations] = useState(new Map());
   const cleanupRefs = useRef([]);
   const pendingStartsRef = useRef(new Map());
+  const usageHydrationTimersRef = useRef(new Set());
 
   useEffect(() => {
     if (!window.api) return;
+
+    const scheduleUsageHydrationRetry = (conversationId, codexThreadId, attempt = 0) => {
+      if (!window.api?.loadSession) return;
+
+      void window.api.loadSession(codexThreadId).then((result) => {
+        const fallbackUsage = extractUsageFromSessionResult(result);
+        if (fallbackUsage) {
+          setConversations((prev) => {
+            const next = new Map(prev);
+            const convo = next.get(conversationId);
+            if (!convo) return prev;
+
+            const msgs = [...convo.messages];
+            const latestAssistantIdx = findLatestAssistantIndex(msgs);
+            if (latestAssistantIdx < 0 || msgs[latestAssistantIdx]?._usage) return prev;
+
+            msgs[latestAssistantIdx] = {
+              ...msgs[latestAssistantIdx],
+              _usage: fallbackUsage,
+            };
+            next.set(conversationId, { ...convo, messages: msgs });
+            return next;
+          });
+          return;
+        }
+
+        const nextDelay = CODEX_USAGE_HYDRATION_RETRY_DELAYS_MS[attempt + 1];
+        if (nextDelay == null) return;
+
+        const timerId = window.setTimeout(() => {
+          usageHydrationTimersRef.current.delete(timerId);
+          scheduleUsageHydrationRetry(conversationId, codexThreadId, attempt + 1);
+        }, nextDelay);
+        usageHydrationTimersRef.current.add(timerId);
+      }).catch(() => {
+        const nextDelay = CODEX_USAGE_HYDRATION_RETRY_DELAYS_MS[attempt + 1];
+        if (nextDelay == null) return;
+
+        const timerId = window.setTimeout(() => {
+          usageHydrationTimersRef.current.delete(timerId);
+          scheduleUsageHydrationRetry(conversationId, codexThreadId, attempt + 1);
+        }, nextDelay);
+        usageHydrationTimersRef.current.add(timerId);
+      });
+    };
 
     const offStream = window.api.onAgentStream(({ conversationId, event }) => {
       setConversations((prev) => {
@@ -393,11 +488,19 @@ export default function useAgent() {
         }
 
         // --- Codex JSONL stream events ---
-        else if (event.type === "thread.started") {
+        else if (event.type === "session_meta" && event.payload?.id) {
+          convo._codexThreadId = event.payload.id;
+          console.log("[useAgent] Captured Codex thread ID:", {
+            conversationId,
+            threadId: event.payload.id,
+            source: "session_meta",
+          });
+        } else if (event.type === "thread.started") {
           convo._codexThreadId = event.thread_id;
           console.log("[useAgent] Captured Codex thread ID:", {
             conversationId,
             threadId: event.thread_id,
+            source: "thread.started",
           });
         } else if (event.type === "event_msg" && event.payload?.type === "token_count") {
           const tokenInfo = event.payload.info;
@@ -412,6 +515,16 @@ export default function useAgent() {
             if (usage) patch._usage = usage;
             if (rateLimits) patch._rateLimits = rateLimits;
             msgs[msgs.length - 1] = patch;
+            lastMsg = msgs[msgs.length - 1];
+          }
+        } else if (event.type === "event_msg" && event.payload?.type === "task_started") {
+          const am = ensureAssistant();
+          const contextWindow = event.payload.model_context_window;
+          if (Number.isFinite(contextWindow)) {
+            msgs[msgs.length - 1] = {
+              ...am,
+              _usage: mergeUsage(am._usage, { context_window: contextWindow }),
+            };
             lastMsg = msgs[msgs.length - 1];
           }
         } else if (event.type === "turn.started") {
@@ -465,15 +578,102 @@ export default function useAgent() {
             msgs[msgs.length - 1] = { ...am, parts };
             lastMsg = msgs[msgs.length - 1];
           }
-        } else if (event.type === "turn.completed") {
-          if (lastMsg && lastMsg.role === "assistant") {
-            // Do not fall back to `turn.completed.usage` for Codex. Those
-            // numbers are cumulative across the whole session, not the current
-            // prompt window, and produce impossible `ctx` readings. The live
-            // `token_count` event above is the only trustworthy source here.
-            msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
+        } else if (event.type === "response_item") {
+          const payload = event.payload || {};
+          if (payload.type === "message" && payload.role === "assistant") {
+            const text = extractCodexResponseText(payload.content);
+            if (text) {
+              const am = ensureAssistant();
+              const parts = cloneParts(am.parts);
+              parts.push({ type: "text", text });
+              msgs[msgs.length - 1] = { ...am, parts };
+              lastMsg = msgs[msgs.length - 1];
+            }
+          } else if (payload.type === "function_call" || payload.type === "custom_tool_call") {
+            const am = ensureAssistant();
+            const parts = cloneParts(am.parts);
+            const toolId = payload.call_id || uid();
+            const existingIdx = parts.findIndex((p) => p.type === "tool" && p.id === toolId);
+            const nextTool = {
+              type: "tool",
+              id: toolId,
+              name: payload.name || "tool",
+              args: normalizeCodexToolArgs(payload),
+              result: existingIdx >= 0 ? parts[existingIdx].result : null,
+              status: payload.status === "completed" ? "done" : "running",
+            };
+
+            if (existingIdx >= 0) {
+              parts[existingIdx] = { ...parts[existingIdx], ...nextTool };
+            } else {
+              parts.push(nextTool);
+            }
+
+            msgs[msgs.length - 1] = { ...am, parts };
+            lastMsg = msgs[msgs.length - 1];
+          } else if (payload.type === "function_call_output" || payload.type === "custom_tool_call_output") {
+            const am = ensureAssistant();
+            const parts = cloneParts(am.parts);
+            const existingIdx = parts.findIndex(
+              (p) => p.type === "tool" && p.id === payload.call_id
+            );
+            const result = normalizeCodexToolResult(payload.output);
+
+            if (existingIdx >= 0) {
+              parts[existingIdx] = {
+                ...parts[existingIdx],
+                result,
+                status: "done",
+              };
+            } else {
+              parts.push({
+                type: "tool",
+                id: payload.call_id || uid(),
+                name: "tool",
+                args: {},
+                result,
+                status: "done",
+              });
+            }
+
+            msgs[msgs.length - 1] = { ...am, parts };
             lastMsg = msgs[msgs.length - 1];
           }
+        } else if (event.type === "turn.completed") {
+          if (lastMsg && lastMsg.role === "assistant") {
+            // RayLine's live Codex stdout still uses the older
+            // `thread.started`/`turn.completed` schema even though the saved
+            // session JSONL now contains the richer `token_count` event.
+            // Merge this older usage packet as an immediate fallback so the
+            // footer can render without waiting for session-file hydration.
+            const fallbackUsage = normalizeCodexUsage(event.usage);
+            msgs[msgs.length - 1] = freezeElapsed({
+              ...lastMsg,
+              ...(fallbackUsage
+                ? { _usage: mergeUsage(lastMsg._usage, fallbackUsage) }
+                : {}),
+              isStreaming: false,
+              isThinking: false,
+            });
+            lastMsg = msgs[msgs.length - 1];
+          }
+        } else if (event.type === "event_msg" && event.payload?.type === "task_complete") {
+          const completionText = event.payload.last_agent_message;
+          const am = ensureAssistant();
+          let parts = cloneParts(am.parts);
+          const hasText = parts.some((part) => part.type === "text" && part.text);
+
+          if (!hasText && completionText) {
+            parts.push({ type: "text", text: completionText });
+          }
+
+          msgs[msgs.length - 1] = freezeElapsed({
+            ...am,
+            parts,
+            isStreaming: false,
+            isThinking: false,
+          });
+          lastMsg = msgs[msgs.length - 1];
         }
 
         next.set(conversationId, { ...convo, messages: msgs });
@@ -503,31 +703,7 @@ export default function useAgent() {
       });
 
       if (needsUsageHydration && codexThreadId && window.api?.loadSession) {
-        void window.api.loadSession(codexThreadId).then((result) => {
-          const fallbackAssistantIdx = findLatestAssistantIndex(result?.messages || []);
-          const fallbackUsage =
-            result?.usageSnapshot ||
-            (fallbackAssistantIdx >= 0 ? result.messages[fallbackAssistantIdx]?._usage : null) ||
-            null;
-          if (!fallbackUsage) return;
-
-          setConversations((prev) => {
-            const next = new Map(prev);
-            const convo = next.get(conversationId);
-            if (!convo) return prev;
-
-            const msgs = [...convo.messages];
-            const latestAssistantIdx = findLatestAssistantIndex(msgs);
-            if (latestAssistantIdx < 0 || msgs[latestAssistantIdx]?._usage) return prev;
-
-            msgs[latestAssistantIdx] = {
-              ...msgs[latestAssistantIdx],
-              _usage: fallbackUsage,
-            };
-            next.set(conversationId, { ...convo, messages: msgs });
-            return next;
-          });
-        }).catch(() => {});
+        scheduleUsageHydrationRetry(conversationId, codexThreadId);
       }
     });
 
@@ -550,7 +726,11 @@ export default function useAgent() {
     });
 
     cleanupRefs.current = [offStream, offDone, offError];
-    return () => cleanupRefs.current.forEach((fn) => fn?.());
+    return () => {
+      cleanupRefs.current.forEach((fn) => fn?.());
+      usageHydrationTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+      usageHydrationTimersRef.current.clear();
+    };
   }, []);
 
   const prepareMessage = useCallback(({ conversationId, prompt, images, files }) => {

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -23,9 +23,11 @@ function cloneStreamState(streamState) {
 // survives reloads (`Date.now() - _startedAt` would drift across sessions).
 function freezeElapsed(msg) {
   if (!msg || msg.role !== "assistant") return msg;
-  if (msg._elapsedMs != null) return msg;
-  if (!msg._startedAt) return msg;
-  return { ...msg, _elapsedMs: Date.now() - msg._startedAt };
+  // Compaction is a transient mid-turn signal — never persist it past stream end.
+  const { _compacting, ...rest } = msg;
+  if (rest._elapsedMs != null) return rest;
+  if (!rest._startedAt) return rest;
+  return { ...rest, _elapsedMs: Date.now() - rest._startedAt };
 }
 
 function mergeUsage(prev, incoming) {
@@ -38,7 +40,36 @@ function mergeUsage(prev, incoming) {
       incoming.cache_creation_input_tokens ?? base.cache_creation_input_tokens ?? 0,
     cache_read_input_tokens:
       incoming.cache_read_input_tokens ?? base.cache_read_input_tokens ?? 0,
+    ...(Number.isFinite(incoming.total_tokens)
+      ? { total_tokens: incoming.total_tokens }
+      : Number.isFinite(base.total_tokens)
+        ? { total_tokens: base.total_tokens }
+        : {}),
+    ...(Number.isFinite(incoming.context_window)
+      ? { context_window: incoming.context_window }
+      : Number.isFinite(base.context_window)
+        ? { context_window: base.context_window }
+        : {}),
   };
+}
+
+function normalizeCodexUsage(usage, contextWindow) {
+  if (!usage) return null;
+  return {
+    input_tokens: usage.input_tokens ?? 0,
+    output_tokens: usage.output_tokens ?? 0,
+    total_tokens: usage.total_tokens ?? null,
+    cache_read_input_tokens: usage.cached_input_tokens ?? usage.cache_read_input_tokens ?? 0,
+    cache_creation_input_tokens: usage.cache_creation_input_tokens ?? 0,
+    ...(Number.isFinite(contextWindow) ? { context_window: contextWindow } : {}),
+  };
+}
+
+function findLatestAssistantIndex(messages) {
+  for (let i = (messages?.length || 0) - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === "assistant") return i;
+  }
+  return -1;
 }
 
 function buildBlockKey(turn, blockIndex) {
@@ -114,10 +145,21 @@ export default function useAgent() {
             lastMsg = merged;
           };
 
-          // Capture usage deltas so the loading indicator can show live token counts.
+          // Context-window fullness tracking.
+          //
+          // We deliberately track the LATEST API call's usage (not the turn
+          // aggregate). A multi-tool-use turn re-sends the prompt once per
+          // call, so aggregating would make `cache_read` balloon by the number
+          // of calls — that measures how much *work* was done, not how full
+          // the window is. The cumulative snapshot at the END of the last
+          // call is what actually reflects "tokens currently in the window."
+          //
+          // - `message_start` → overwrite `_usage` (new API call begins)
+          // - `message_delta` → merge (output_tokens grows during generation)
+          // - `result` below → ignored for usage (it's turn-aggregated)
           if (inner.type === "message_start" && inner.message?.usage) {
             ensureAssistant();
-            updateAssistant({ _usage: mergeUsage(lastMsg._usage, inner.message.usage) });
+            updateAssistant({ _usage: { ...inner.message.usage } });
           } else if (inner.type === "message_delta" && inner.usage) {
             ensureAssistant();
             updateAssistant({ _usage: mergeUsage(lastMsg._usage, inner.usage) });
@@ -211,12 +253,9 @@ export default function useAgent() {
         } else if (event.type === "assistant") {
           // With --include-partial-messages, assistant events contain full accumulated text.
           // Only use these if we have NO stream_event parts yet (fallback for non-streaming).
+          // Usage here is per-API-call, not cumulative — skip it to avoid flicker;
+          // the `result` event below owns the authoritative cumulative usage.
           const am = ensureAssistant();
-          if (event.message?.usage) {
-            const merged = { ...am, _usage: mergeUsage(am._usage, event.message.usage) };
-            msgs[msgs.length - 1] = merged;
-            lastMsg = merged;
-          }
           const parts = cloneParts(lastMsg.parts);
           const hasStreamParts = parts.length > 0;
           if (!hasStreamParts && event.message?.content) {
@@ -273,11 +312,11 @@ export default function useAgent() {
           }
         } else if (event.type === "result") {
           if (lastMsg && lastMsg.role === "assistant") {
-            if (event.usage) {
-              const merged = { ...lastMsg, _usage: mergeUsage(lastMsg._usage, event.usage) };
-              msgs[msgs.length - 1] = merged;
-              lastMsg = merged;
-            }
+            // Note: `event.usage` here is aggregated across every API call in
+            // the turn (ballooned `cache_read` when the turn had multiple tool
+            // loops). That's right for cost, wrong for window fullness — we
+            // already captured the final call's cumulative usage from
+            // `message_delta`. Leave `_usage` alone.
             if (event.is_error || event.subtype === "error_during_execution") {
               // Surface the error as text in the assistant message
               const errorText = event.result || event.error
@@ -304,6 +343,16 @@ export default function useAgent() {
           }
         }
 
+        // Claude Code emits a top-level `system` event with
+        // `subtype: "compact_boundary"` whenever auto-compaction runs. Flag
+        // the message transiently so the live status can show "compacting…";
+        // `freezeElapsed` strips this on stream end so it doesn't persist.
+        else if (event.type === "system" && event.subtype === "compact_boundary") {
+          const am = ensureAssistant();
+          msgs[msgs.length - 1] = { ...am, _compacting: true };
+          lastMsg = msgs[msgs.length - 1];
+        }
+
         // --- Codex JSONL stream events ---
         else if (event.type === "thread.started") {
           convo._codexThreadId = event.thread_id;
@@ -311,6 +360,17 @@ export default function useAgent() {
             conversationId,
             threadId: event.thread_id,
           });
+        } else if (event.type === "event_msg" && event.payload?.type === "token_count") {
+          const tokenInfo = event.payload.info;
+          const usage = normalizeCodexUsage(
+            tokenInfo?.last_token_usage || tokenInfo?.total_token_usage,
+            tokenInfo?.model_context_window
+          );
+          if (usage) {
+            const am = ensureAssistant();
+            msgs[msgs.length - 1] = { ...am, _usage: usage };
+            lastMsg = msgs[msgs.length - 1];
+          }
         } else if (event.type === "turn.started") {
           ensureAssistant();
         } else if (event.type === "item.started") {
@@ -364,6 +424,10 @@ export default function useAgent() {
           }
         } else if (event.type === "turn.completed") {
           if (lastMsg && lastMsg.role === "assistant") {
+            // Do not fall back to `turn.completed.usage` for Codex. Those
+            // numbers are cumulative across the whole session, not the current
+            // prompt window, and produce impossible `ctx` readings. The live
+            // `token_count` event above is the only trustworthy source here.
             msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
             lastMsg = msgs[msgs.length - 1];
           }
@@ -376,17 +440,52 @@ export default function useAgent() {
 
     const offDone = window.api.onAgentDone(({ conversationId }) => {
       pendingStartsRef.current.delete(conversationId);
+      let codexThreadId = null;
+      let needsUsageHydration = false;
       setConversations((prev) => {
         const next = new Map(prev);
         const convo = next.get(conversationId);
         if (convo) {
+          codexThreadId = convo._codexThreadId || null;
           const msgs = convo.messages.map((m) =>
             m.role === "assistant" ? freezeElapsed({ ...m, isStreaming: false, isThinking: false }) : m
           );
+          const latestAssistantIdx = findLatestAssistantIndex(msgs);
+          if (latestAssistantIdx >= 0 && !msgs[latestAssistantIdx]?._usage && codexThreadId) {
+            needsUsageHydration = true;
+          }
           next.set(conversationId, { ...convo, messages: msgs, isStreaming: false });
         }
         return next;
       });
+
+      if (needsUsageHydration && codexThreadId && window.api?.loadSession) {
+        void window.api.loadSession(codexThreadId).then((result) => {
+          const fallbackAssistantIdx = findLatestAssistantIndex(result?.messages || []);
+          const fallbackUsage =
+            result?.usageSnapshot ||
+            (fallbackAssistantIdx >= 0 ? result.messages[fallbackAssistantIdx]?._usage : null) ||
+            null;
+          if (!fallbackUsage) return;
+
+          setConversations((prev) => {
+            const next = new Map(prev);
+            const convo = next.get(conversationId);
+            if (!convo) return prev;
+
+            const msgs = [...convo.messages];
+            const latestAssistantIdx = findLatestAssistantIndex(msgs);
+            if (latestAssistantIdx < 0 || msgs[latestAssistantIdx]?._usage) return prev;
+
+            msgs[latestAssistantIdx] = {
+              ...msgs[latestAssistantIdx],
+              _usage: fallbackUsage,
+            };
+            next.set(conversationId, { ...convo, messages: msgs });
+            return next;
+          });
+        }).catch(() => {});
+      }
     });
 
     const offError = window.api.onAgentError(({ conversationId, error }) => {

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -18,6 +18,16 @@ function cloneStreamState(streamState) {
   };
 }
 
+// Freeze the final elapsed duration onto the assistant message when the
+// stream ends. Once persisted, the loading indicator uses this value so it
+// survives reloads (`Date.now() - _startedAt` would drift across sessions).
+function freezeElapsed(msg) {
+  if (!msg || msg.role !== "assistant") return msg;
+  if (msg._elapsedMs != null) return msg;
+  if (!msg._startedAt) return msg;
+  return { ...msg, _elapsedMs: Date.now() - msg._startedAt };
+}
+
 function mergeUsage(prev, incoming) {
   if (!incoming) return prev || null;
   const base = prev || {};
@@ -275,7 +285,7 @@ export default function useAgent() {
                 || "An error occurred.";
               const parts = cloneParts(lastMsg.parts);
               parts.push({ type: "text", text: `**Error:** ${errorText}` });
-              msgs[msgs.length - 1] = { ...lastMsg, parts, isStreaming: false, isThinking: false };
+              msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, parts, isStreaming: false, isThinking: false });
             } else if (event.terminal_reason === "hook_stopped") {
               const parts = cloneParts(lastMsg.parts);
               const hasPausedStatus = parts.some((part) => part.type === "status" && part.kind === "paused");
@@ -287,9 +297,9 @@ export default function useAgent() {
                   text: "Claude stopped after a tool hook returned continue: false. This is expected — send another message when you want to continue.",
                 });
               }
-              msgs[msgs.length - 1] = { ...lastMsg, parts, isStreaming: false, isThinking: false };
+              msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, parts, isStreaming: false, isThinking: false });
             } else {
-              msgs[msgs.length - 1] = { ...lastMsg, isStreaming: false, isThinking: false };
+              msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
             }
           }
         }
@@ -354,7 +364,7 @@ export default function useAgent() {
           }
         } else if (event.type === "turn.completed") {
           if (lastMsg && lastMsg.role === "assistant") {
-            msgs[msgs.length - 1] = { ...lastMsg, isStreaming: false, isThinking: false };
+            msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
             lastMsg = msgs[msgs.length - 1];
           }
         }
@@ -371,7 +381,7 @@ export default function useAgent() {
         const convo = next.get(conversationId);
         if (convo) {
           const msgs = convo.messages.map((m) =>
-            m.role === "assistant" ? { ...m, isStreaming: false, isThinking: false } : m
+            m.role === "assistant" ? freezeElapsed({ ...m, isStreaming: false, isThinking: false }) : m
           );
           next.set(conversationId, { ...convo, messages: msgs, isStreaming: false });
         }
@@ -390,7 +400,7 @@ export default function useAgent() {
         if (lastMsg && lastMsg.role === "assistant") {
           const parts = cloneParts(lastMsg.parts);
           parts.push({ type: "text", text: `**Error:** ${error}` });
-          msgs[msgs.length - 1] = { ...lastMsg, parts, isStreaming: false, isThinking: false };
+          msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, parts, isStreaming: false, isThinking: false });
         }
         next.set(conversationId, { messages: msgs, error, isStreaming: false });
         return next;
@@ -461,7 +471,7 @@ export default function useAgent() {
         const convo = next.get(conversationId);
         if (convo) {
           const msgs = convo.messages.map((m) =>
-            m.role === "assistant" ? { ...m, isStreaming: false, isThinking: false } : m
+            m.role === "assistant" ? freezeElapsed({ ...m, isStreaming: false, isThinking: false }) : m
           );
           next.set(conversationId, { ...convo, messages: msgs, isStreaming: false, error: null });
         }

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -65,6 +65,32 @@ function normalizeCodexUsage(usage, contextWindow) {
   };
 }
 
+// Codex emits plan-quota snapshots inside the same `token_count` event as token
+// usage — `payload.rate_limits` is a sibling of `payload.info`. The shape uses
+// `primary` (5h rolling window, window_minutes=300) and `secondary` (7d, =10080).
+// Normalize to a provider-agnostic shape so Claude Code's statusline JSON
+// (`five_hour`/`seven_day`) can later reuse the same renderer.
+function normalizeCodexRateLimits(rl) {
+  if (!rl || typeof rl !== "object") return null;
+  const pickWindow = (w) => {
+    if (!w || typeof w !== "object") return null;
+    if (!Number.isFinite(w.used_percent)) return null;
+    return {
+      used_percent: w.used_percent,
+      resets_at: Number.isFinite(w.resets_at) ? w.resets_at : null,
+      window_minutes: Number.isFinite(w.window_minutes) ? w.window_minutes : null,
+    };
+  };
+  const five = pickWindow(rl.primary);
+  const seven = pickWindow(rl.secondary);
+  if (!five && !seven) return null;
+  return {
+    ...(five ? { five_hour: five } : {}),
+    ...(seven ? { seven_day: seven } : {}),
+    ...(rl.plan_type ? { plan_type: rl.plan_type } : {}),
+  };
+}
+
 function findLatestAssistantIndex(messages) {
   for (let i = (messages?.length || 0) - 1; i >= 0; i -= 1) {
     if (messages[i]?.role === "assistant") return i;
@@ -343,6 +369,19 @@ export default function useAgent() {
           }
         }
 
+        // Claude Code plan quota — synthetic event emitted by the main process
+        // after each `result`, sourced from `api.anthropic.com/api/oauth/usage`
+        // (Pro/Max only — silently absent for API-key users). Already
+        // normalized to the same `{ five_hour, seven_day }` shape Codex uses,
+        // so it just attaches to the latest assistant message.
+        else if (event.type === "rate_limits" && event.rate_limits) {
+          const idx = findLatestAssistantIndex(msgs);
+          if (idx >= 0) {
+            msgs[idx] = { ...msgs[idx], _rateLimits: event.rate_limits };
+            if (idx === msgs.length - 1) lastMsg = msgs[idx];
+          }
+        }
+
         // Claude Code emits a top-level `system` event with
         // `subtype: "compact_boundary"` whenever auto-compaction runs. Flag
         // the message transiently so the live status can show "compacting…";
@@ -366,9 +405,13 @@ export default function useAgent() {
             tokenInfo?.last_token_usage || tokenInfo?.total_token_usage,
             tokenInfo?.model_context_window
           );
-          if (usage) {
+          const rateLimits = normalizeCodexRateLimits(event.payload.rate_limits);
+          if (usage || rateLimits) {
             const am = ensureAssistant();
-            msgs[msgs.length - 1] = { ...am, _usage: usage };
+            const patch = { ...am };
+            if (usage) patch._usage = usage;
+            if (rateLimits) patch._rateLimits = rateLimits;
+            msgs[msgs.length - 1] = patch;
             lastMsg = msgs[msgs.length - 1];
           }
         } else if (event.type === "turn.started") {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,7 +3,16 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
 
-createRoot(document.getElementById("root")).render(
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Root container #root was not found.");
+}
+
+const root = container.__raylineRoot || createRoot(container);
+container.__raylineRoot = root;
+
+root.render(
   <StrictMode>
     <App />
   </StrictMode>


### PR DESCRIPTION
- **feat: add live loading status with token usage and elapsed time**
- **feat: persist elapsed time on messages and restyle loading spinner**
- **feat: improve Codex token tracking, context window display, and message dedup**
- **feat: show Claude Code plan quota (5h/7d) in loading status**
- **fix: improve Codex event schema compatibility and usage hydration**
- **feat: emit and hydrate Codex rate-limits alongside usage snapshots**
