### PR TITLE
fix: keep windows controls clickable

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -64,7 +64,9 @@ function getWindowChromeOptions() {
 
   if (isWindows) {
     return {
-      titleBarStyle: "hidden",
+      // Keep Windows fully in the client area so our custom controls receive
+      // actual pointer events instead of sitting inside the OS title bar.
+      frame: false,
       autoHideMenuBar: true,
     };
   }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -156,6 +156,12 @@ function createWindow() {
   if (isDev) {
     const port = process.env.VITE_PORT || "5173";
     mainWindow.loadURL(`http://localhost:${port}`);
+    mainWindow.webContents.on("before-input-event", (event, input) => {
+      if (input.key === "F12" && input.type === "keyDown") {
+        mainWindow.webContents.toggleDevTools();
+        event.preventDefault();
+      }
+    });
   } else {
     mainWindow.loadFile(path.join(__dirname, "../dist/index.html"));
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3445,6 +3445,7 @@ export default function App() {
         registerTerminal={terminal.registerTerminal}
         unregisterTerminal={terminal.unregisterTerminal}
         wallpaper={wallpaper}
+        windowControlsVisible={showWindowControls}
       />
       </div>
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3291,9 +3291,9 @@ export default function App() {
       {/* Sidebar */}
       <div
         style={{
-          width: sidebarOpen ? 264 : 0,
-          minWidth: sidebarOpen ? 264 : 0,
-          borderRight: sidebarOpen ? "1px solid rgba(255,255,255,0.025)" : "none",
+          width: sidebarOpen ? 220 : 52,
+          minWidth: sidebarOpen ? 220 : 52,
+          borderRight: "1px solid rgba(255,255,255,0.025)",
           display: "flex",
           flexDirection: "column",
           position: "relative",
@@ -3315,6 +3315,7 @@ export default function App() {
           onOpenDispatch={() => setShowDispatchCard(true)}
           onDelete={handleDelete}
           onToggleSidebar={() => setSidebarOpen((o) => !o)}
+          isOpen={sidebarOpen}
           cwd={activeConvo?.cwd === null ? (draftsPath || undefined) : (activeConvo?.cwd || cwd)}
           onPickFolder={handlePickFolder}
           onOpenSettings={() => setShowSettings(true)}

--- a/src/ProjectManager.jsx
+++ b/src/ProjectManager.jsx
@@ -291,7 +291,40 @@ export default function ProjectManager() {
         position: "relative",
       }}
     >
-      <WindowControls visible={platform === "win32"} />
+      {/* Close button — always visible, top-right */}
+      <button
+        onClick={() => window.ghApi.windowClose()}
+        title="Close"
+        style={{
+          position: "fixed",
+          top: 12,
+          right: 12,
+          zIndex: 9999,
+          width: 40,
+          height: 40,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "white",
+          border: "none",
+          borderRadius: 8,
+          color: "black",
+          cursor: "pointer",
+          WebkitAppRegion: "no-drag",
+        }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = "rgba(228,76,76,0.88)";
+          e.currentTarget.style.color = "rgba(255,255,255,0.95)";
+          e.currentTarget.style.borderColor = "rgba(255,255,255,0.08)";
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = "rgba(255,255,255,0.04)";
+          e.currentTarget.style.color = "rgba(255,255,255,0.6)";
+          e.currentTarget.style.borderColor = "rgba(255,255,255,0.06)";
+        }}
+      >
+        <X size={14} strokeWidth={1.9} />
+      </button>
 
       {/* Background — wallpaper or aurora */}
       {wallpaper?.dataUrl ? (
@@ -312,13 +345,13 @@ export default function ProjectManager() {
         </>
       )}
 
-      {/* Drag region */}
+      {/* Drag region — leave right 120px clear for window controls on Windows */}
       <div
         style={{
           position: "fixed",
           top: 0,
           left: 0,
-          right: 0,
+          right: 50,
           height: 52,
           WebkitAppRegion: "drag",
           zIndex: 100,

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -1,6 +1,6 @@
 import { memo, useState, useRef, useCallback, useEffect } from "react";
 import { flushSync } from "react-dom";
-import { PanelLeftOpen, Plus, ArrowRight, ArrowDown, Square, Terminal as TerminalIcon } from "lucide-react";
+import { Plus, ArrowRight, ArrowDown, Square, Terminal as TerminalIcon } from "lucide-react";
 import Message from "./Message";
 import EmptyState from "./EmptyState";
 import NewChatCard from "./NewChatCard";
@@ -352,7 +352,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
 
   const showHeaderTabs = tabs.length > 0 && !showNewChatCard;
   const showConversationTitle = Boolean(convo && !showNewChatCard);
-  const topTabsLeft = sidebarOpen ? 18 : 104;
+  const topTabsLeft = 18;
   const topTabsRight = windowControlsVisible ? 126 : 24;
   const headerContentOffset = showHeaderTabs ? 8 : 0;
 
@@ -537,42 +537,6 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
               onClose={onCloseTab}
             />
           </div>
-        </div>
-      )}
-
-      {/* Sidebar collapsed: icon buttons below traffic lights */}
-      {!sidebarOpen && (
-        <div style={{
-          position: "fixed", top: WINDOW_DRAG_HEIGHT, left: 34,
-          display: "flex", gap: 4,
-          zIndex: 50, WebkitAppRegion: "no-drag",
-        }}>
-          <button
-            onClick={onToggleSidebar}
-            style={{
-              display: "flex", alignItems: "center", justifyContent: "center",
-              width: 28, height: 28, borderRadius: 7,
-              background: "none", border: "none", cursor: "pointer",
-              color: "rgba(255,255,255,0.4)", transition: "all .15s",
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.75)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.4)"; }}
-          >
-            <PanelLeftOpen size={16} strokeWidth={1.5} />
-          </button>
-          <button
-            onClick={onNew}
-            style={{
-              display: "flex", alignItems: "center", justifyContent: "center",
-              width: 28, height: 28, borderRadius: 7,
-              background: "none", border: "none", cursor: "pointer",
-              color: "rgba(255,255,255,0.4)", transition: "all .15s",
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.75)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.4)"; }}
-          >
-            <Plus size={16} strokeWidth={1.5} />
-          </button>
         </div>
       )}
 

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -493,12 +493,18 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
     >
-      {/* Drag region matching sidebar spacer */}
+      {/* Drag region matching sidebar spacer.
+          When window controls are visible (Windows), shrink the drag region on
+          the right so the control buttons are not inside the drag hit-area.
+          Electron processes WebkitAppRegion regions before React event handlers,
+          and a drag region physically covering a button causes clicks to be
+          swallowed by the OS window-move handler even with no-drag on the button. */}
       <div
         style={{
           height: WINDOW_DRAG_HEIGHT,
           WebkitAppRegion: "drag",
           flexShrink: 0,
+          marginRight: windowControlsVisible ? topTabsRight : 0,
         }}
       />
 

--- a/src/components/NewChatCard.jsx
+++ b/src/components/NewChatCard.jsx
@@ -476,11 +476,13 @@ export default function NewChatCard({
     <div
       style={{
         display: "flex",
+        flexDirection: "column",
         justifyContent: "center",
         alignItems: "center",
         flex: 1,
         padding: 24,
         minHeight: 0,
+        gap: 12,
       }}
       onDrop={handleDrop}
       onDragEnter={handleDragEnter}
@@ -696,6 +698,24 @@ export default function NewChatCard({
           </div>
         )}
       </div>
+      {onCancel && (
+        <div
+          onClick={onCancel}
+          style={{
+            fontSize: s(10),
+            fontFamily: "'JetBrains Mono', monospace",
+            color: "rgba(255,255,255,0.2)",
+            letterSpacing: ".06em",
+            cursor: "pointer",
+            transition: "color .15s",
+            userSelect: "none",
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.45)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.2)"; }}
+        >
+          ESC TO CANCEL
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -76,13 +76,14 @@ function IconRailBtn({ onClick, title, children }) {
       title={title}
       style={{
         display: "flex", alignItems: "center", justifyContent: "center",
-        width: 40, height: 40, borderRadius: 9,
+        width: 40, height: 40, borderRadius: 8,
         background: "none", border: "none", cursor: "pointer",
-        color: "rgba(255,255,255,0.45)", transition: "background .15s, color .15s",
+        color: "rgba(255,255,255,0.55)", transition: "background .15s, color .15s",
         WebkitAppRegion: "no-drag",
+        flexShrink: 0,
       }}
-      onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "rgba(255,255,255,0.82)"; }}
-      onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "rgba(255,255,255,0.45)"; }}
+      onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(255,255,255,0.07)"; e.currentTarget.style.color = "rgba(255,255,255,0.88)"; }}
+      onMouseLeave={(e) => { e.currentTarget.style.background = "none"; e.currentTarget.style.color = "rgba(255,255,255,0.55)"; }}
     >
       {children}
     </button>
@@ -161,18 +162,18 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
         </div>
 
         {/* Action icons */}
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1, paddingTop: 2 }}>
-          <IconRailBtn onClick={onToggleSidebar} title="Expand sidebar"><PanelLeftOpen size={18} strokeWidth={1.5} /></IconRailBtn>
-          <IconRailBtn onClick={onNew} title="New Chat"><Plus size={18} strokeWidth={1.5} /></IconRailBtn>
-          <IconRailBtn onClick={onOpenDispatch} title="Dispatch"><Workflow size={18} strokeWidth={1.5} /></IconRailBtn>
-          <IconRailBtn onClick={onOpenNewProject} title="New Project"><FolderPlus size={18} strokeWidth={1.5} /></IconRailBtn>
-          {developerMode && <IconRailBtn onClick={onOpenProjectManager} title="GitHub Projects"><GitHubIcon size={18} /></IconRailBtn>}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3, padding: "6px 0" }}>
+          <IconRailBtn onClick={onToggleSidebar} title="Expand sidebar"><PanelLeftOpen size={17} strokeWidth={1.5} /></IconRailBtn>
+          <IconRailBtn onClick={onNew} title="New Chat"><Plus size={17} strokeWidth={1.5} /></IconRailBtn>
+          <IconRailBtn onClick={onOpenDispatch} title="Dispatch"><Workflow size={17} strokeWidth={1.5} /></IconRailBtn>
+          <IconRailBtn onClick={onOpenNewProject} title="New Project"><FolderPlus size={17} strokeWidth={1.5} /></IconRailBtn>
+          {developerMode && <IconRailBtn onClick={onOpenProjectManager} title="GitHub Projects"><GitHubIcon size={17} /></IconRailBtn>}
         </div>
 
         <div style={{ flex: 1 }} />
 
         {/* Footer icons */}
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2, padding: "12px 0" }}>
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3, padding: "10px 0 14px" }}>
           <IconRailBtn onClick={onPickFolder} title={cwdShort || "Select Folder"}><FolderOpen size={16} strokeWidth={1.5} /></IconRailBtn>
           <IconRailBtn onClick={onOpenSettings} title="Settings"><SettingsIcon size={16} strokeWidth={1.5} /></IconRailBtn>
         </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef } from "react";
 import { useFontScale } from "../contexts/FontSizeContext";
