### PR TITLE
feat: hint above composer when Multica branch has uncommitted / unpublished changes

### DIFF
--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -13,6 +13,8 @@ import { useFontScale } from "../contexts/FontSizeContext";
 import { WINDOW_DRAG_HEIGHT } from "../windowChrome";
 import { getPaneSurfaceStyle } from "../utils/paneSurface";
 import TabStrip from "./TabStrip";
+import useGitStatus from "../hooks/useGitStatus";
+import { isMulticaModelId } from "../data/models";
 
 const EMPTY_MESSAGES = [];
 
@@ -161,6 +163,21 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
     return parts.slice(-2).join("/") || parts[parts.length - 1] || cwd;
   })() : "current workspace";
 
+  const activeModelId = convo?.model || defaultModel;
+  const isMulticaModel = isMulticaModelId(activeModelId);
+  const { status: gitStatus } = useGitStatus(cwd);
+  const hasDirtyWorktree = (gitStatus?.files?.length || 0) > 0;
+  const hasNoUpstream = Boolean(gitStatus?.branch) && !gitStatus?.upstream && !gitStatus?.detached;
+  const branchNeedsAttention = hasDirtyWorktree || hasNoUpstream;
+  const [branchHintDismissed, setBranchHintDismissed] = useState(false);
+  useEffect(() => { setBranchHintDismissed(false); }, [convo?.id]);
+  const showBranchHint = isMulticaModel && !showNewChatCard && branchNeedsAttention && !branchHintDismissed && !shellMode;
+  const branchHintText = (() => {
+    if (hasDirtyWorktree && hasNoUpstream) return "BRANCH MAY NEED UPDATING  //  UNCOMMITTED CHANGES + NOT PUBLISHED";
+    if (hasDirtyWorktree) return "BRANCH MAY NEED UPDATING  //  UNCOMMITTED CHANGES";
+    return "BRANCH MAY NEED UPDATING  //  NOT PUBLISHED TO ORIGIN";
+  })();
+
   const send = useCallback(() => {
     if (!canSend) return;
     const nextInput = trimmedInput;
@@ -171,8 +188,9 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
       setSelectedCmd(0);
     });
     if (inRef.current) inRef.current.style.height = "20px";
+    if (isMulticaModel && !shellMode) setBranchHintDismissed(true);
     onSend(nextInput, nextAttachments);
-  }, [attachments, canSend, onSend, shellMode, trimmedInput]);
+  }, [attachments, canSend, isMulticaModel, onSend, shellMode, trimmedInput]);
 
   const handleInput = (e) => {
     setInput(e.target.value);
@@ -858,6 +876,19 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               {canRunShell
                 ? `SHELL MODE  //  RUNS IN ${shellLocation.toUpperCase()}`
                 : "SHELL MODE  //  TYPE A COMMAND AFTER !"}
+            </div>
+          )}
+          {showBranchHint && (
+            <div
+              style={{
+                marginBottom: 6,
+                fontSize: s(10),
+                fontFamily: "'JetBrains Mono',monospace",
+                letterSpacing: ".1em",
+                color: "rgba(255,210,140,0.55)",
+              }}
+            >
+              {branchHintText}
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- When a Multica model is selected in an open chat, poll \`useGitStatus(cwd)\` and show a subtle amber hint above the message input if the branch has uncommitted changes or no upstream.
- The hint wording reflects which condition(s) apply (\`UNCOMMITTED CHANGES\`, \`NOT PUBLISHED TO ORIGIN\`, or both).
- Suppressed on the new-chat page, in shell mode (\`!\`-prefixed), and whenever the repo isn't a git workspace / HEAD is detached.
- Dismisses itself as soon as the user sends a Multica message on that conversation, and re-evaluates when you switch chats (tied to \`convo?.id\`).

## Test plan
- [ ] On a Multica-selected chat in a clean repo with an upstream, hint does not appear.
- [ ] Touch a file so the worktree is dirty — hint appears with \`UNCOMMITTED CHANGES\`.
- [ ] Create a branch without pushing it — hint appears with \`NOT PUBLISHED TO ORIGIN\`.
- [ ] Dirty + unpublished — hint appears with the combined message.
- [ ] Send a Multica message — hint disappears and stays gone for that chat.
- [ ] Switch to a non-Multica model — hint does not render.
- [ ] Type a \`!\` shell command — branch hint is hidden while shell hint shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)