### PR TITLE
fix: show Multica agent name in model picker instead of status

### DIFF
--- a/src/data/multicaModels.jsx
+++ b/src/data/multicaModels.jsx
@@ -6,7 +6,7 @@ export function multicaAgentToModel(agent, state) {
   return {
     id: `multica:${agent.id}`,
     name: agent.name,
-    tag: (agent.status || "unknown").toUpperCase(),
+    tag: (agent.name || "agent").toUpperCase(),
     provider: "multica",
     agentId: agent.id,
     workspaceId: state.workspaceId,
@@ -57,7 +57,7 @@ export function useMulticaModels() {
       const agent = e.detail;
       if (!agent?.id) return;
       setModels((prev) => prev.map((m) => m.agentId === agent.id
-        ? { ...m, tag: (agent.status || "unknown").toUpperCase(), status: agent.status }
+        ? { ...m, status: agent.status }
         : m));
     };
     window.addEventListener("multica-agent-status", h);


### PR DESCRIPTION
## Summary
- The model picker button renders `tag`, which was being derived from `agent.status` — so selecting a Multica agent displayed `IDLE` / `WORKING` instead of the agent's name.
- `tag` now comes from `agent.name` (uppercased), matching the `OPUS` / `SONNET` / `GPT-5.4` convention used by the built-in models.
- The `multica-agent-status` event listener no longer overwrites `tag` on status transitions; it just updates `status`, which is still kept on the model object for other UI surfaces.

## Test plan
- [ ] Connect a Multica workspace, open the model picker, and verify the button shows the agent name (uppercase) instead of `IDLE` / `WORKING`.
- [ ] Trigger a status change on a selected Multica agent and confirm the button label does not flip to the status string.
- [ ] Confirm built-in Claude / Codex models still render their usual tags unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)