### PR TITLE
fix: show Multica agent name in sidebar conversation rows

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3229,6 +3229,7 @@ export default function App() {
           draftsCollapsed={draftsCollapsed}
           onToggleDraftsCollapsed={() => setDraftsCollapsed(p => !p)}
           developerMode={developerMode}
+          multicaModels={multicaModels}
         />
       </div>
 

--- a/src/components/ProjectGroup.jsx
+++ b/src/components/ProjectGroup.jsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { ChevronRight, FolderClosed, Plus, MoreHorizontal, Trash2 } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
-import { getM } from "../data/models";
+import { getMOrMulticaFallback } from "../data/models";
 import { relativeTime } from "../utils/time";
 import { applyPaneInteractionStyle, getPaneInteractionStyle } from "../utils/paneSurface";
 
@@ -15,6 +15,7 @@ export default function ProjectGroup({
   onToggleCollapse,
   onHideProject,
   searchActive,
+  multicaModels = [],
 }) {
   const s = useFontScale();
   const [headerHovered, setHeaderHovered] = useState(false);
@@ -211,7 +212,7 @@ export default function ProjectGroup({
       >
       {project.convos.map((c) => {
         const isActive = c.id === active;
-        const cm = getM(c.model);
+        const cm = getMOrMulticaFallback(c.model, multicaModels);
 
         return (
           <div

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -3,7 +3,7 @@ import { useFontScale } from "../contexts/FontSizeContext";
 import { Plus, Search, Trash2, PanelLeftClose, FolderOpen, Settings as SettingsIcon, ChevronRight, Workflow } from "lucide-react";
 import { SIDEBAR_TOGGLE_LEFT, SIDEBAR_TOGGLE_SIZE, SIDEBAR_TOGGLE_TOP, WINDOW_DRAG_HEIGHT } from "../windowChrome";
 import ProjectGroup from "./ProjectGroup";
-import { getM } from "../data/models";
+import { getMOrMulticaFallback } from "../data/models";
 import { applyPaneInteractionStyle, getPaneInteractionStyle } from "../utils/paneSurface";
 
 function getMainRepoRoot(dir) {
@@ -77,7 +77,7 @@ function GitHubIcon({ size = 12 }) {
   );
 }
 
-export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onToggleSidebar, cwd, onPickFolder, onOpenSettings, onOpenProjectManager, onOpenDispatch, projects, onToggleProjectCollapse, onHideProject, onNewInProject, draftsCollapsed, onToggleDraftsCollapsed, developerMode = true }) {
+export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onToggleSidebar, cwd, onPickFolder, onOpenSettings, onOpenProjectManager, onOpenDispatch, projects, onToggleProjectCollapse, onHideProject, onNewInProject, draftsCollapsed, onToggleDraftsCollapsed, developerMode = true, multicaModels = [] }) {
   const s = useFontScale();
   const [search, setSearch]     = useState("");
   const [searchFocused, setSF]  = useState(false);
@@ -309,6 +309,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             onToggleCollapse={onToggleProjectCollapse}
             onHideProject={onHideProject}
             searchActive={searchActive}
+            multicaModels={multicaModels}
           />
         ))
         }
@@ -359,7 +360,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             {/* Draft conversation rows */}
             {(searchActive || !draftsCollapsed) && drafts.map((c, i) => {
               const isActive = c.id === active;
-              const cm = getM(c.model);
+              const cm = getMOrMulticaFallback(c.model, multicaModels);
 
               return (
                 <div


### PR DESCRIPTION
## Summary
- Sidebar rows called `getM(c.model)` to resolve the model tag, which only knows built-in Claude/Codex models. For Multica conversations (`model = "multica:<agentId>"`) this fell back to the default, so every sidebar row showed "SONNET" regardless of which Multica agent the chat was bound to.
- Pipe the already-live `useMulticaModels()` array through `App.jsx → Sidebar → ProjectGroup` and resolve the tag with `getMOrMulticaFallback`, mirroring the pattern introduced by c356e2b for the model picker.

## Files
- `src/App.jsx` — pass `multicaModels` prop to `<Sidebar>`
- `src/components/Sidebar.jsx` — accept `multicaModels`, forward to `ProjectGroup`, use fallback for drafts
- `src/components/ProjectGroup.jsx` — accept `multicaModels`, use fallback per-convo

## Test plan
- [ ] Open the app with an active Multica workspace; verify sidebar rows show the agent name (e.g. `CLAUDE`, `GPT-BOY`) instead of `SONNET`.
- [ ] Switch a chat's agent via the model picker; verify the sidebar tag updates.
- [ ] Before Multica agents load, verify rows show the generic `MULTICA` fallback rather than `SONNET`.
- [ ] Non-Multica chats still render their normal tag (`OPUS`, `SONNET`, `GPT-5.4`).