### PR TITLE
fix: make windows controls clickable and default font 17px

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ const SHELL_TERMINAL_TIMEOUT_MS = 15000;
 const LAB_CONTROL_ENDPOINT = "http://127.0.0.1:4001/control";
 const LAB_CONTROL_COMMIT_DELAY_MS = 1000;
 const DEFAULT_SIDEBAR_ACTIVE_OPACITY = 4;
+const DEFAULT_FONT_SIZE = 17;
 
 function logSessionState(...args) {
   console.log("[session-state]", ...args);
@@ -1038,7 +1039,7 @@ export default function App() {
   const [stateLoaded, setStateLoaded] = useState(false);
   const [platform, setPlatform] = useState(null);
   const [wallpaper, setWallpaper] = useState(null);
-  const [fontSize, setFontSize] = useState(15);
+  const [fontSize, setFontSize] = useState(DEFAULT_FONT_SIZE);
   const [sidebarActiveOpacity, setSidebarActiveOpacity] = useState(DEFAULT_SIDEBAR_ACTIVE_OPACITY);
   const [defaultPrBranch, setDefaultPrBranch] = useState("main");
   const [coauthorEnabled, setCoauthorEnabled] = useState(true);
@@ -1253,7 +1254,7 @@ export default function App() {
         return;
       case "fontSize":
       case "app.fontSize":
-        setFontSize(clampNumber(value, 12, 22, 15));
+        setFontSize(clampNumber(value, 12, 22, DEFAULT_FONT_SIZE));
         return;
       case "sidebar.activeOpacity":
         setSidebarActiveOpacity(clampNumber(value, 0, 20, DEFAULT_SIDEBAR_ACTIVE_OPACITY));

--- a/src/components/WindowControls.jsx
+++ b/src/components/WindowControls.jsx
@@ -13,6 +13,7 @@ const buttonBaseStyle = {
   cursor: "pointer",
   transition: "background .15s ease, border-color .15s ease, color .15s ease",
   padding: 0,
+  WebkitAppRegion: "no-drag",
 };
 
 function getBridge() {
@@ -48,6 +49,20 @@ export default function WindowControls({ visible = false }) {
     target.style.color = "rgba(255,255,255,0.94)";
   };
 
+  const handleMouseDown = (event) => {
+    // Windows keeps a top-level drag region across the header. Explicitly
+    // cancelling pointer-down here prevents the buttons from being treated as
+    // drag targets, so the click reaches the IPC handler.
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleClick = (event, action) => {
+    event.preventDefault();
+    event.stopPropagation();
+    void action();
+  };
+
   return (
     <div
       style={{
@@ -63,7 +78,8 @@ export default function WindowControls({ visible = false }) {
       <button
         aria-label="Minimize window"
         title="Minimize"
-        onClick={() => void bridge.windowMinimize()}
+        onMouseDown={handleMouseDown}
+        onClick={(event) => handleClick(event, bridge.windowMinimize)}
         style={buttonBaseStyle}
         onMouseEnter={(event) => handleHover(event, "minimize", true)}
         onMouseLeave={(event) => handleHover(event, "minimize", false)}
@@ -73,7 +89,8 @@ export default function WindowControls({ visible = false }) {
       <button
         aria-label="Maximize window"
         title="Maximize"
-        onClick={() => void bridge.windowToggleMaximize()}
+        onMouseDown={handleMouseDown}
+        onClick={(event) => handleClick(event, bridge.windowToggleMaximize)}
         style={buttonBaseStyle}
         onMouseEnter={(event) => handleHover(event, "maximize", true)}
         onMouseLeave={(event) => handleHover(event, "maximize", false)}
@@ -83,7 +100,8 @@ export default function WindowControls({ visible = false }) {
       <button
         aria-label="Close window"
         title="Close"
-        onClick={() => void bridge.windowClose()}
+        onMouseDown={handleMouseDown}
+        onClick={(event) => handleClick(event, bridge.windowClose)}
         style={buttonBaseStyle}
         onMouseEnter={(event) => handleHover(event, "close", true)}
         onMouseLeave={(event) => handleHover(event, "close", false)}


### PR DESCRIPTION
## Summary
- make the custom Windows window controls explicitly opt out of the drag region so minimize / maximize / close clicks reach the IPC handlers
- set the default app font size to 17px for new state
- keep the change on the Windows branch line only

## Verification
- `git diff --check`
- `npm run lint` not run because this checkout does not have `node_modules` installed