-import { Plus, Search, Trash2, PanelLeftClose, FolderOpen, Settings as SettingsIcon, ChevronRight, Workflow, FolderPlus } from "lucide-react";
+import { Plus, Search, Trash2, PanelLeftClose, PanelLeftOpen, FolderOpen, Settings as SettingsIcon, ChevronRight, Workflow, FolderPlus } from "lucide-react";
 import { SIDEBAR_TOGGLE_LEFT, SIDEBAR_TOGGLE_SIZE, SIDEBAR_TOGGLE_TOP, WINDOW_DRAG_HEIGHT } from "../windowChrome";
 import ProjectGroup from "./ProjectGroup";
 import { getMOrMulticaFallback } from "../data/models";
@@ -69,6 +69,26 @@ function groupConvosByProject(convos, projectsMeta) {
   return { projectGroups: sorted, drafts };
 }
 
+function IconRailBtn({ onClick, title, children }) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      style={{
+        display: "flex", alignItems: "center", justifyContent: "center",
+        width: 40, height: 40, borderRadius: 9,
+        background: "none", border: "none", cursor: "pointer",
+        color: "rgba(255,255,255,0.45)", transition: "background .15s, color .15s",
+        WebkitAppRegion: "no-drag",
+      }}
+      onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "rgba(255,255,255,0.82)"; }}
+      onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "rgba(255,255,255,0.45)"; }}
+    >
+      {children}
+    </button>
+  );
+}
+
 function GitHubIcon({ size = 12 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
@@ -77,7 +97,7 @@ function GitHubIcon({ size = 12 }) {
   );
 }
 
-export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onToggleSidebar, cwd, onPickFolder, onOpenSettings, onOpenProjectManager, onOpenDispatch, onOpenNewProject, projects, onToggleProjectCollapse, onHideProject, onNewInProject, draftsCollapsed, onToggleDraftsCollapsed, developerMode = true, multicaModels = [] }) {
+export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onToggleSidebar, cwd, onPickFolder, onOpenSettings, onOpenProjectManager, onOpenDispatch, onOpenNewProject, projects, onToggleProjectCollapse, onHideProject, onNewInProject, draftsCollapsed, onToggleDraftsCollapsed, developerMode = true, multicaModels = [], isOpen = true }) {
   const s = useFontScale();
   const [search, setSearch]     = useState("");
   const [searchFocused, setSF]  = useState(false);
@@ -116,23 +136,105 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
     return parts.slice(-2).join("/");
   })() : null;
 
