### PR TITLE
fix(win): custom frameless window controls so wallpaper shows through

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -64,12 +64,7 @@ function getWindowChromeOptions() {
 
   if (isWindows) {
     return {
-      titleBarStyle: "hidden",
-      titleBarOverlay: {
-        color: WINDOW_BACKGROUND,
-        symbolColor: "#C8CBD3",
-        height: 52,
-      },
+      frame: false,
       autoHideMenuBar: true,
     };
   }
@@ -78,8 +73,9 @@ function getWindowChromeOptions() {
 }
 
 function applyWindowChromeTweaks(win) {
-  if (!win || !isWindows) return;
-  win.setMenuBarVisibility(false);
+  if (!win) return;
+  if (isWindows) win.setMenuBarVisibility(false);
+  wireWindowStateEvents(win);
 }
 
 function getWallpaperStorageDir() {
@@ -261,6 +257,44 @@ ipcMain.handle("set-window-opacity", (event, opacity) => {
   win.setOpacity(Math.max(0.2, Math.min(1, v)));
   return true;
 });
+
+// Custom window controls (frameless on Windows). Caller is whichever window owns the webContents.
+ipcMain.handle("window-minimize", (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  win?.minimize();
+  return true;
+});
+
+ipcMain.handle("window-toggle-maximize", (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return false;
+  if (win.isMaximized()) win.unmaximize();
+  else win.maximize();
+  return win.isMaximized();
+});
+
+ipcMain.handle("window-close", (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  win?.close();
+  return true;
+});
+
+ipcMain.handle("window-is-maximized", (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  return Boolean(win?.isMaximized());
+});
+
+function wireWindowStateEvents(win) {
+  if (!win) return;
+  const send = () => {
+    if (win.isDestroyed()) return;
+    win.webContents.send("window-state-changed", { isMaximized: win.isMaximized() });
+  };
+  win.on("maximize", send);
+  win.on("unmaximize", send);
+  win.on("enter-full-screen", send);
+  win.on("leave-full-screen", send);
+}
 
 ipcMain.handle("clipboard-write-image", (_event, dataUrl) => {
   if (typeof dataUrl !== "string" || !dataUrl.startsWith("data:image/")) {

--- a/electron/preload-pm.cjs
+++ b/electron/preload-pm.cjs
@@ -28,6 +28,15 @@ contextBridge.exposeInMainWorld("ghApi", {
   loadPmState: () => ipcRenderer.invoke("gh-load-pm-state"),
   savePmState: (state) => ipcRenderer.invoke("gh-save-pm-state", state),
   readImage: (filePath) => ipcRenderer.invoke("read-image", filePath),
+  windowMinimize: () => ipcRenderer.invoke("window-minimize"),
+  windowToggleMaximize: () => ipcRenderer.invoke("window-toggle-maximize"),
+  windowClose: () => ipcRenderer.invoke("window-close"),
+  windowIsMaximized: () => ipcRenderer.invoke("window-is-maximized"),
+  onWindowStateChanged: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on("window-state-changed", handler);
+    return () => ipcRenderer.removeListener("window-state-changed", handler);
+  },
   authStart: () => ipcRenderer.invoke("gh-auth-start"),
   authCancel: () => ipcRenderer.invoke("gh-auth-cancel"),
   authLogout: () => ipcRenderer.invoke("gh-auth-logout"),

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -105,6 +105,17 @@ contextBridge.exposeInMainWorld("api", {
   setWindowOpacity: (opacity) => ipcRenderer.invoke("set-window-opacity", opacity),
   writeClipboardImage: (dataUrl) => ipcRenderer.invoke("clipboard-write-image", dataUrl),
 
+  // Window controls (frameless chrome)
+  windowMinimize: () => ipcRenderer.invoke("window-minimize"),
+  windowToggleMaximize: () => ipcRenderer.invoke("window-toggle-maximize"),
+  windowClose: () => ipcRenderer.invoke("window-close"),
+  windowIsMaximized: () => ipcRenderer.invoke("window-is-maximized"),
+  onWindowStateChanged: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on("window-state-changed", handler);
+    return () => ipcRenderer.removeListener("window-state-changed", handler);
+  },
+
   // multica
   multicaSendCode: (args) => ipcRenderer.invoke("multica-send-code", args),
   multicaVerifyCode: (args) => ipcRenderer.invoke("multica-verify-code", args),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import useTerminal  from "./hooks/useTerminal";
 import TerminalDrawer from "./components/TerminalDrawer";
 import Settings     from "./components/Settings";
 import MulticaSetupModal from "./components/MulticaSetupModal";
+import WindowControls from "./components/WindowControls";
 import { DEFAULT_MODEL_ID, getMOrMulticaFallback, isMulticaModelId, MODELS, normalizeModelId } from "./data/models";
 import { useMulticaModels } from "./data/multicaModels.jsx";
 import { buildConversationPrime, buildCrossProviderPrime, decoratePromptWithPrime } from "./utils/crossProviderPrime";
@@ -3402,6 +3403,7 @@ export default function App() {
         wallpaper={wallpaper}
       />
       </div>
+      <WindowControls api={typeof window !== "undefined" ? window.api : null} />
     </div>
     </FontSizeContext.Provider>
   );

--- a/src/ProjectManager.jsx
+++ b/src/ProjectManager.jsx
@@ -10,6 +10,7 @@ function GitHubIcon({ size = 48 }) {
 }
 import AuroraCanvas from "./components/AuroraCanvas";
 import Grain from "./components/Grain";
+import WindowControls from "./components/WindowControls";
 import AuthModal from "./pm-components/AuthModal";
 import AccountManager from "./pm-components/AccountManager";
 import CreateForm from "./pm-components/CreateForm";
@@ -199,6 +200,8 @@ export default function ProjectManager() {
     if (repoFilter === repo) setRepoFilter(null);
   };
 
+  const pmApi = typeof window !== "undefined" ? window.ghApi : null;
+
   // Loading state
   if (authOk === null) {
     return (
@@ -214,6 +217,7 @@ export default function ProjectManager() {
           fontSize: 14,
         }}
       >
+        <WindowControls api={pmApi} />
         Checking authentication...
       </div>
     );
@@ -234,6 +238,7 @@ export default function ProjectManager() {
           fontFamily: "system-ui, sans-serif",
         }}
       >
+        <WindowControls api={pmApi} />
         <GitHubIcon size={48} />
         <div style={{ fontSize: 16, color: "rgba(255,255,255,0.6)" }}>
           GitHub CLI not authenticated
@@ -591,6 +596,7 @@ export default function ProjectManager() {
           onAuthSuccess={handleAuthSuccess}
         />
       )}
+      <WindowControls api={pmApi} />
     </div>
   );
 }

--- a/src/components/WindowControls.jsx
+++ b/src/components/WindowControls.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+
+const isWindowsPlatform = () => {
+  if (typeof navigator === "undefined") return false;
+  const p = navigator.userAgentData?.platform || navigator.platform || "";
+  return /win/i.test(p);
+};
+
+const BTN_SIZE = { width: 46, height: 36 };
+
+const btnBase = {
+  ...BTN_SIZE,
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "transparent",
+  border: "none",
+  padding: 0,
+  cursor: "pointer",
+  color: "#C8CBD3",
+  outline: "none",
+  WebkitAppRegion: "no-drag",
+  transition: "background-color .12s ease",
+};
+
+function IconMinimize() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <rect x="0" y="4.5" width="10" height="1" fill="currentColor" />
+    </svg>
+  );
+}
+
+function IconMaximize() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function IconRestore() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <rect x="2.5" y="0.5" width="7" height="7" fill="none" stroke="currentColor" strokeWidth="1" />
+      <rect x="0.5" y="2.5" width="7" height="7" fill="#0D0D10" stroke="currentColor" strokeWidth="1" />
+    </svg>
+  );
+}
+
+function IconClose() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <path d="M1 1 L9 9 M9 1 L1 9" stroke="currentColor" strokeWidth="1" fill="none" />
+    </svg>
+  );
+}
+
+function CaptionButton({ onClick, ariaLabel, children, variant }) {
+  const [hover, setHover] = useState(false);
+  const hoverBg =
+    variant === "close"
+      ? "#E81123"
+      : "rgba(255,255,255,0.12)";
+  const color = hover && variant === "close" ? "#FFFFFF" : "#C8CBD3";
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        ...btnBase,
+        backgroundColor: hover ? hoverBg : "transparent",
+        color,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function WindowControls({ api }) {
+  const [isMax, setIsMax] = useState(false);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (!isWindowsPlatform()) return undefined;
+    if (!api?.windowIsMaximized) return undefined;
+    setShow(true);
+    let cancelled = false;
+    api.windowIsMaximized().then((v) => {
+      if (!cancelled) setIsMax(Boolean(v));
+    });
+    const off = api.onWindowStateChanged?.(({ isMaximized }) => {
+      setIsMax(Boolean(isMaximized));
+    });
+    return () => {
+      cancelled = true;
+      off?.();
+    };
+  }, [api]);
+
+  if (!show) return null;
+
+  const controlsWidth = BTN_SIZE.width * 3;
+
+  return (
+    <>
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          right: controlsWidth,
+          height: BTN_SIZE.height,
+          zIndex: 9999,
+          WebkitAppRegion: "drag",
+          pointerEvents: "auto",
+        }}
+      />
+      <div
+        style={{
+          position: "fixed",
+          top: 0,
+          right: 0,
+          zIndex: 10000,
+          display: "flex",
+          height: BTN_SIZE.height,
+          WebkitAppRegion: "no-drag",
+        }}
+      >
+        <CaptionButton ariaLabel="Minimize" onClick={() => api.windowMinimize()}>
+          <IconMinimize />
+        </CaptionButton>
+        <CaptionButton
+          ariaLabel={isMax ? "Restore" : "Maximize"}
+          onClick={() => api.windowToggleMaximize()}
+        >
+          {isMax ? <IconRestore /> : <IconMaximize />}
+        </CaptionButton>
+        <CaptionButton ariaLabel="Close" variant="close" onClick={() => api.windowClose()}>
+          <IconClose />
+        </CaptionButton>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Windows caption-button strip was always solid #0D0D10 because
titleBarOverlay.color does not honor alpha in Electron — #00000000
is painted as opaque black. Drop titleBarOverlay entirely, use
frame:false, and render min/max/close in React instead. Wallpaper
now bleeds through the full top of the window.

WindowControls is mounted as the last child of the root so its
no-drag region wins Electron's -webkit-app-region hit test against
other drag strips (ChatArea, Settings, Sidebar header, etc.) —
otherwise clicks fell through to OS drag handling whenever a sibling
drag region painted over the button area.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
