### PR TITLE
Add Linux build target for electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "ensue",
   "productName": "RayLine",
   "description": "RayLine — a desktop client for Claude Code",
-  "author": "Ensue Laboratories",
+  "author": {
+    "name": "Ensue Laboratories",
+    "email": "contact@ensue.dev"
+  },
+  "homepage": "https://github.com/EnSue-Laboratories/RAYLINE",
   "private": true,
   "version": "0.1.1",
   "type": "module",
@@ -40,6 +44,7 @@
   "build": {
     "appId": "com.ensue.rayline",
     "productName": "RayLine",
+    "publish": null,
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "public/icon.png",
@@ -65,6 +70,16 @@
           "type": "link",
           "path": "/Applications"
         }
+      ]
+    },
+    "linux": {
+      "category": "Development",
+      "icon": "public/icon.png",
+      "maintainer": "Ensue Laboratories <contact@ensue.dev>",
+      "target": [
+        "AppImage",
+        "deb",
+        "tar.gz"
       ]
     },
     "files": [


### PR DESCRIPTION
Adds AppImage, deb, and tar.gz Linux targets. Converts author to object form with email and adds homepage + deb maintainer (required by .deb packaging). Sets publish: null since there is no update provider configured.