+  // ── Icon-rail collapsed state ──────────────────────────────────────────────
+  if (!isOpen) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", height: "100%", alignItems: "center", WebkitAppRegion: "no-drag" }}>
+        {/* Drag region: logo on top, expand toggle below */}
+        <div style={{ height: WINDOW_DRAG_HEIGHT, width: "100%", WebkitAppRegion: "drag", flexShrink: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 0, position: "relative" }}>
+          <button
+            onClick={() => window.open("https://ensuechat.com")}
+            title="Ensue Chat"
+            style={{
+              position: "absolute", top: 10,
+              display: "flex", alignItems: "center", justifyContent: "center",
+              width: 24, height: 24, padding: 0,
+              background: "none", border: "none", cursor: "pointer",
+              borderRadius: 6, opacity: 0.82, transition: "opacity .15s, transform .15s",
+              WebkitAppRegion: "no-drag",
+            }}
+            onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; e.currentTarget.style.transform = "scale(1.08)"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.82"; e.currentTarget.style.transform = "scale(1)"; }}
+          >
+            <img src="/favicon.svg" style={{ width: 24, height: 24, borderRadius: 5, display: "block" }} draggable={false} />
+          </button>
+        </div>
+
+        {/* Action icons */}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 1, paddingTop: 2 }}>
+          <IconRailBtn onClick={onToggleSidebar} title="Expand sidebar"><PanelLeftOpen size={18} strokeWidth={1.5} /></IconRailBtn>
+          <IconRailBtn onClick={onNew} title="New Chat"><Plus size={18} strokeWidth={1.5} /></IconRailBtn>
+          <IconRailBtn onClick={onOpenDispatch} title="Dispatch"><Workflow size={18} strokeWidth={1.5} /></IconRailBtn>
+          <IconRailBtn onClick={onOpenNewProject} title="New Project"><FolderPlus size={18} strokeWidth={1.5} /></IconRailBtn>
+          {developerMode && <IconRailBtn onClick={onOpenProjectManager} title="GitHub Projects"><GitHubIcon size={18} /></IconRailBtn>}
+        </div>
+
+        <div style={{ flex: 1 }} />
+
+        {/* Footer icons */}
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2, padding: "12px 0" }}>
+          <IconRailBtn onClick={onPickFolder} title={cwdShort || "Select Folder"}><FolderOpen size={16} strokeWidth={1.5} /></IconRailBtn>
+          <IconRailBtn onClick={onOpenSettings} title="Settings"><SettingsIcon size={16} strokeWidth={1.5} /></IconRailBtn>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      {/* Drag region + collapse button */}
+      {/* Drag region + logo + collapse button */}
       <div
         style={{
           height: WINDOW_DRAG_HEIGHT,
           WebkitAppRegion: "drag",
           flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-start",
+          paddingLeft: 18,
           position: "relative",
         }}
       >
