### PR TITLE
fix: support Windows dev electron startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Before running the app locally, make sure you have:
 - Node.js and npm installed
 - the `claude` CLI installed and available on your `PATH`
 - an authenticated Claude Code environment
+- if you need PTY-backed terminal sessions on Windows, Python and Visual Studio
+  Build Tools available for `node-gyp`
 
 The Electron packaging config in `package.json` is currently set up for macOS
 distribution, but the development workflow is the standard Electron + Vite loop.
@@ -48,6 +50,11 @@ If Electron or `node-pty` was updated, rebuild the native dependency:
 ```bash
 npm run rebuild
 ```
+
+On Windows, `npm run rebuild` compiles `node-pty` with `node-gyp`, so Python
+and the Visual Studio C++ build tools need to be installed first. If you are
+only working on the main UI, you can start the app without rebuilding and
+terminal sessions will remain unavailable until the rebuild succeeds.
 
 Start the desktop app in development mode:
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "vite",
-    "dev:electron": "concurrently \"vite --port 5199 --strictPort\" \"wait-on http://localhost:5199 && VITE_PORT=5199 electron .\"",
+    "dev:electron": "concurrently \"vite --port 5199 --strictPort\" \"wait-on http://localhost:5199 && node scripts/dev-electron.cjs 5199\"",
     "build": "vite build",
     "build:electron": "vite build && electron-builder",
     "lint": "eslint .",

--- a/scripts/dev-electron.cjs
+++ b/scripts/dev-electron.cjs
@@ -1,0 +1,32 @@
+"use strict";
+
+const { spawn } = require("child_process");
+
+const electronBinary = require("electron");
+const port = process.argv[2] || process.env.VITE_PORT || "5173";
+
+const child = spawn(electronBinary, ["."], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    VITE_PORT: port,
+  },
+});
+
+function forwardSignal(signal) {
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill(signal);
+  }
+}
+
+process.on("SIGINT", () => forwardSignal("SIGINT"));
+process.on("SIGTERM", () => forwardSignal("SIGTERM"));
+
+child.on("error", (error) => {
+  console.error("[dev-electron] Failed to launch Electron:", error.message);
+  process.exit(1);
+});
+
+child.on("exit", (code) => {
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Summary
- replace the POSIX-only `VITE_PORT=... electron .` dev command with a small Node launcher that works on Windows
- keep Electron pointed at the Vite dev server by setting `VITE_PORT` inside the launcher process
- document that `node-pty` rebuilds on Windows require Python and Visual Studio Build Tools, and that the app can still launch without terminal support until rebuild succeeds

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`
- `node --check scripts/dev-electron.cjs`