### PR TITLE
Add GitHub account re-authentication UI

### DIFF
--- a/electron/github-manager.cjs
+++ b/electron/github-manager.cjs
@@ -110,7 +110,13 @@ function ghWithRawStdin(args, input) {
 async function checkAuth() {
   try {
     const out = await gh(["auth", "status", "--hostname", "github.com"]);
-    const user = parseAuthStatusUser(out);
+    let user = parseAuthStatusUser(out);
+    if (!user) {
+      // Authoritative fallback — works across all gh output variants.
+      try {
+        user = (await gh(["api", "user", "-q", ".login"])) || null;
+      } catch { /* leave user null */ }
+    }
     return { ok: true, user };
   } catch (err) {
     return { ok: false, error: err.message };
@@ -170,6 +176,8 @@ function startWebAuth(onEvent) {
   let browserEventSent = false;
   let authenticated = false;
   let finished = false;
+  let gitCredPromptAnswered = false;
+  let stallTimer = null;
 
   const finish = (event) => {
     if (finished) return;
@@ -183,6 +191,7 @@ function startWebAuth(onEvent) {
     buffer += text;
     // Cap buffer so we don't grow unbounded on long flows.
     if (buffer.length > 32 * 1024) buffer = buffer.slice(-16 * 1024);
+    log("auth buffer tail:", buffer.slice(-200).replace(/\n/g, "\\n"));
 
     // Extract one-time code once.
     if (!codeSeen) {
@@ -190,6 +199,16 @@ function startWebAuth(onEvent) {
       if (codeMatch) {
         codeSeen = true;
         onEvent({ type: "code", code: codeMatch[1] });
+        // Open the device page and advance gh immediately once the code is
+        // visible instead of relying on exact prompt wording.
+        if (!browserEventSent) {
+          browserEventSent = true;
+          onEvent({ type: "browser", url: "https://github.com/login/device" });
+        }
+        if (!enterSent) {
+          enterSent = true;
+          try { proc.write("\r"); } catch {}
+        }
       }
     }
 
@@ -208,6 +227,13 @@ function startWebAuth(onEvent) {
       try { proc.write("y\r"); } catch {}
     }
 
+    // gh 2.89 still asks this before showing the one-time code. Default is
+    // "Yes" — press Enter to accept.
+    if (!gitCredPromptAnswered && /Authenticate Git with your GitHub credentials\??/i.test(buffer)) {
+      gitCredPromptAnswered = true;
+      try { proc.write("\r"); } catch {}
+    }
+
     // Success markers from gh. `Logged in as` is the most reliable one across
     // gh versions; `Authentication complete` is printed just before it.
     if (!authenticated) {
@@ -223,6 +249,7 @@ function startWebAuth(onEvent) {
 
   proc.onData(handleChunk);
   proc.onExit(({ exitCode }) => {
+    if (stallTimer) { clearTimeout(stallTimer); stallTimer = null; }
     if (finished) return;
     if (exitCode === 0 && authenticated) {
       // Already handled by the success marker above.
@@ -240,6 +267,19 @@ function startWebAuth(onEvent) {
       });
     }
   });
+
+  // If 20s pass with no one-time code shown, something is blocking the flow.
+  // Kill the process and surface the captured output so the user (and us)
+  // can see which prompt gh was stuck on.
+  stallTimer = setTimeout(() => {
+    if (finished || codeSeen) return;
+    try { proc.kill(); } catch {}
+    finish({
+      type: "error",
+      error: "Timed out waiting for GitHub. gh may be stuck on a prompt.",
+      output: buffer.trim().slice(-500) || "(no output)",
+    });
+  }, 20000);
 
   const session = {
     proc,

--- a/electron/github-manager.cjs
+++ b/electron/github-manager.cjs
@@ -1,6 +1,15 @@
 const { execFile, spawn } = require("child_process");
 const { buildSpawnPath, isExecutable, resolveCliBin } = require("./cli-bin-resolver.cjs");
 
+// node-pty is a native module — load lazily so the manager still loads even
+// if the prebuild is missing for the current Electron version.
+let pty;
+try {
+  pty = require("node-pty");
+} catch (e) {
+  console.error("[github-manager] node-pty failed to load:", e.message);
+}
+
 function log(...args) {
   console.log("[github-manager]", ...args);
 }
@@ -100,9 +109,162 @@ function ghWithRawStdin(args, input) {
 
 async function checkAuth() {
   try {
-    await gh(["auth", "status"]);
+    const out = await gh(["auth", "status", "--hostname", "github.com"]);
+    const user = parseAuthStatusUser(out);
+    return { ok: true, user };
+  } catch (err) {
+    return { ok: false, error: err.message };
+  }
+}
+
+function parseAuthStatusUser(text) {
+  if (!text) return null;
+  // Match both newer ("account USERNAME") and older ("as USERNAME") phrasings.
+  const m =
+    text.match(/Logged in to [^\s]+ account ([^\s(]+)/i) ||
+    text.match(/Logged in to [^\s]+ as ([^\s(]+)/i);
+  return m ? m[1] : null;
+}
+
+// --- Interactive auth flow -------------------------------------------------
+// Drives `gh auth login --web` in a PTY so we can watch for the one-time
+// code, auto-press Enter on prompts, and surface progress to the UI.
+
+let activeAuthSession = null;
+
+function stripAnsi(s) {
+  return s.replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "");
+}
+
+function startWebAuth(onEvent) {
+  if (!pty) {
+    onEvent({ type: "error", error: "node-pty is unavailable; cannot run interactive auth." });
+    return { cancel() {} };
+  }
+  if (activeAuthSession) {
+    onEvent({ type: "error", error: "An auth flow is already in progress." });
+    return { cancel() {} };
+  }
+
+  let bin;
+  try { bin = resolveGhBin(); } catch (err) {
+    onEvent({ type: "error", error: err.message });
+    return { cancel() {} };
+  }
+
+  const proc = pty.spawn(
+    bin,
+    ["auth", "login", "--hostname", "github.com", "--web", "--git-protocol", "https", "--skip-ssh-key"],
+    {
+      name: "xterm-256color",
+      cols: 120,
+      rows: 30,
+      cwd: process.env.HOME || process.cwd(),
+      env: ghEnv(),
+    },
+  );
+
+  let buffer = "";
+  let codeSeen = false;
+  let enterSent = false;
+  let browserEventSent = false;
+  let authenticated = false;
+  let finished = false;
+
+  const finish = (event) => {
+    if (finished) return;
+    finished = true;
+    if (activeAuthSession && activeAuthSession.proc === proc) activeAuthSession = null;
+    onEvent(event);
+  };
+
+  const handleChunk = (raw) => {
+    const text = stripAnsi(raw);
+    buffer += text;
+    // Cap buffer so we don't grow unbounded on long flows.
+    if (buffer.length > 32 * 1024) buffer = buffer.slice(-16 * 1024);
+
+    // Extract one-time code once.
+    if (!codeSeen) {
+      const codeMatch = buffer.match(/one-time code:\s*([A-Z0-9][A-Z0-9-]{3,})/i);
+      if (codeMatch) {
+        codeSeen = true;
+        onEvent({ type: "code", code: codeMatch[1] });
+      }
+    }
+
+    // Auto-press Enter when gh asks.
+    if (!enterSent && /Press Enter to open/i.test(buffer)) {
+      enterSent = true;
+      try { proc.write("\r"); } catch {}
+      if (!browserEventSent) {
+        browserEventSent = true;
+        onEvent({ type: "browser", url: "https://github.com/login/device" });
+      }
+    }
+
+    // Respond "y" to any "already logged in" / re-auth confirmation.
+    if (/already logged into.*re-authenticate/i.test(buffer) && /\(Y\/n\)/i.test(buffer)) {
+      try { proc.write("y\r"); } catch {}
+    }
+
+    // Success markers from gh. `Logged in as` is the most reliable one across
+    // gh versions; `Authentication complete` is printed just before it.
+    if (!authenticated) {
+      const userMatch =
+        buffer.match(/Logged in as ([^\s*!]+)/i) ||
+        buffer.match(/✓ Logged in as ([^\s*!]+)/i);
+      if (userMatch) {
+        authenticated = true;
+        finish({ type: "success", user: userMatch[1] });
+      }
+    }
+  };
+
+  proc.onData(handleChunk);
+  proc.onExit(({ exitCode }) => {
+    if (finished) return;
+    if (exitCode === 0 && authenticated) {
+      // Already handled by the success marker above.
+      return;
+    }
+    if (exitCode === 0) {
+      // Flow completed but we never saw the username — treat as success and
+      // let the caller re-query auth status to pick up the user.
+      finish({ type: "success", user: null });
+    } else {
+      finish({
+        type: "error",
+        error: `gh auth login exited with code ${exitCode}`,
+        output: buffer.trim().slice(-500),
+      });
+    }
+  });
+
+  const session = {
+    proc,
+    cancel() {
+      if (finished) return;
+      try { proc.kill(); } catch {}
+      finish({ type: "cancelled" });
+    },
+  };
+  activeAuthSession = session;
+  return session;
+}
+
+function cancelWebAuth() {
+  if (activeAuthSession) activeAuthSession.cancel();
+}
+
+async function logout() {
+  // `gh auth logout -h github.com` doesn't prompt when an account is
+  // unambiguous. Swallow the "not logged in" case so repeated clicks are safe.
+  try {
+    await gh(["auth", "logout", "--hostname", "github.com"]);
     return { ok: true };
   } catch (err) {
+    if (/not logged in/i.test(err.message || "")) return { ok: true };
     return { ok: false, error: err.message };
   }
 }
@@ -315,6 +477,9 @@ async function getLinkedPRs(repo, issueNumber) {
 
 module.exports = {
   checkAuth,
+  startWebAuth,
+  cancelWebAuth,
+  logout,
   listUserRepos,
   listIssues,
   listPRs,

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1173,6 +1173,22 @@ ipcMain.handle("gh-current-branch", () => ghManager.getCurrentBranch());
 ipcMain.handle("gh-repo-default-branch", (_e, repo) => ghManager.getRepoDefaultBranch(repo));
 ipcMain.handle("gh-upload-image", (_e, repo, base64Data, filename) => ghManager.uploadImage(repo, base64Data, filename));
 
+// GitHub auth flow — streams events back to the requesting window.
+ipcMain.handle("gh-auth-logout", () => ghManager.logout());
+ipcMain.handle("gh-auth-start", (event) => {
+  const sender = event.sender;
+  ghManager.startWebAuth((payload) => {
+    if (sender.isDestroyed()) return;
+    sender.send("gh-auth-event", payload);
+    // Auto-open the verification page in the default browser.
+    if (payload.type === "browser" && payload.url) {
+      shell.openExternal(payload.url);
+    }
+  });
+  return { started: true };
+});
+ipcMain.handle("gh-auth-cancel", () => { ghManager.cancelWebAuth(); return true; });
+
 ipcMain.handle("gh-load-pm-state", async () => {
   try {
     if (fs.existsSync(stateFilePath)) {

--- a/electron/preload-pm.cjs
+++ b/electron/preload-pm.cjs
@@ -26,4 +26,12 @@ contextBridge.exposeInMainWorld("ghApi", {
   loadPmState: () => ipcRenderer.invoke("gh-load-pm-state"),
   savePmState: (state) => ipcRenderer.invoke("gh-save-pm-state", state),
   readImage: (filePath) => ipcRenderer.invoke("read-image", filePath),
+  authStart: () => ipcRenderer.invoke("gh-auth-start"),
+  authCancel: () => ipcRenderer.invoke("gh-auth-cancel"),
+  authLogout: () => ipcRenderer.invoke("gh-auth-logout"),
+  onAuthEvent: (handler) => {
+    const listener = (_e, payload) => handler(payload);
+    ipcRenderer.on("gh-auth-event", listener);
+    return () => ipcRenderer.removeListener("gh-auth-event", listener);
+  },
 });

--- a/src/ProjectManager.jsx
+++ b/src/ProjectManager.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Plus, X } from "lucide-react";
+import { Check, Pencil, Plus, X } from "lucide-react";
 
 function GitHubIcon({ size = 48 }) {
   return (
@@ -20,25 +20,10 @@ import ItemDetail from "./pm-components/ItemDetail";
 import { getPaneInteractionStyle, getPaneSurfaceStyle } from "./utils/paneSurface";
 import { getWallpaperImageFilter, normalizeWallpaper } from "./utils/wallpaper";
 
-const manageLinkStyle = (variant) => ({
-  background: "none",
-  border: "none",
-  cursor: "pointer",
-  fontSize: 10,
-  fontFamily: "'JetBrains Mono', monospace",
-  color: variant === "danger"
-    ? "rgba(200,80,80,0.6)"
-    : "rgba(255,255,255,0.3)",
-  letterSpacing: ".08em",
-  padding: 0,
-  textAlign: "left",
-  transition: "color .2s",
-});
-
 const iconBtnStyle = {
-  width: 28,
-  height: 28,
-  borderRadius: 7,
+  width: 24,
+  height: 24,
+  borderRadius: 6,
   border: "1px solid var(--pane-border)",
   background: "var(--pane-interaction-hover-fill, var(--pane-hover))",
   backdropFilter: "var(--pane-interaction-hover-filter, none)",
@@ -349,7 +334,7 @@ export default function ProjectManager() {
         {/* Spacer for traffic lights */}
         <div style={{ height: 52, flexShrink: 0 }} />
 
-        {/* Header: title + add button */}
+        {/* Header: title + repo actions */}
         <div
           style={{
             padding: "0 16px 16px",
@@ -368,9 +353,39 @@ export default function ProjectManager() {
           >
             REPOS
           </span>
-          <button onClick={() => setShowAddRepo(true)} style={iconBtnStyle}>
-            <Plus size={14} strokeWidth={1.5} />
-          </button>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <button
+              onClick={() => setRemoveMode(!removeMode)}
+              title={removeMode ? "Done editing repositories" : "Edit repositories"}
+              aria-label={removeMode ? "Done editing repositories" : "Edit repositories"}
+              style={{
+                ...iconBtnStyle,
+                ...(removeMode
+                  ? {
+                    border: "1px solid rgba(120,230,150,0.22)",
+                    background: "rgba(120,230,150,0.12)",
+                    boxShadow: "0 0 0 1px rgba(120,230,150,0.06) inset",
+                    color: "rgba(120,230,150,0.9)",
+                  }
+                  : {}),
+              }}
+            >
+              {removeMode
+                ? <Check size={12} strokeWidth={1.8} />
+                : <Pencil size={12} strokeWidth={1.6} />}
+            </button>
+            <button
+              onClick={() => {
+                setRemoveMode(false);
+                setShowAddRepo(true);
+              }}
+              title="Add repository"
+              aria-label="Add repository"
+              style={iconBtnStyle}
+            >
+              <Plus size={12} strokeWidth={1.5} />
+            </button>
+          </div>
         </div>
 
         {/* Repo filter list */}
@@ -393,26 +408,26 @@ export default function ProjectManager() {
           ))}
         </div>
 
-        {/* Manage footer: stacked repos + account links */}
+        {/* Footer: account management */}
         <div
           style={{
             padding: "12px 16px",
-            borderTop: "1px solid rgba(255,255,255,0.04)",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "flex-start",
-            gap: 8,
           }}
         >
           <button
-            onClick={() => setRemoveMode(!removeMode)}
-            style={manageLinkStyle(removeMode ? "danger" : "idle")}
-          >
-            {removeMode ? "DONE" : "MANAGE REPOS"}
-          </button>
-          <button
             onClick={() => setShowAccountManager(true)}
-            style={manageLinkStyle("idle")}
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              fontSize: 10,
+              fontFamily: "'JetBrains Mono', monospace",
+              color: "rgba(255,255,255,0.3)",
+              letterSpacing: ".08em",
+              padding: 0,
+              textAlign: "left",
+              transition: "color .2s",
+            }}
           >
             MANAGE ACCOUNT
           </button>

--- a/src/ProjectManager.jsx
+++ b/src/ProjectManager.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Plus, X, UserCog } from "lucide-react";
+import { Plus, X } from "lucide-react";
 
 function GitHubIcon({ size = 48 }) {
   return (
@@ -11,6 +11,7 @@ function GitHubIcon({ size = 48 }) {
 import AuroraCanvas from "./components/AuroraCanvas";
 import Grain from "./components/Grain";
 import AuthModal from "./pm-components/AuthModal";
+import AccountManager from "./pm-components/AccountManager";
 import CreateForm from "./pm-components/CreateForm";
 import RepoManager from "./pm-components/RepoManager";
 import IssueList from "./pm-components/IssueList";
@@ -18,6 +19,21 @@ import PRList from "./pm-components/PRList";
 import ItemDetail from "./pm-components/ItemDetail";
 import { getPaneInteractionStyle, getPaneSurfaceStyle } from "./utils/paneSurface";
 import { getWallpaperImageFilter, normalizeWallpaper } from "./utils/wallpaper";
+
+const manageLinkStyle = (variant) => ({
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: 10,
+  fontFamily: "'JetBrains Mono', monospace",
+  color: variant === "danger"
+    ? "rgba(200,80,80,0.6)"
+    : "rgba(255,255,255,0.3)",
+  letterSpacing: ".08em",
+  padding: 0,
+  textAlign: "left",
+  transition: "color .2s",
+});
 
 const iconBtnStyle = {
   width: 28,
@@ -143,6 +159,7 @@ export default function ProjectManager() {
   const [authUser, setAuthUser] = useState(null);
   const [authModalMode, setAuthModalMode] = useState(null); // null | "signin" | "switch"
   const [showAddRepo, setShowAddRepo] = useState(false);
+  const [showAccountManager, setShowAccountManager] = useState(false);
   const [removeMode, setRemoveMode] = useState(false);
   const [wallpaper, setWallpaper] = useState(null);
   const [stateLoaded, setStateLoaded] = useState(false);
@@ -376,74 +393,28 @@ export default function ProjectManager() {
           ))}
         </div>
 
-        {/* Manage repos button */}
+        {/* Manage footer: stacked repos + account links */}
         <div
           style={{
             padding: "12px 16px",
             borderTop: "1px solid rgba(255,255,255,0.04)",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-start",
+            gap: 8,
           }}
         >
           <button
             onClick={() => setRemoveMode(!removeMode)}
-            style={{
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              fontSize: 10,
-              fontFamily: "'JetBrains Mono', monospace",
-              color: removeMode
-                ? "rgba(200,80,80,0.6)"
-                : "rgba(255,255,255,0.3)",
-              letterSpacing: ".08em",
-              padding: 0,
-              transition: "color .2s",
-            }}
+            style={manageLinkStyle(removeMode ? "danger" : "idle")}
           >
             {removeMode ? "DONE" : "MANAGE REPOS"}
           </button>
-        </div>
-
-        {/* Account footer: signed-in user + switch-account button */}
-        <div
-          style={{
-            padding: "10px 12px",
-            borderTop: "1px solid rgba(255,255,255,0.04)",
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              flex: 1,
-              minWidth: 0,
-              color: "rgba(255,255,255,0.5)",
-            }}
-          >
-            <GitHubIcon size={13} />
-            <span
-              title={authUser ? `@${authUser}` : "Signed in"}
-              style={{
-                fontSize: 11,
-                fontFamily: "'JetBrains Mono', monospace",
-                color: "rgba(255,255,255,0.6)",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {authUser ? `@${authUser}` : "signed in"}
-            </span>
-          </div>
           <button
-            onClick={() => setAuthModalMode("switch")}
-            title="Switch GitHub account"
-            style={{ ...iconBtnStyle, width: 24, height: 24 }}
+            onClick={() => setShowAccountManager(true)}
+            style={manageLinkStyle("idle")}
           >
-            <UserCog size={12} strokeWidth={1.5} />
+            MANAGE ACCOUNT
           </button>
         </div>
       </div>
@@ -571,6 +542,23 @@ export default function ProjectManager() {
           repos={repos}
           onAdd={handleAddRepo}
           onClose={() => setShowAddRepo(false)}
+        />
+      )}
+
+      {/* Account manager modal */}
+      {showAccountManager && (
+        <AccountManager
+          currentUser={authUser}
+          onSwitchAccount={() => {
+            setShowAccountManager(false);
+            setAuthModalMode("switch");
+          }}
+          onSignedOut={async () => {
+            setShowAccountManager(false);
+            setSelectedItem(null);
+            await refreshAuth();
+          }}
+          onClose={() => setShowAccountManager(false)}
         />
       )}
 

--- a/src/ProjectManager.jsx
+++ b/src/ProjectManager.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Plus, X } from "lucide-react";
+import { Plus, X, UserCog } from "lucide-react";
 
 function GitHubIcon({ size = 48 }) {
   return (
@@ -10,6 +10,7 @@ function GitHubIcon({ size = 48 }) {
 }
 import AuroraCanvas from "./components/AuroraCanvas";
 import Grain from "./components/Grain";
+import AuthModal from "./pm-components/AuthModal";
 import CreateForm from "./pm-components/CreateForm";
 import RepoManager from "./pm-components/RepoManager";
 import IssueList from "./pm-components/IssueList";
@@ -139,6 +140,8 @@ export default function ProjectManager() {
   const [repoFilter, setRepoFilter] = useState(null);
   const [selectedItem, setSelectedItem] = useState(null);
   const [authOk, setAuthOk] = useState(null);
+  const [authUser, setAuthUser] = useState(null);
+  const [authModalMode, setAuthModalMode] = useState(null); // null | "signin" | "switch"
   const [showAddRepo, setShowAddRepo] = useState(false);
   const [removeMode, setRemoveMode] = useState(false);
   const [wallpaper, setWallpaper] = useState(null);
@@ -148,8 +151,15 @@ export default function ProjectManager() {
   const [freshIssue, setFreshIssue] = useState(null);
   const [freshPR, setFreshPR] = useState(null);
 
+  const refreshAuth = () =>
+    window.ghApi.checkAuth().then(({ ok, user }) => {
+      setAuthOk(ok);
+      setAuthUser(ok ? user || null : null);
+      return ok;
+    });
+
   useEffect(() => {
-    window.ghApi.checkAuth().then(({ ok }) => setAuthOk(ok));
+    refreshAuth();
     window.ghApi.loadPmState().then(({ repos, wallpaper: wp }) => {
       setRepos(repos);
       if (wp?.path) {
@@ -161,6 +171,14 @@ export default function ProjectManager() {
       setStateLoaded(true);
     });
   }, []);
+
+  const handleAuthSuccess = async () => {
+    await refreshAuth();
+    setAuthModalMode(null);
+    // Force lists and repo pickers to refetch under the new account.
+    setSelectedItem(null);
+    setRefreshSignal((k) => k + 1);
+  };
 
   useEffect(() => {
     if (stateLoaded) {
@@ -218,21 +236,36 @@ export default function ProjectManager() {
         <div style={{ fontSize: 16, color: "rgba(255,255,255,0.6)" }}>
           GitHub CLI not authenticated
         </div>
-        <div style={{ fontSize: 13, color: "rgba(255,255,255,0.35)" }}>
-          Run{" "}
-          <code
-            style={{
-              background: "var(--pane-interaction-hover-fill, var(--pane-hover))",
-              backdropFilter: "var(--pane-interaction-hover-filter, none)",
-              boxShadow: "var(--pane-interaction-hover-shadow, none)",
-              padding: "2px 6px",
-              borderRadius: 4,
-            }}
-          >
-            gh auth login
-          </code>{" "}
-          in your terminal
+        <div style={{ fontSize: 13, color: "rgba(255,255,255,0.35)", maxWidth: 360, textAlign: "center" }}>
+          Sign in with GitHub to browse your repos, issues, and pull requests.
         </div>
+        <button
+          onClick={() => setAuthModalMode("signin")}
+          style={{
+            marginTop: 4,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "9px 18px",
+            borderRadius: 8,
+            border: "1px solid var(--pane-border)",
+            background: "rgba(255,255,255,0.1)",
+            color: "rgba(255,255,255,0.9)",
+            fontSize: 13,
+            fontFamily: "system-ui, sans-serif",
+            cursor: "pointer",
+          }}
+        >
+          <GitHubIcon size={14} /> Sign in with GitHub
+        </button>
+        {authModalMode && (
+          <AuthModal
+            mode={authModalMode}
+            currentUser={authUser}
+            onClose={() => setAuthModalMode(null)}
+            onAuthSuccess={handleAuthSuccess}
+          />
+        )}
       </div>
     );
   }
@@ -369,6 +402,50 @@ export default function ProjectManager() {
             {removeMode ? "DONE" : "MANAGE REPOS"}
           </button>
         </div>
+
+        {/* Account footer: signed-in user + switch-account button */}
+        <div
+          style={{
+            padding: "10px 12px",
+            borderTop: "1px solid rgba(255,255,255,0.04)",
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flex: 1,
+              minWidth: 0,
+              color: "rgba(255,255,255,0.5)",
+            }}
+          >
+            <GitHubIcon size={13} />
+            <span
+              title={authUser ? `@${authUser}` : "Signed in"}
+              style={{
+                fontSize: 11,
+                fontFamily: "'JetBrains Mono', monospace",
+                color: "rgba(255,255,255,0.6)",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {authUser ? `@${authUser}` : "signed in"}
+            </span>
+          </div>
+          <button
+            onClick={() => setAuthModalMode("switch")}
+            title="Switch GitHub account"
+            style={{ ...iconBtnStyle, width: 24, height: 24 }}
+          >
+            <UserCog size={12} strokeWidth={1.5} />
+          </button>
+        </div>
       </div>
 
       {/* Right content area */}
@@ -494,6 +571,16 @@ export default function ProjectManager() {
           repos={repos}
           onAdd={handleAddRepo}
           onClose={() => setShowAddRepo(false)}
+        />
+      )}
+
+      {/* Auth modal (sign in or switch account) */}
+      {authModalMode && (
+        <AuthModal
+          mode={authModalMode}
+          currentUser={authUser}
+          onClose={() => setAuthModalMode(null)}
+          onAuthSuccess={handleAuthSuccess}
         />
       )}
     </div>

--- a/src/pm-components/AccountManager.jsx
+++ b/src/pm-components/AccountManager.jsx
@@ -1,0 +1,281 @@
+import { useState } from "react";
+import { X, LogOut, UserCog, Loader2 } from "lucide-react";
+
+function GitHubGlyph({ size = 18 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
+export default function AccountManager({ currentUser, onSwitchAccount, onSignedOut, onClose }) {
+  const [signingOut, setSigningOut] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSignOut = async () => {
+    setSigningOut(true);
+    setError(null);
+    try {
+      const res = await window.ghApi.authLogout();
+      if (res && res.ok === false) {
+        setError(res.error || "Sign out failed");
+        setSigningOut(false);
+        return;
+      }
+      onSignedOut && onSignedOut();
+    } catch (err) {
+      const msg = (err && err.message) || "Sign out failed";
+      const cleaned = msg
+        .replace(/^Error invoking remote method '[^']+':\s*/i, "")
+        .replace(/^Error:\s*/i, "");
+      setError(cleaned);
+      setSigningOut(false);
+    }
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.7)",
+        backdropFilter: "blur(8px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 200,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 400,
+          background: "var(--pane-elevated)",
+          borderRadius: 12,
+          border: "1px solid var(--pane-border)",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "16px 20px",
+            borderBottom: "1px solid rgba(255,255,255,0.04)",
+            flexShrink: 0,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 500,
+              color: "rgba(255,255,255,0.85)",
+            }}
+          >
+            Manage Account
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 7,
+              border: "1px solid var(--pane-border)",
+              background: "var(--pane-hover)",
+              color: "rgba(255,255,255,0.5)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            <X size={14} strokeWidth={1.5} />
+          </button>
+        </div>
+
+        {/* Current user card */}
+        <div style={{ padding: "14px 16px 8px" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: currentUser ? "12px 14px" : "14px",
+              borderRadius: 8,
+              border: "1px solid var(--pane-border)",
+              background: "var(--pane-hover)",
+            }}
+          >
+            <div style={{ color: "rgba(255,255,255,0.6)", display: "flex" }}>
+              <GitHubGlyph size={18} />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              {currentUser ? (
+                <>
+                  <div
+                    style={{
+                      fontSize: 10,
+                      fontFamily: "'JetBrains Mono', monospace",
+                      color: "rgba(255,255,255,0.35)",
+                      letterSpacing: ".08em",
+                      marginBottom: 2,
+                    }}
+                  >
+                    SIGNED IN AS
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontFamily: "'JetBrains Mono', monospace",
+                      color: "rgba(255,255,255,0.85)",
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    @{currentUser}
+                  </div>
+                </>
+              ) : (
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontFamily: "system-ui, sans-serif",
+                    color: "rgba(255,255,255,0.75)",
+                  }}
+                >
+                  Signed in to GitHub
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div style={{ padding: "4px 12px 12px" }}>
+          <ActionRow
+            icon={<UserCog size={15} strokeWidth={1.5} />}
+            title="Switch account"
+            subtitle="Sign in as a different GitHub user"
+            onClick={onSwitchAccount}
+          />
+          <ActionRow
+            icon={
+              signingOut ? (
+                <Loader2
+                  size={15}
+                  strokeWidth={1.5}
+                  style={{ animation: "spin 1s linear infinite" }}
+                />
+              ) : (
+                <LogOut size={15} strokeWidth={1.5} />
+              )
+            }
+            title={signingOut ? "Signing out…" : "Sign out"}
+            subtitle="Log out of the GitHub CLI on this device"
+            onClick={signingOut ? null : handleSignOut}
+            danger
+          />
+          <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+
+          {error && (
+            <div
+              style={{
+                marginTop: 8,
+                padding: "8px 12px",
+                borderRadius: 7,
+                border: "1px solid rgba(220,120,120,0.22)",
+                background: "rgba(220,120,120,0.07)",
+                fontSize: 12,
+                color: "rgba(230,180,180,0.82)",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {error}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ActionRow({ icon, title, subtitle, onClick, danger }) {
+  const [hovered, setHovered] = useState(false);
+  const disabled = !onClick;
+  return (
+    <button
+      onClick={onClick || undefined}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      disabled={disabled}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        width: "100%",
+        padding: "10px 12px",
+        borderRadius: 8,
+        border: "none",
+        cursor: disabled ? "default" : "pointer",
+        background: hovered && !disabled ? "var(--pane-hover)" : "transparent",
+        transition: "background .15s, color .15s",
+        textAlign: "left",
+        color: danger
+          ? hovered
+            ? "rgba(230,140,140,0.95)"
+            : "rgba(220,140,140,0.8)"
+          : "rgba(255,255,255,0.8)",
+        opacity: disabled ? 0.6 : 1,
+      }}
+    >
+      <span
+        style={{
+          display: "flex",
+          width: 15,
+          height: 15,
+          flexShrink: 0,
+          color: danger
+            ? hovered
+              ? "rgba(230,140,140,0.95)"
+              : "rgba(220,140,140,0.7)"
+            : "rgba(255,255,255,0.55)",
+        }}
+      >
+        {icon}
+      </span>
+      <span style={{ flex: 1, minWidth: 0 }}>
+        <span
+          style={{
+            display: "block",
+            fontSize: 13,
+            fontFamily: "system-ui, sans-serif",
+            color: "inherit",
+          }}
+        >
+          {title}
+        </span>
+        <span
+          style={{
+            display: "block",
+            fontSize: 11,
+            fontFamily: "system-ui, sans-serif",
+            color: "rgba(255,255,255,0.35)",
+            marginTop: 2,
+          }}
+        >
+          {subtitle}
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/src/pm-components/AuthModal.jsx
+++ b/src/pm-components/AuthModal.jsx
@@ -1,0 +1,382 @@
+import { useEffect, useRef, useState } from "react";
+import { X, Loader2, Check, Copy, ExternalLink } from "lucide-react";
+
+function GitHubGlyph({ size = 28 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
+// phases: idle | starting | code | success | error | cancelled
+export default function AuthModal({ mode = "signin", currentUser, onClose, onAuthSuccess }) {
+  const [phase, setPhase] = useState("idle");
+  const [code, setCode] = useState(null);
+  const [user, setUser] = useState(null);
+  const [error, setError] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const unsubRef = useRef(null);
+  const startedRef = useRef(false);
+
+  const start = async () => {
+    setPhase("starting");
+    setCode(null);
+    setUser(null);
+    setError(null);
+
+    const unsub = window.ghApi.onAuthEvent((event) => {
+      if (event.type === "code") {
+        setCode(event.code);
+        setPhase("code");
+      } else if (event.type === "success") {
+        setUser(event.user || null);
+        setPhase("success");
+      } else if (event.type === "error") {
+        setError(event.error || "Authentication failed");
+        setPhase("error");
+      } else if (event.type === "cancelled") {
+        setPhase("cancelled");
+      }
+    });
+    unsubRef.current = unsub;
+
+    try {
+      if (mode === "switch") {
+        await window.ghApi.authLogout();
+      }
+      await window.ghApi.authStart();
+    } catch (err) {
+      setError(err.message || "Failed to start auth flow");
+      setPhase("error");
+    }
+  };
+
+  useEffect(() => {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      start();
+    }
+    return () => {
+      if (unsubRef.current) unsubRef.current();
+      // Best-effort: if the user closes the modal mid-flow, kill the gh process.
+      window.ghApi.authCancel().catch(() => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (phase === "success") {
+      const t = setTimeout(() => {
+        onAuthSuccess && onAuthSuccess(user);
+      }, 1200);
+      return () => clearTimeout(t);
+    }
+  }, [phase, user, onAuthSuccess]);
+
+  const copyCode = async () => {
+    if (!code) return;
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch { /* clipboard may be unavailable; user can copy manually */ }
+  };
+
+  const retry = () => {
+    if (unsubRef.current) { unsubRef.current(); unsubRef.current = null; }
+    startedRef.current = false;
+    start();
+    startedRef.current = true;
+  };
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,0.7)",
+        backdropFilter: "blur(8px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 200,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 420,
+          background: "var(--pane-elevated)",
+          borderRadius: 12,
+          border: "1px solid var(--pane-border)",
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        {/* Header */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "16px 20px",
+            borderBottom: "1px solid rgba(255,255,255,0.04)",
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 10, color: "rgba(255,255,255,0.85)" }}>
+            <GitHubGlyph size={18} />
+            <span style={{ fontSize: 14, fontWeight: 500 }}>
+              {mode === "switch" ? "Switch GitHub account" : "Sign in to GitHub"}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            style={{
+              width: 28,
+              height: 28,
+              borderRadius: 7,
+              border: "1px solid var(--pane-border)",
+              background: "var(--pane-hover)",
+              color: "rgba(255,255,255,0.5)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            <X size={14} strokeWidth={1.5} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: "20px 22px", minHeight: 180 }}>
+          {mode === "switch" && currentUser && phase !== "success" && (
+            <div
+              style={{
+                fontSize: 12,
+                color: "rgba(255,255,255,0.45)",
+                marginBottom: 14,
+              }}
+            >
+              Currently signed in as{" "}
+              <span style={{ color: "rgba(255,255,255,0.75)", fontFamily: "'JetBrains Mono', monospace" }}>
+                @{currentUser}
+              </span>
+            </div>
+          )}
+
+          {phase === "starting" && (
+            <Center>
+              <Loader2 size={22} style={{ animation: "spin 1s linear infinite", color: "rgba(255,255,255,0.5)" }} />
+              <Label>Starting GitHub authentication…</Label>
+              <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+            </Center>
+          )}
+
+          {phase === "code" && code && (
+            <>
+              <Label>
+                1. Copy this one-time code
+              </Label>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  marginTop: 8,
+                  padding: "14px 16px",
+                  borderRadius: 8,
+                  border: "1px solid var(--pane-border)",
+                  background: "var(--pane-hover)",
+                }}
+              >
+                <div
+                  style={{
+                    flex: 1,
+                    fontFamily: "'JetBrains Mono', monospace",
+                    fontSize: 22,
+                    letterSpacing: ".18em",
+                    color: "rgba(255,255,255,0.9)",
+                    textAlign: "center",
+                  }}
+                >
+                  {code}
+                </div>
+                <button
+                  onClick={copyCode}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    background: "var(--pane-interaction-hover-fill, var(--pane-hover))",
+                    border: "1px solid var(--pane-border)",
+                    borderRadius: 6,
+                    color: copied ? "rgba(130, 220, 160, 0.9)" : "rgba(255,255,255,0.6)",
+                    fontSize: 11,
+                    fontFamily: "'JetBrains Mono', monospace",
+                    padding: "6px 10px",
+                    cursor: "pointer",
+                    letterSpacing: ".05em",
+                  }}
+                >
+                  {copied ? <Check size={12} /> : <Copy size={12} />}
+                  {copied ? "COPIED" : "COPY"}
+                </button>
+              </div>
+              <Label style={{ marginTop: 16 }}>
+                2. Paste the code in your browser to authorize
+              </Label>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 6 }}>
+                <ExternalLink size={12} style={{ color: "rgba(255,255,255,0.35)" }} />
+                <span
+                  style={{
+                    fontSize: 12,
+                    fontFamily: "'JetBrains Mono', monospace",
+                    color: "rgba(255,255,255,0.55)",
+                  }}
+                >
+                  github.com/login/device
+                </span>
+                <span style={{ fontSize: 11, color: "rgba(255,255,255,0.3)", marginLeft: 4 }}>
+                  opened automatically
+                </span>
+              </div>
+              <Label style={{ marginTop: 16 }}>
+                3. Waiting for authorization…
+              </Label>
+              <Loader2
+                size={16}
+                style={{
+                  animation: "spin 1s linear infinite",
+                  color: "rgba(255,255,255,0.35)",
+                  marginTop: 8,
+                }}
+              />
+              <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+            </>
+          )}
+
+          {phase === "success" && (
+            <Center>
+              <div
+                style={{
+                  width: 36,
+                  height: 36,
+                  borderRadius: "50%",
+                  background: "rgba(130, 220, 160, 0.15)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  color: "rgba(130, 220, 160, 0.9)",
+                }}
+              >
+                <Check size={18} />
+              </div>
+              <div style={{ fontSize: 14, color: "rgba(255,255,255,0.85)", marginTop: 10 }}>
+                {user ? <>Signed in as <span style={{ fontFamily: "'JetBrains Mono', monospace" }}>@{user}</span></> : "Signed in"}
+              </div>
+            </Center>
+          )}
+
+          {phase === "error" && (
+            <>
+              <Label style={{ color: "rgba(220,120,120,0.85)" }}>Authentication failed</Label>
+              <div
+                style={{
+                  marginTop: 8,
+                  padding: "10px 12px",
+                  borderRadius: 7,
+                  border: "1px solid rgba(220,120,120,0.25)",
+                  background: "rgba(220,120,120,0.08)",
+                  fontSize: 12,
+                  fontFamily: "'JetBrains Mono', monospace",
+                  color: "rgba(255,200,200,0.75)",
+                  maxHeight: 140,
+                  overflow: "auto",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                }}
+              >
+                {error || "Unknown error"}
+              </div>
+              <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
+                <button onClick={retry} style={primaryBtn}>Try again</button>
+                <button onClick={onClose} style={secondaryBtn}>Close</button>
+              </div>
+            </>
+          )}
+
+          {phase === "cancelled" && (
+            <Center>
+              <Label>Authentication cancelled.</Label>
+              <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
+                <button onClick={retry} style={primaryBtn}>Start again</button>
+                <button onClick={onClose} style={secondaryBtn}>Close</button>
+              </div>
+            </Center>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Center({ children }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10,
+        padding: "20px 0",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Label({ children, style }) {
+  return (
+    <div
+      style={{
+        fontSize: 12,
+        fontFamily: "'JetBrains Mono', monospace",
+        letterSpacing: ".06em",
+        color: "rgba(255,255,255,0.55)",
+        ...(style || {}),
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+const primaryBtn = {
+  background: "rgba(255,255,255,0.12)",
+  border: "1px solid var(--pane-border)",
+  borderRadius: 6,
+  color: "rgba(255,255,255,0.85)",
+  fontSize: 12,
+  fontFamily: "system-ui, sans-serif",
+  padding: "7px 14px",
+  cursor: "pointer",
+};
+
+const secondaryBtn = {
+  background: "transparent",
+  border: "1px solid var(--pane-border)",
+  borderRadius: 6,
+  color: "rgba(255,255,255,0.55)",
+  fontSize: 12,
+  fontFamily: "system-ui, sans-serif",
+  padding: "7px 14px",
+  cursor: "pointer",
+};

--- a/src/pm-components/AuthModal.jsx
+++ b/src/pm-components/AuthModal.jsx
@@ -283,21 +283,27 @@ export default function AuthModal({ mode = "signin", currentUser, onClose, onAut
                 >
                   github.com/login/device
                 </span>
-                <span style={{ fontSize: 11, color: "rgba(255,255,255,0.3)", marginLeft: 4 }}>
-                  opened automatically
-                </span>
               </div>
-              <Label style={{ marginTop: 16 }}>
-                3. Waiting for authorization…
-              </Label>
-              <Loader2
-                size={16}
+              <div
                 style={{
-                  animation: "spin 1s linear infinite",
-                  color: "rgba(255,255,255,0.35)",
-                  marginTop: 8,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  marginTop: 16,
                 }}
-              />
+              >
+                <Label style={{ marginTop: 0 }}>
+                  3. Waiting for authorization…
+                </Label>
+                <Loader2
+                  size={16}
+                  style={{
+                    animation: "spin 1s linear infinite",
+                    color: "rgba(255,255,255,0.35)",
+                    flexShrink: 0,
+                  }}
+                />
+              </div>
               <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
             </>
           )}

--- a/src/pm-components/AuthModal.jsx
+++ b/src/pm-components/AuthModal.jsx
@@ -1,5 +1,13 @@
 import { useEffect, useRef, useState } from "react";
-import { X, Loader2, Check, Copy, ExternalLink } from "lucide-react";
+import { X, Loader2, Check, Copy, ExternalLink, AlertCircle } from "lucide-react";
+
+function cleanError(msg) {
+  if (!msg) return "Unknown error";
+  return String(msg)
+    .replace(/^Error invoking remote method '[^']+':\s*/i, "")
+    .replace(/^Error:\s*/i, "")
+    .trim();
+}
 
 function GitHubGlyph({ size = 28 }) {
   return (
@@ -15,52 +23,79 @@ export default function AuthModal({ mode = "signin", currentUser, onClose, onAut
   const [code, setCode] = useState(null);
   const [user, setUser] = useState(null);
   const [error, setError] = useState(null);
+  const [errorOutput, setErrorOutput] = useState(null);
   const [copied, setCopied] = useState(false);
   const unsubRef = useRef(null);
-  const startedRef = useRef(false);
+  const startTimerRef = useRef(null);
+  const flowStartedRef = useRef(false);
+
+  const clearAuthListener = () => {
+    if (unsubRef.current) {
+      unsubRef.current();
+      unsubRef.current = null;
+    }
+  };
 
   const start = async () => {
+    clearAuthListener();
+    flowStartedRef.current = true;
     setPhase("starting");
     setCode(null);
     setUser(null);
     setError(null);
+    setErrorOutput(null);
 
     const unsub = window.ghApi.onAuthEvent((event) => {
       if (event.type === "code") {
         setCode(event.code);
         setPhase("code");
       } else if (event.type === "success") {
+        flowStartedRef.current = false;
         setUser(event.user || null);
         setPhase("success");
       } else if (event.type === "error") {
-        setError(event.error || "Authentication failed");
+        flowStartedRef.current = false;
+        setError(cleanError(event.error) || "Authentication failed");
+        setErrorOutput(event.output || null);
         setPhase("error");
       } else if (event.type === "cancelled") {
+        flowStartedRef.current = false;
         setPhase("cancelled");
       }
     });
     unsubRef.current = unsub;
 
     try {
-      if (mode === "switch") {
-        await window.ghApi.authLogout();
-      }
+      // `gh auth login --web` handles the already-signed-in case by asking
+      // for re-auth confirmation, which we auto-accept in github-manager.
+      // No explicit pre-logout is needed for `switch`.
       await window.ghApi.authStart();
     } catch (err) {
-      setError(err.message || "Failed to start auth flow");
+      flowStartedRef.current = false;
+      setError(cleanError(err && err.message) || "Failed to start auth flow");
       setPhase("error");
     }
   };
 
   useEffect(() => {
-    if (!startedRef.current) {
-      startedRef.current = true;
+    // Defer startup one tick so React StrictMode's mount probe doesn't start
+    // and immediately cancel the interactive gh session in development.
+    startTimerRef.current = setTimeout(() => {
+      startTimerRef.current = null;
       start();
-    }
+    }, 0);
+
     return () => {
-      if (unsubRef.current) unsubRef.current();
+      if (startTimerRef.current) {
+        clearTimeout(startTimerRef.current);
+        startTimerRef.current = null;
+      }
+      clearAuthListener();
       // Best-effort: if the user closes the modal mid-flow, kill the gh process.
-      window.ghApi.authCancel().catch(() => {});
+      if (flowStartedRef.current) {
+        flowStartedRef.current = false;
+        window.ghApi.authCancel().catch(() => {});
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -83,11 +118,17 @@ export default function AuthModal({ mode = "signin", currentUser, onClose, onAut
     } catch { /* clipboard may be unavailable; user can copy manually */ }
   };
 
-  const retry = () => {
-    if (unsubRef.current) { unsubRef.current(); unsubRef.current = null; }
-    startedRef.current = false;
+  const retry = async () => {
+    if (startTimerRef.current) {
+      clearTimeout(startTimerRef.current);
+      startTimerRef.current = null;
+    }
+    clearAuthListener();
+    if (flowStartedRef.current) {
+      flowStartedRef.current = false;
+      await window.ghApi.authCancel().catch(() => {});
+    }
     start();
-    startedRef.current = true;
   };
 
   return (
@@ -285,17 +326,43 @@ export default function AuthModal({ mode = "signin", currentUser, onClose, onAut
 
           {phase === "error" && (
             <>
-              <Label style={{ color: "rgba(220,120,120,0.85)" }}>Authentication failed</Label>
+              <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                <div
+                  style={{
+                    width: 28,
+                    height: 28,
+                    borderRadius: "50%",
+                    background: "rgba(220,120,120,0.12)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    color: "rgba(230,140,140,0.9)",
+                    flexShrink: 0,
+                  }}
+                >
+                  <AlertCircle size={15} strokeWidth={1.8} />
+                </div>
+                <div
+                  style={{
+                    fontSize: 14,
+                    fontWeight: 500,
+                    color: "rgba(255,255,255,0.85)",
+                  }}
+                >
+                  Authentication failed
+                </div>
+              </div>
               <div
                 style={{
-                  marginTop: 8,
+                  marginTop: 10,
                   padding: "10px 12px",
                   borderRadius: 7,
-                  border: "1px solid rgba(220,120,120,0.25)",
-                  background: "rgba(220,120,120,0.08)",
+                  border: "1px solid rgba(255,255,255,0.05)",
+                  background: "rgba(255,255,255,0.025)",
                   fontSize: 12,
-                  fontFamily: "'JetBrains Mono', monospace",
-                  color: "rgba(255,200,200,0.75)",
+                  fontFamily: "system-ui, sans-serif",
+                  color: "rgba(255,255,255,0.55)",
+                  lineHeight: 1.45,
                   maxHeight: 140,
                   overflow: "auto",
                   whiteSpace: "pre-wrap",
@@ -304,6 +371,38 @@ export default function AuthModal({ mode = "signin", currentUser, onClose, onAut
               >
                 {error || "Unknown error"}
               </div>
+              {errorOutput && (
+                <details
+                  style={{
+                    marginTop: 8,
+                    fontSize: 11,
+                    color: "rgba(255,255,255,0.4)",
+                    fontFamily: "system-ui, sans-serif",
+                  }}
+                >
+                  <summary style={{ cursor: "pointer", userSelect: "none" }}>
+                    Show gh output
+                  </summary>
+                  <pre
+                    style={{
+                      marginTop: 6,
+                      padding: "8px 10px",
+                      borderRadius: 6,
+                      border: "1px solid rgba(255,255,255,0.05)",
+                      background: "rgba(0,0,0,0.25)",
+                      fontSize: 11,
+                      fontFamily: "'JetBrains Mono', monospace",
+                      color: "rgba(255,255,255,0.55)",
+                      maxHeight: 160,
+                      overflow: "auto",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                    }}
+                  >
+                    {errorOutput}
+                  </pre>
+                </details>
+              )}
               <div style={{ display: "flex", gap: 8, marginTop: 14 }}>
                 <button onClick={retry} style={primaryBtn}>Try again</button>
                 <button onClick={onClose} style={secondaryBtn}>Close</button>
@@ -360,11 +459,12 @@ function Label({ children, style }) {
 }
 
 const primaryBtn = {
-  background: "rgba(255,255,255,0.12)",
-  border: "1px solid var(--pane-border)",
+  background: "rgba(255,255,255,0.18)",
+  border: "1px solid rgba(255,255,255,0.12)",
   borderRadius: 6,
-  color: "rgba(255,255,255,0.85)",
+  color: "rgba(255,255,255,0.95)",
   fontSize: 12,
+  fontWeight: 500,
   fontFamily: "system-ui, sans-serif",
   padding: "7px 14px",
   cursor: "pointer",
@@ -374,7 +474,7 @@ const secondaryBtn = {
   background: "transparent",
   border: "1px solid var(--pane-border)",
   borderRadius: 6,
-  color: "rgba(255,255,255,0.55)",
+  color: "rgba(255,255,255,0.5)",
   fontSize: 12,
   fontFamily: "system-ui, sans-serif",
   padding: "7px 14px",


### PR DESCRIPTION
## Summary
- Adds a PTY-driven `gh auth login --web` flow so users can sign in / switch GitHub accounts from inside RayLine.
- The Project Manager sidebar now shows the active `@user` and a switch-account button, and the unauthenticated screen offers a "Sign in with GitHub" button instead of telling users to open a terminal.
- A new `AuthModal` displays the one-time code (with copy), auto-opens `github.com/login/device` via `shell.openExternal`, waits for authorization, then refreshes repos / issues / PRs under the new account.

## Test plan
- [ ] Start from a fresh `gh` install (no auth) → open Project Manager → click "Sign in with GitHub" → complete OAuth → PM loads your repos.
- [ ] While signed in as account A, click the switch-account button in the sidebar footer → sign in as account B → sidebar shows `@B` and lists reflect B's access.
- [ ] Close the modal mid-flow → verify the background `gh` process is killed and a later retry works.
- [ ] Cancel on GitHub's OAuth page → error state shown in modal with "Try again".

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)