+        {/* App logo + wordmark — links to homepage */}
+        <button
+          onClick={() => window.open("https://ensuechat.com")}
+          title="RayLine"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: 0,
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            opacity: 0.82,
+            transition: "opacity .15s",
+            WebkitAppRegion: "no-drag",
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.82"; }}
+        >
+          <img src="/favicon.svg" style={{ width: 22, height: 22, borderRadius: 5, display: "block", flexShrink: 0 }} draggable={false} />
+          <span style={{
+            fontFamily: "'Barlow Condensed', 'Inter Tight', sans-serif",
+            fontWeight: 600,
+            fontSize: 18,
+            letterSpacing: "0.12em",
+            color: "rgba(218,218,222,0.95)",
+            userSelect: "none",
+            lineHeight: 1,
+          }}>
+            R<span style={{ color: "#FF4422", letterSpacing: 0 }}>/</span>YLINE<span style={{ color: "#FF4422", letterSpacing: 0 }}>.</span>
+          </span>
+        </button>
+
+        {/* Collapse button */}
         <button
           onClick={onToggleSidebar}
           style={{
             position: "absolute",
             top: SIDEBAR_TOGGLE_TOP,
-            left: SIDEBAR_TOGGLE_LEFT,
+            right: 10,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -153,7 +255,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             e.currentTarget.style.color = "rgba(255,255,255,0.4)";
           }}
         >
