### PR TITLE
fix(dispatch): stable submit button shape + softer loading dots

### DIFF
--- a/src/components/DispatchCard.jsx
+++ b/src/components/DispatchCard.jsx
@@ -285,7 +285,7 @@ function DispatchLoadingDots() {
     width: 5,
     height: 5,
     borderRadius: "50%",
-    background: "currentColor",
+    background: "rgba(0,0,0,0.45)",
     display: "inline-block",
     animation: `dotPulse 1.2s ease-in-out ${delay} infinite`,
   });

--- a/src/components/DispatchCard.jsx
+++ b/src/components/DispatchCard.jsx
@@ -265,9 +265,14 @@ export default function DispatchCard({
             disabled={!canDispatch}
             style={primaryBtnStyle(canDispatch, submitting)}
           >
-            {submitting
-              ? <DispatchLoadingDots />
-              : <>Dispatch {activeRows.length || 0} agent{activeRows.length === 1 ? "" : "s"}</>}
+            <span style={{ visibility: submitting ? "hidden" : "visible" }}>
+              Dispatch {activeRows.length || 0} agent{activeRows.length === 1 ? "" : "s"}
+            </span>
+            {submitting && (
+              <span style={{ position: "absolute", inset: 0, display: "inline-flex", alignItems: "center", justifyContent: "center" }}>
+                <DispatchLoadingDots />
+              </span>
+            )}
           </button>
         </footer>
       </div>
@@ -841,12 +846,12 @@ const footerStyle = {
   padding: "12px 18px", borderTop: "1px solid var(--pane-border)",
 };
 const primaryBtnStyle = (enabled, loading) => ({
+  position: "relative",
   padding: "8px 14px", borderRadius: 6, border: "none",
   background: loading ? "rgba(255,255,255,0.85)" : (enabled ? "white" : "rgba(255,255,255,0.1)"),
   color: loading ? "black" : (enabled ? "black" : "rgba(255,255,255,0.4)"),
   cursor: loading ? "progress" : (enabled ? "pointer" : "not-allowed"),
   fontSize: 12, fontWeight: 500,
-  minWidth: loading ? 120 : undefined,
   display: "inline-flex", alignItems: "center", justifyContent: "center",
 });
 


### PR DESCRIPTION
## Summary
Carries the two cosmetic refinements from #113 that were not included when image paste + three-dot loader landed via #114. Targets `main` directly; #113 can be closed.

- **Stable button shape while dispatching** (`bcf2d8a`) — render the label with `visibility: hidden` and overlay the dots absolutely, so the button width/height does not jump when `submitting` toggles. Drops the `minWidth: 120` workaround.
- **Softer loading dots** (`dfbf161`) — switch dot color from `currentColor` to `rgba(0,0,0,0.45)` so they read as muted instead of pure black.

## Test plan
- [ ] Trigger a slow dispatch — dots animate in place; button width/height does not jump.
- [ ] Idle/disabled button states are unchanged.
- [ ] Dot color reads as soft gray, not pure black, against the white button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)