### PR TITLE
fix: hide Windows menu and title chrome

### DIFF
--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -1,8 +1,7 @@
-const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
+const { buildSpawnPath, isExecutable, resolveCliBin, spawnCli } = require("./cli-bin-resolver.cjs");
 const { findSessionCwd, moveSession } = require("./session-reader.cjs");
 const { fetchClaudeUsage } = require("./claude-usage-fetcher.cjs");
 
@@ -302,7 +301,7 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
     log("Full args:", args.filter((arg) => arg !== runPrompt).join(" "));
     log("Prompt:", runPrompt.slice(0, 100));
 
-    const child = spawn(claudeBin, args, {
+    const child = spawnCli(claudeBin, args, {
       cwd: launchCwd,
       env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
       stdio: ["ignore", "pipe", "pipe"],
@@ -537,7 +536,7 @@ function rewindFiles({ sessionId, messageUuid, cwd }) {
       return;
     }
 
-    const child = spawn(claudeBin, args, {
+    const child = spawnCli(claudeBin, args, {
       cwd: launchCwd,
       env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
       stdio: ["ignore", "pipe", "pipe"],

--- a/electron/cli-bin-resolver.cjs
+++ b/electron/cli-bin-resolver.cjs
@@ -3,20 +3,39 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
-const COMMON_EXTRA_PATH_DIRS = [
-  "/opt/homebrew/bin",
-  "/usr/local/bin",
-  "/usr/bin",
-  "/bin",
-];
+const IS_WINDOWS = process.platform === "win32";
+
+const COMMON_EXTRA_PATH_DIRS = IS_WINDOWS
+  ? []
+  : ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"];
 
 function isExecutable(filePath) {
   try {
-    fs.accessSync(filePath, fs.constants.X_OK);
-    return fs.statSync(filePath).isFile();
+    if (!fs.statSync(filePath).isFile()) return false;
+    // X_OK is not meaningful on Windows — existence + PATHEXT match is enough.
+    if (!IS_WINDOWS) fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
   } catch {
     return false;
   }
+}
+
+function getPathExtensions() {
+  if (!IS_WINDOWS) return [""];
+  const raw = process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD";
+  const exts = raw
+    .split(";")
+    .map((e) => e.trim())
+    .filter(Boolean);
+  return ["", ...exts];
+}
+
+function hasKnownExtension(candidate) {
+  if (!IS_WINDOWS) return true;
+  const lower = candidate.toLowerCase();
+  return getPathExtensions()
+    .filter(Boolean)
+    .some((ext) => lower.endsWith(ext.toLowerCase()));
 }
 
 function expandHome(inputPath) {
@@ -37,7 +56,7 @@ function getUserBinDirs() {
   const home = os.homedir();
   if (!home) return [];
 
-  return [
+  const shared = [
     path.join(home, "bin"),
     path.join(home, ".local", "bin"),
     path.join(home, ".npm-global", "bin"),
@@ -51,6 +70,29 @@ function getUserBinDirs() {
     path.join(home, ".local", "share", "mise", "shims"),
     path.join(home, ".cargo", "bin"),
   ];
+
+  if (!IS_WINDOWS) return shared;
+
+  const appData = process.env.APPDATA;
+  const localAppData = process.env.LOCALAPPDATA;
+  const programFiles = process.env.ProgramFiles;
+  const programFilesX86 = process.env["ProgramFiles(x86)"];
+
+  const windowsDirs = [
+    appData && path.join(appData, "npm"),
+    localAppData && path.join(localAppData, "Programs", "claude"),
+    localAppData && path.join(localAppData, "Volta", "bin"),
+    localAppData && path.join(localAppData, "fnm"),
+    localAppData && path.join(localAppData, "Microsoft", "WindowsApps"),
+    path.join(home, "scoop", "shims"),
+    path.join(home, ".bun", "bin"),
+    programFiles && path.join(programFiles, "nodejs"),
+    programFiles && path.join(programFiles, "Git", "bin"),
+    programFiles && path.join(programFiles, "Git", "cmd"),
+    programFilesX86 && path.join(programFilesX86, "nodejs"),
+  ].filter(Boolean);
+
+  return [...shared, ...windowsDirs];
 }
 
 function buildSpawnPath(extraDirs = []) {
@@ -62,28 +104,37 @@ function buildSpawnPath(extraDirs = []) {
   ])].join(path.delimiter);
 }
 
+function tryWithExtensions(basePath) {
+  for (const ext of getPathExtensions()) {
+    const candidate = basePath + ext;
+    if (isExecutable(candidate)) return candidate;
+  }
+  if (IS_WINDOWS && !hasKnownExtension(basePath) && isExecutable(basePath)) {
+    return basePath;
+  }
+  return null;
+}
+
 function resolvePathCandidate(candidate, searchPath) {
   if (!candidate || typeof candidate !== "string") return null;
 
   const normalized = expandHome(candidate.trim());
   if (!normalized) return null;
 
-  if (path.isAbsolute(normalized) && isExecutable(normalized)) {
-    return normalized;
+  if (path.isAbsolute(normalized)) {
+    const resolved = tryWithExtensions(normalized);
+    if (resolved) return resolved;
   }
 
-  if (normalized.includes(path.sep)) {
+  if (normalized.includes(path.sep) || (IS_WINDOWS && normalized.includes("/"))) {
     const absoluteCandidate = path.resolve(normalized);
-    if (isExecutable(absoluteCandidate)) {
-      return absoluteCandidate;
-    }
+    const resolved = tryWithExtensions(absoluteCandidate);
+    if (resolved) return resolved;
   }
 
   for (const dir of splitPath(searchPath)) {
-    const fullPath = path.join(dir, normalized);
-    if (isExecutable(fullPath)) {
-      return fullPath;
-    }
+    const resolved = tryWithExtensions(path.join(dir, normalized));
+    if (resolved) return resolved;
   }
 
   return null;

--- a/electron/cli-bin-resolver.cjs
+++ b/electron/cli-bin-resolver.cjs
@@ -222,7 +222,46 @@ function buildCmdWrappedArgs(binPath, args) {
   return { command: process.env.ComSpec || "cmd.exe", args: ["/d", "/s", "/c", line] };
 }
 
+// npm's generated .cmd shims on Windows have a fixed shape that ends with
+//   "%_prog%"  "%dp0%\path\to\script.js" %*
+// If we dispatch through cmd.exe, multi-line args (e.g. a whole system-context
+// prompt) are truncated at the first newline because cmd.exe parses them as
+// separate commands. Extracting the underlying JS entrypoint lets us spawn
+// `node script.js ...args` directly — no cmd.exe, no arg-length or newline
+// limits, no percent-expansion. For non-npm `.cmd` shims we fall back to the
+// cmd.exe wrapper which preserves single-line behavior.
+function resolveNpmShimTarget(cmdPath) {
+  if (!IS_WINDOWS) return null;
+  try {
+    const content = fs.readFileSync(cmdPath, "utf-8");
+    const match = content.match(/"%_prog%"\s+"%dp0%[\\/]([^"]+)"\s+%\*/);
+    if (!match) return null;
+    const scriptPath = path.join(path.dirname(cmdPath), match[1]);
+    return fs.existsSync(scriptPath) ? scriptPath : null;
+  } catch {
+    return null;
+  }
+}
+
+let cachedNodeBin = null;
+function resolveNodeBin() {
+  if (cachedNodeBin && isExecutable(cachedNodeBin)) return cachedNodeBin;
+  cachedNodeBin = resolveCliBin("node", { envVarName: "NODE_BIN" });
+  return cachedNodeBin;
+}
+
+function maybeDirectNodeInvocation(binPath) {
+  if (!needsCmdWrapping(binPath)) return null;
+  const shimTarget = resolveNpmShimTarget(binPath);
+  if (!shimTarget) return null;
+  const nodeBin = resolveNodeBin();
+  if (!nodeBin) return null;
+  return { command: nodeBin, prefixArgs: [shimTarget] };
+}
+
 function spawnCli(binPath, args, options = {}) {
+  const direct = maybeDirectNodeInvocation(binPath);
+  if (direct) return spawn(direct.command, [...direct.prefixArgs, ...args], options);
   if (needsCmdWrapping(binPath)) {
     const { command, args: wrapped } = buildCmdWrappedArgs(binPath, args);
     return spawn(command, wrapped, { ...options, windowsVerbatimArguments: true });
@@ -233,6 +272,8 @@ function spawnCli(binPath, args, options = {}) {
 function execFileCli(binPath, args, options, callback) {
   if (typeof options === "function") { callback = options; options = {}; }
   options = options || {};
+  const direct = maybeDirectNodeInvocation(binPath);
+  if (direct) return execFile(direct.command, [...direct.prefixArgs, ...args], options, callback);
   if (needsCmdWrapping(binPath)) {
     const { command, args: wrapped } = buildCmdWrappedArgs(binPath, args);
     return execFile(command, wrapped, { ...options, windowsVerbatimArguments: true }, callback);

--- a/electron/cli-bin-resolver.cjs
+++ b/electron/cli-bin-resolver.cjs
@@ -1,4 +1,4 @@
-const { spawnSync } = require("child_process");
+const { execFile, spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -27,7 +27,12 @@ function getPathExtensions() {
     .split(";")
     .map((e) => e.trim())
     .filter(Boolean);
-  return ["", ...exts];
+  // On Windows, PATHEXT matches must be tried FIRST. npm's global bin
+  // (`%APPDATA%\npm`) installs three files per command — `codex`,
+  // `codex.cmd`, `codex.ps1` — and only the `.cmd` is directly spawnable.
+  // Trying the bare name first would return the extension-less bash shim,
+  // which `child_process.spawn` can't execute.
+  return [...exts, ""];
 }
 
 function hasKnownExtension(candidate) {
@@ -195,9 +200,51 @@ function resolveCliBin(commandName, { envVarName, extraDirs = [] } = {}) {
   return resolveWithLoginShell(commandName, searchPath);
 }
 
+function escapeCmdArg(arg) {
+  const s = String(arg);
+  if (!s) return '""';
+  // No quoting needed if arg has no whitespace or cmd.exe metacharacters.
+  if (!/[\s"&|<>()^!%,;=]/.test(s)) return s;
+  // CreateProcess parse rules: escape embedded quotes and any trailing
+  // backslash runs that would otherwise eat the closing quote.
+  const inner = s
+    .replace(/(\\*)"/g, (_, bs) => bs + bs + '\\"')
+    .replace(/(\\+)$/, (_, bs) => bs + bs);
+  return `"${inner}"`;
+}
+
+function needsCmdWrapping(binPath) {
+  return IS_WINDOWS && /\.(cmd|bat)$/i.test(binPath);
+}
+
+function buildCmdWrappedArgs(binPath, args) {
+  const line = [binPath, ...args].map(escapeCmdArg).join(" ");
+  return { command: process.env.ComSpec || "cmd.exe", args: ["/d", "/s", "/c", line] };
+}
+
+function spawnCli(binPath, args, options = {}) {
+  if (needsCmdWrapping(binPath)) {
+    const { command, args: wrapped } = buildCmdWrappedArgs(binPath, args);
+    return spawn(command, wrapped, { ...options, windowsVerbatimArguments: true });
+  }
+  return spawn(binPath, args, options);
+}
+
+function execFileCli(binPath, args, options, callback) {
+  if (typeof options === "function") { callback = options; options = {}; }
+  options = options || {};
+  if (needsCmdWrapping(binPath)) {
+    const { command, args: wrapped } = buildCmdWrappedArgs(binPath, args);
+    return execFile(command, wrapped, { ...options, windowsVerbatimArguments: true }, callback);
+  }
+  return execFile(binPath, args, options, callback);
+}
+
 module.exports = {
   COMMON_EXTRA_PATH_DIRS,
   buildSpawnPath,
   isExecutable,
   resolveCliBin,
+  spawnCli,
+  execFileCli,
 };

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -1,8 +1,7 @@
-const { spawn } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
+const { buildSpawnPath, isExecutable, resolveCliBin, spawnCli } = require("./cli-bin-resolver.cjs");
 const { loadSessionMessages } = require("./session-reader.cjs");
 
 const activeAgents = new Map();
@@ -305,7 +304,7 @@ function startCodexAgent({ conversationId, prompt, model, effort, cwd, images, f
   log("Full args:", args.filter(a => a !== fullPrompt).join(" "));
   log("Prompt:", fullPrompt.slice(0, 100));
 
-  const child = spawn(codexBin, args, {
+  const child = spawnCli(codexBin, args, {
     cwd: launchCwd,
     env: {
       ...process.env,

--- a/electron/github-manager.cjs
+++ b/electron/github-manager.cjs
@@ -1,5 +1,5 @@
-const { execFile, spawn } = require("child_process");
-const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
+const { execFile } = require("child_process");
+const { buildSpawnPath, isExecutable, resolveCliBin, spawnCli, execFileCli } = require("./cli-bin-resolver.cjs");
 
 function log(...args) {
   console.log("[github-manager]", ...args);
@@ -27,7 +27,7 @@ function gh(args) {
   return new Promise((resolve, reject) => {
     let bin;
     try { bin = resolveGhBin(); } catch (err) { reject(err); return; }
-    execFile(bin, args, {
+    execFileCli(bin, args, {
       env: ghEnv(),
       timeout: 15000,
       maxBuffer: 5 * 1024 * 1024,
@@ -45,7 +45,7 @@ function ghWithStdin(args, jsonBody) {
   return new Promise((resolve, reject) => {
     let bin;
     try { bin = resolveGhBin(); } catch (err) { reject(err); return; }
-    const child = spawn(bin, args, {
+    const child = spawnCli(bin, args, {
       env: ghEnv(),
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 15000,
@@ -75,7 +75,7 @@ function ghWithRawStdin(args, input) {
   return new Promise((resolve, reject) => {
     let bin;
     try { bin = resolveGhBin(); } catch (err) { reject(err); return; }
-    const child = spawn(bin, args, {
+    const child = spawnCli(bin, args, {
       env: ghEnv(),
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 15000,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -16,7 +16,7 @@ const {
   multicaListMessages,
   subscribeMulticaAgent,
 } = require("./multica-manager.cjs");
-const { buildSpawnPath, resolveCliBin } = require("./cli-bin-resolver.cjs");
+const { buildSpawnPath, resolveCliBin, spawnCli } = require("./cli-bin-resolver.cjs");
 const { listSessions, loadSessionMessages, moveSession } = require("./session-reader.cjs");
 const { createCheckpoint, restoreCheckpoint } = require("./checkpoint.cjs");
 const terminalManager = require("./terminal-manager.cjs");
@@ -481,7 +481,6 @@ ipcMain.handle("system-info", () => ({
 
 // IPC: quick explain (one-shot, not in chat history)
 ipcMain.handle("quick-explain", async (_event, { text, model }) => {
-  const { spawn } = require("child_process");
   return new Promise((resolve) => {
     const claudeBin = resolveCliBin("claude", { envVarName: "CLAUDE_BIN" });
     if (!claudeBin) {
@@ -498,7 +497,7 @@ ipcMain.handle("quick-explain", async (_event, { text, model }) => {
       "--system-prompt", "You are a concise explainer. Give 1-3 sentence explanations. Use markdown for formatting.",
       `Explain this briefly:\n\n${text}`,
     ];
-    const child = spawn(claudeBin, args, {
+    const child = spawnCli(claudeBin, args, {
       env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -1109,8 +1108,7 @@ ipcMain.handle("git-gen-commit-message", async (_e, cwd) => {
     ];
 
     return await new Promise((resolve) => {
-      const { spawn } = require("child_process");
-      const child = spawn(claudeBin, args, {
+      const child = spawnCli(claudeBin, args, {
         cwd,
         env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
         stdio: ["ignore", "pipe", "pipe"],

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -11,8 +11,11 @@ const terminalManager = require("./terminal-manager.cjs");
 const ghManager = require("./github-manager.cjs");
 
 const isDev = !app.isPackaged;
+const isMac = process.platform === "darwin";
+const isWindows = process.platform === "win32";
 const SHELL_COMMAND_TIMEOUT_MS = 15000;
 const SHELL_OUTPUT_LIMIT = 128 * 1024;
+const WINDOW_BACKGROUND = "#0D0D10";
 const WALLPAPER_EXTENSIONS = ["png", "jpg", "jpeg", "webp", "gif", "bmp", "avif"];
 const WALLPAPER_MIME_TYPES = {
   png: "image/png",
@@ -26,7 +29,7 @@ const WALLPAPER_MIME_TYPES = {
 
 // Override app name (in dev, Electron uses its own binary name)
 app.setName("RayLine");
-if (isDev && process.platform === "darwin") {
+if (isDev && isMac) {
   // Patch the dock name in dev mode
   const { execSync } = require("child_process");
   try {
@@ -38,6 +41,34 @@ if (isDev && process.platform === "darwin") {
 
 let mainWindow;
 let pmWindow;
+
+function getWindowChromeOptions() {
+  if (isMac) {
+    return {
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 16, y: 18 },
+    };
+  }
+
+  if (isWindows) {
+    return {
+      titleBarStyle: "hidden",
+      titleBarOverlay: {
+        color: WINDOW_BACKGROUND,
+        symbolColor: "#C8CBD3",
+        height: 52,
+      },
+      autoHideMenuBar: true,
+    };
+  }
+
+  return {};
+}
+
+function applyWindowChromeTweaks(win) {
+  if (!win || !isWindows) return;
+  win.setMenuBarVisibility(false);
+}
 
 function getWallpaperStorageDir() {
   const dir = path.join(app.getPath("userData"), "wallpapers");
@@ -85,16 +116,16 @@ function createWindow() {
     height: 800,
     minWidth: 800,
     minHeight: 600,
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 18 },
-    backgroundColor: "#0D0D10",
+    backgroundColor: WINDOW_BACKGROUND,
     icon: path.join(__dirname, "../public/icon.png"),
+    ...getWindowChromeOptions(),
     webPreferences: {
       preload: path.join(__dirname, "preload.cjs"),
       contextIsolation: true,
       nodeIntegration: false,
     },
   });
+  applyWindowChromeTweaks(mainWindow);
 
   // Open external links in system browser
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -128,16 +159,16 @@ function createProjectManagerWindow() {
     height: 700,
     minWidth: 700,
     minHeight: 500,
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 18 },
-    backgroundColor: "#0D0D10",
+    backgroundColor: WINDOW_BACKGROUND,
     icon: path.join(__dirname, "../public/icon.png"),
+    ...getWindowChromeOptions(),
     webPreferences: {
       preload: path.join(__dirname, "preload-pm.cjs"),
       contextIsolation: true,
       nodeIntegration: false,
     },
   });
+  applyWindowChromeTweaks(pmWindow);
 
   pmWindow.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
@@ -158,7 +189,7 @@ app.setName("RayLine");
 
 app.whenReady().then(() => {
   // Set dock icon on macOS
-  if (process.platform === "darwin") {
+  if (isMac) {
     const iconPath = path.join(__dirname, "../public/icon.png");
     const icon = nativeImage.createFromPath(iconPath);
     if (!icon.isEmpty()) app.dock.setIcon(icon);
@@ -191,7 +222,7 @@ app.whenReady().then(() => {
 });
 
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") app.quit();
+  if (!isMac) app.quit();
 });
 
 app.on("activate", () => {
@@ -500,7 +531,6 @@ ipcMain.handle("shell-run", async (_event, { command, cwd }) => {
       return;
     }
 
-    const isWindows = process.platform === "win32";
     const shellBin = isWindows ? (process.env.ComSpec || "cmd.exe") : "/bin/sh";
     const shellArgs = isWindows
       ? ["/d", "/s", "/c", shellCommand]

--- a/electron/session-reader.cjs
+++ b/electron/session-reader.cjs
@@ -8,7 +8,10 @@ const MAX_MESSAGES = 50; // max user+assistant message pairs to load
 const CODEX_USER_PROMPT_MARKER = "--- USER PROMPT ---";
 
 function projectDirName(cwd) {
-  return cwd.replace(/\//g, "-");
+  // Claude CLI encodes both POSIX and Windows paths by replacing path
+  // separators and the Windows drive colon with `-`. For `C:\Users\kira\Documents`
+  // this yields `C--Users-kira-Documents`, matching what the CLI writes.
+  return cwd.replace(/[\\/:]/g, "-");
 }
 
 function extractSessionCwdFromFile(filePath) {

--- a/electron/session-reader.cjs
+++ b/electron/session-reader.cjs
@@ -8,10 +8,14 @@ const MAX_MESSAGES = 50; // max user+assistant message pairs to load
 const CODEX_USER_PROMPT_MARKER = "--- USER PROMPT ---";
 
 function projectDirName(cwd) {
-  // Claude CLI encodes both POSIX and Windows paths by replacing path
-  // separators and the Windows drive colon with `-`. For `C:\Users\kira\Documents`
-  // this yields `C--Users-kira-Documents`, matching what the CLI writes.
-  return cwd.replace(/[\\/:]/g, "-");
+  // Windows: the Claude CLI encodes `C:\Users\kira\Documents` as
+  // `C--Users-kira-Documents` — we must replace backslash and drive colon
+  // too, or the path gets pasted verbatim into `~/.claude/projects/` and
+  // produces an illegal nested drive letter.
+  // Other platforms: keep the original `/` → `-` rule untouched to preserve
+  // bug-compatible behavior for existing session files.
+  if (process.platform === "win32") return cwd.replace(/[\\/:]/g, "-");
+  return cwd.replace(/\//g, "-");
 }
 
 function extractSessionCwdFromFile(filePath) {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
   "build": {
     "appId": "com.ensue.rayline",
     "productName": "RayLine",
+    "publish": {
+      "provider": "github",
+      "owner": "EnSue-Laboratories",
+      "repo": "RAYLINE",
+      "releaseType": "draft"
+    },
     "win": {
       "icon": "public/icon.png",
       "target": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "ensue",
   "productName": "RayLine",
   "description": "RayLine — a desktop client for Claude Code",
-  "author": "Ensue Laboratories",
+  "author": {
+    "name": "Ensue Laboratories",
+    "email": "contact@ensue.dev"
+  },
+  "homepage": "https://github.com/EnSue-Laboratories/RAYLINE",
   "private": true,
   "version": "0.1.1",
   "type": "module",
@@ -40,6 +44,7 @@
   "build": {
     "appId": "com.ensue.rayline",
     "productName": "RayLine",
+    "publish": null,
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "public/icon.png",
@@ -65,6 +70,16 @@
           "type": "link",
           "path": "/Applications"
         }
+      ]
+    },
+    "linux": {
+      "category": "Development",
+      "icon": "public/icon.png",
+      "maintainer": "Ensue Laboratories <contact@ensue.dev>",
+      "target": [
+        "AppImage",
+        "deb",
+        "tar.gz"
       ]
     },
     "files": [

--- a/package.json
+++ b/package.json
@@ -40,6 +40,21 @@
   "build": {
     "appId": "com.ensue.rayline",
     "productName": "RayLine",
+    "npmRebuild": false,
+    "win": {
+      "icon": "public/icon.png",
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        }
+      ]
+    },
+    "nsis": {
+      "oneClick": true,
+      "perMachine": false,
+      "allowToChangeInstallationDirectory": false
+    },
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "public/icon.png",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:electron": "concurrently \"vite --port 5199 --strictPort\" \"wait-on http://localhost:5199 && node scripts/dev-electron.cjs 5199\"",
     "build": "vite build",
     "build:electron": "vite build && electron-builder",
+    "build:electron:win": "vite build && electron-builder --win --config.npmRebuild=false",
     "lint": "eslint .",
     "preview": "vite preview",
     "rebuild": "electron-rebuild -f -w node-pty"
@@ -40,7 +41,6 @@
   "build": {
     "appId": "com.ensue.rayline",
     "productName": "RayLine",
-    "npmRebuild": false,
     "win": {
       "icon": "public/icon.png",
       "target": [


### PR DESCRIPTION
## Summary
- make Electron window chrome platform-specific instead of sharing the macOS config
- hide the Windows in-window menu bar and use a hidden title bar overlay so the app matches the macOS-style renderer better
- keep macOS traffic lights and hiddenInset behavior unchanged

## Verification
- `node --check electron/main.cjs`
- `npm run lint` not run because this checkout does not have `node_modules` installed