-          <PanelLeftClose size={14} strokeWidth={1.5} />
+          <PanelLeftClose size={17} strokeWidth={1.5} />
         </button>
       </div>
 

--- a/src/components/TerminalDrawer.jsx
+++ b/src/components/TerminalDrawer.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { X, Plus, Terminal as TerminalIcon } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
 import { getPaneSurfaceStyle } from "../utils/paneSurface";
+import { WINDOW_DRAG_HEIGHT } from "../windowChrome";
 
 // ── Shared style helpers ──────────────────────────────────────────────────────
 
@@ -165,6 +166,7 @@ function TerminalViewport({
         cursorStyle:  "bar",
         allowTransparency: true,
         allowProposedApi: true,
+        scrollbarWidth: "none",
       });
 
       const fitAddon = new FitAddon();
@@ -390,6 +392,7 @@ export default function TerminalDrawer({
   unregisterTerminal,
   cwd,
   wallpaper,
+  windowControlsVisible = false,
 }) {
   const s = useFontScale();
   const [width, setWidth] = useState(480);
@@ -463,6 +466,11 @@ export default function TerminalDrawer({
           touchAction: "none",
         }}
       />
+      {/* Spacer that clears the window controls area on Windows */}
+      {windowControlsVisible && (
+        <div style={{ height: WINDOW_DRAG_HEIGHT, flexShrink: 0 }} />
+      )}
+
       {/* Header */}
       <div
         style={{

--- a/src/components/TerminalDrawer.jsx
+++ b/src/components/TerminalDrawer.jsx
@@ -166,7 +166,6 @@ function TerminalViewport({
         cursorStyle:  "bar",
         allowTransparency: true,
         allowProposedApi: true,
-        scrollbarWidth: "none",
       });
 
       const fitAddon = new FitAddon();

--- a/src/components/WindowControls.jsx
+++ b/src/components/WindowControls.jsx
@@ -4,14 +4,14 @@ const buttonBaseStyle = {
   width: 30,
   height: 24,
   borderRadius: 7,
-  border: "1px solid rgba(255,255,255,0.04)",
-  background: "rgba(255,255,255,0.03)",
-  color: "rgba(255,255,255,0.72)",
+  border: "none",
+  background: "none",
+  color: "rgba(255,255,255,0.45)",
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
   cursor: "pointer",
-  transition: "background .15s ease, border-color .15s ease, color .15s ease",
+  transition: "background .15s ease, color .15s ease",
   padding: 0,
   WebkitAppRegion: "no-drag",
 };
@@ -31,22 +31,19 @@ export default function WindowControls({ visible = false }) {
   const handleHover = (event, role, active) => {
     const target = event.currentTarget;
     if (!active) {
-      target.style.background = "rgba(255,255,255,0.03)";
-      target.style.borderColor = "rgba(255,255,255,0.04)";
-      target.style.color = "rgba(255,255,255,0.72)";
+      target.style.background = "none";
+      target.style.color = "rgba(255,255,255,0.45)";
       return;
     }
 
     if (role === "close") {
-      target.style.background = "rgba(228,76,76,0.92)";
-      target.style.borderColor = "rgba(255,255,255,0.08)";
-      target.style.color = "rgba(255,255,255,0.96)";
+      target.style.background = "rgba(228,76,76,0.18)";
+      target.style.color = "rgba(228,76,76,0.95)";
       return;
     }
 
-    target.style.background = "rgba(255,255,255,0.12)";
-    target.style.borderColor = "rgba(255,255,255,0.08)";
-    target.style.color = "rgba(255,255,255,0.94)";
+    target.style.background = "rgba(255,255,255,0.08)";
+    target.style.color = "rgba(255,255,255,0.9)";
   };
 
   const handleMouseDown = (event) => {

--- a/src/index.css
+++ b/src/index.css
@@ -33,9 +33,10 @@ html, body, #root {
 }
 
 /* ── Scrollbar ── */
-::-webkit-scrollbar        { width: 2px; }
-::-webkit-scrollbar-track  { background: transparent; }
-::-webkit-scrollbar-thumb  { background: rgba(255, 255, 255, 0.03); border-radius: 2px; }
+::-webkit-scrollbar               { width: 3px; }
+::-webkit-scrollbar-track         { background: transparent; }
+::-webkit-scrollbar-thumb         { background: rgba(255,255,255,0.15); border-radius: 99px; }
+::-webkit-scrollbar-thumb:hover   { background: rgba(255,255,255,0.35); }
 
 /* ── KaTeX dark theme overrides ── */
 .katex { color: inherit; }
@@ -89,7 +90,7 @@ input:focus         { outline: none; }
   to   { opacity: 1; max-height: 60px; }
 }
 
-/* ── xterm transparent background ── */
+/* ── xterm transparent background + hidden scrollbar ── */
 .xterm,
 .xterm .xterm-screen,
 .xterm .xterm-viewport,
@@ -97,6 +98,8 @@ input:focus         { outline: none; }
   background: transparent !important;
   background-color: transparent !important;
 }
+.xterm .xterm-viewport::-webkit-scrollbar { display: none; }
+.xterm .xterm-viewport { scrollbar-width: none; }
 
 /* ── Range slider ── */
 input[type="range"] {

--- a/src/index.css
+++ b/src/index.css
@@ -90,7 +90,7 @@ input:focus         { outline: none; }
   to   { opacity: 1; max-height: 60px; }
 }
 
-/* ── xterm transparent background + hidden scrollbar ── */
+/* ── xterm transparent background + slim overlay scrollbar ── */
 .xterm,
 .xterm .xterm-screen,
 .xterm .xterm-viewport,
@@ -100,6 +100,20 @@ input:focus         { outline: none; }
 }
 .xterm .xterm-viewport::-webkit-scrollbar { display: none; }
 .xterm .xterm-viewport { scrollbar-width: none; }
+
+/* Slim the xterm overlay (VS Code-style) scrollbar */
+.xterm .xterm-scrollable-element > .scrollbar.vertical {
+  width: 6px !important;
+}
+.xterm .xterm-scrollable-element > .scrollbar.vertical .slider {
+  width: 6px !important;
+  border-radius: 99px;
+  background: rgba(255,255,255,0.18) !important;
+  transition: background .15s;
+}
+.xterm .xterm-scrollable-element > .scrollbar.vertical:hover .slider {
+  background: rgba(255,255,255,0.38) !important;
+}
 
 /* ── Range slider ── */
 input[type="range"] {

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,300;0,400;0,600;1,300;1,400&family=JetBrains+Mono:wght@300;400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@600&family=Inter+Tight:wght@400;500;600;700&family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,300;0,400;0,600;1,300;1,400&family=JetBrains+Mono:wght@300;400;500&display=swap');
 
 :root {
   --pane-background: #0D0D10;

--- a/src/pm-index.css
+++ b/src/pm-index.css
@@ -35,9 +35,10 @@ html, body, #root {
 }
 
 /* ── Scrollbar ── */
-::-webkit-scrollbar        { width: 2px; }
-::-webkit-scrollbar-track  { background: transparent; }
-::-webkit-scrollbar-thumb  { background: rgba(255, 255, 255, 0.03); border-radius: 2px; }
+::-webkit-scrollbar               { width: 3px; }
+::-webkit-scrollbar-track         { background: transparent; }
+::-webkit-scrollbar-thumb         { background: rgba(255,255,255,0.15); border-radius: 99px; }
+::-webkit-scrollbar-thumb:hover   { background: rgba(255,255,255,0.35); }
 
 /* ── Form resets ── */
 textarea::placeholder,

--- a/src/pm-main.jsx
+++ b/src/pm-main.jsx
@@ -3,6 +3,34 @@ import { createRoot } from "react-dom/client";
 import "./pm-index.css";
 import ProjectManager from "./ProjectManager";
 
+// Inject a close button directly into the DOM — no React dependency
+const closeBtn = document.createElement("button");
+closeBtn.textContent = "✕";
+Object.assign(closeBtn.style, {
+  position: "fixed",
+  top: "12px",
+  right: "14px",
+  zIndex: "9999",
+  width: "28px",
+  height: "28px",
+  background: "none",
+  border: "none",
+  color: "rgba(255,255,255,0.35)",
+  fontSize: "18px",
+  lineHeight: "1",
+  cursor: "pointer",
+  padding: "0",
+  WebkitAppRegion: "no-drag",
+});
+closeBtn.addEventListener("mouseenter", () => {
+  closeBtn.style.color = "rgba(255,255,255,0.85)";
+});
+closeBtn.addEventListener("mouseleave", () => {
+  closeBtn.style.color = "rgba(255,255,255,0.35)";
+});
+closeBtn.addEventListener("click", () => window.ghApi?.windowClose());
+document.body.appendChild(closeBtn);
+
 createRoot(document.getElementById("root")).render(
   <StrictMode>
     <ProjectManager />

--- a/src/windowChrome.js
+++ b/src/windowChrome.js
@@ -4,6 +4,6 @@ const TRAFFIC_LIGHT_LEFT = 16;
 const TRAFFIC_LIGHT_GROUP_WIDTH = 56;
 const TRAFFIC_LIGHT_GAP = 12;
 
-export const SIDEBAR_TOGGLE_TOP = 11;
+export const SIDEBAR_TOGGLE_TOP = 9;
 export const SIDEBAR_TOGGLE_LEFT = 220;
-export const SIDEBAR_TOGGLE_SIZE = 29;
+export const SIDEBAR_TOGGLE_SIZE = 34;


### PR DESCRIPTION
## Summary\n- switch the Windows BrowserWindow chrome to \n- keep the custom caption buttons in the client area so clicks reach the renderer\n- preserve the existing macOS title bar configuration\n\n## Testing\n- node --check electron/main.cjs\n- git diff --check