### PR TITLE
fix: surface sensitive-file edit approvals in chat UI

### DIFF
--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -76,8 +76,16 @@ function resolveLaunchCwd({ cwd, sessionId }) {
   throw new Error(`Invalid working directory: ${cwd}`);
 }
 
-function buildClaudeArgs({ model, prompt, sessionId, resumeSessionId, forkSession }) {
-  const args = ["--print", "--output-format=stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"];
+function buildClaudeArgs({ model, sessionId, resumeSessionId, forkSession }) {
+  const args = [
+    "--print",
+    "--input-format=stream-json",
+    "--output-format=stream-json",
+    "--verbose",
+    "--include-partial-messages",
+    "--permission-mode", "bypassPermissions",
+    "--permission-prompt-tool", "stdio",
+  ];
 
   args.push("--append-system-prompt", `You are running inside RayLine, a desktop GUI client for Claude Code.
 The user is interacting via a chat interface, not a terminal.
@@ -176,8 +184,29 @@ The user can see and type into these terminals in real time.`);
     args.push("--session-id", sessionId);
   }
 
-  args.push(prompt);
   return args;
+}
+
+function buildPermissionKey(toolName, input, blockedPath) {
+  const key = blockedPath || input?.file_path || input?.path || input?.filePath || input?.command || "";
+  return `${toolName || ""}::${key}`;
+}
+
+function classifyPermissionRequest(req) {
+  const toolName = req?.tool_name || "";
+  const input = req?.input || {};
+  const blockedPath = req?.blocked_path || null;
+  const targetPath = blockedPath || input.file_path || input.path || input.filePath || null;
+  let summary = "";
+  if (targetPath) summary = targetPath;
+  else if (toolName === "Bash" && typeof input.command === "string") summary = input.command;
+  else if (input.url) summary = input.url;
+  return {
+    toolName,
+    targetPath,
+    summary: summary || (toolName ? `${toolName} request` : "Tool request"),
+    isSensitiveFile: Boolean(blockedPath),
+  };
 }
 
 function buildPromptWithAttachments(prompt, images, files) {
@@ -232,6 +261,11 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
 
   const fullPrompt = buildPromptWithAttachments(prompt, images, files);
 
+  const existing = activeAgents.get(conversationId);
+  const sessionAllowlist = existing?.sessionAllowlist instanceof Set
+    ? existing.sessionAllowlist
+    : new Set();
+
   const state = {
     conversationId,
     webContents,
@@ -250,6 +284,9 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
     firstEventMs: null,
     firstAssistantTextMs: null,
     firstToolUseMs: null,
+    pendingPermissions: new Map(),
+    sessionAllowlist,
+    stdinClosed: false,
   };
 
   log("Starting agent:", { conversationId, model, cwd: launchCwd, sessionId, resumeSessionId, forkSession });
@@ -262,7 +299,6 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
     const runStartedAt = Date.now();
     const args = buildClaudeArgs({
       model,
-      prompt: runPrompt,
       sessionId: runSessionId,
       resumeSessionId: runResumeSessionId,
       forkSession: runForkSession,
@@ -298,17 +334,49 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
       resumeSessionId: runResumeSessionId,
       forkSession: runForkSession,
     });
-    log("Full args:", args.filter((arg) => arg !== runPrompt).join(" "));
+    log("Full args:", args.join(" "));
     log("Prompt:", runPrompt.slice(0, 100));
 
     const child = spawnCli(claudeBin, args, {
       cwd: launchCwd,
       env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
 
     state.child = child;
+    state.stdinClosed = false;
     activeAgents.set(conversationId, state);
+
+    const writeStdinLine = (obj) => {
+      if (!child.stdin || child.stdin.destroyed || state.stdinClosed) return false;
+      try {
+        child.stdin.write(JSON.stringify(obj) + "\n");
+        return true;
+      } catch (err) {
+        log("stdin write failed:", err?.message || err);
+        return false;
+      }
+    };
+
+    const endStdin = () => {
+      if (state.stdinClosed) return;
+      state.stdinClosed = true;
+      try { child.stdin?.end(); } catch {}
+    };
+
+    if (child.stdin) {
+      child.stdin.on("error", (err) => {
+        log("stdin error:", err?.message || err);
+      });
+    }
+
+    writeStdinLine({
+      type: "user",
+      message: { role: "user", content: runPrompt },
+    });
+
+    state.writeStdinLine = writeStdinLine;
+    state.endStdin = endStdin;
 
     log("Spawned PID:", child.pid, "run:", runNumber);
 
@@ -325,6 +393,24 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
 
         markFirstTiming(state, "firstEventMs");
         if (!isThinking) log("Parsed event type:", event.type, "subtype:", event.subtype, "run:", runNumber);
+
+        if (event.type === "control_request" && event.request?.subtype === "can_use_tool") {
+          handleCanUseTool(state, event);
+          return;
+        }
+        if (event.type === "control_cancel_request") {
+          const reqId = event.request_id || event.cancel_request_id;
+          if (reqId && state.pendingPermissions.has(reqId)) {
+            state.pendingPermissions.delete(reqId);
+            if (!webContents.isDestroyed?.()) {
+              webContents.send("agent-permission-cancelled", { conversationId, requestId: reqId });
+            }
+          }
+          return;
+        }
+        if (event.type === "control_response") {
+          return;
+        }
 
         if (event.type === "assistant" && messageHasAssistantText(event.message)) {
           markFirstTiming(state, "firstAssistantTextMs");
@@ -365,6 +451,8 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
           state.latestSessionId = event.session_id || state.latestSessionId;
           log("Result keys:", Object.keys(event));
           log("Result summary:", summarizeResult(event));
+          // Close stdin so the CLI exits cleanly; no further turns in this run.
+          endStdin();
         }
 
         webContents.send("agent-stream", { conversationId, event });
@@ -494,11 +582,100 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
   });
 }
 
+function writeControlResponse(state, requestId, responseBody) {
+  if (!state || !state.writeStdinLine) return false;
+  return state.writeStdinLine({
+    type: "control_response",
+    response: {
+      subtype: "success",
+      request_id: requestId,
+      response: responseBody,
+    },
+  });
+}
+
+function handleCanUseTool(state, event) {
+  const request = event.request || {};
+  const requestId = event.request_id;
+  if (!requestId) return;
+  const classified = classifyPermissionRequest(request);
+  const allowKey = buildPermissionKey(classified.toolName, request.input, request.blocked_path);
+
+  if (state.sessionAllowlist.has(allowKey)) {
+    log("Auto-allowing via session allowlist:", allowKey);
+    writeControlResponse(state, requestId, {
+      behavior: "allow",
+      updatedInput: request.input || {},
+    });
+    return;
+  }
+
+  const payload = {
+    conversationId: state.conversationId,
+    requestId,
+    toolUseId: request.tool_use_id || null,
+    toolName: classified.toolName,
+    input: request.input || {},
+    blockedPath: request.blocked_path || null,
+    description: request.description || null,
+    permissionSuggestions: request.permission_suggestions || null,
+    summary: classified.summary,
+    targetPath: classified.targetPath,
+    isSensitiveFile: classified.isSensitiveFile,
+    allowKey,
+  };
+
+  state.pendingPermissions.set(requestId, { request, allowKey });
+  if (!state.webContents.isDestroyed?.()) {
+    state.webContents.send("agent-permission-request", payload);
+  }
+}
+
+function respondPermission({ conversationId, requestId, behavior, message, updatedInput, scope }) {
+  const state = activeAgents.get(conversationId);
+  if (!state) {
+    log("respondPermission: no active agent for", conversationId);
+    return false;
+  }
+  const pending = state.pendingPermissions.get(requestId);
+  if (!pending) {
+    log("respondPermission: no pending request", requestId);
+    return false;
+  }
+  state.pendingPermissions.delete(requestId);
+
+  if (behavior === "allow") {
+    if (scope === "session" && pending.allowKey) {
+      state.sessionAllowlist.add(pending.allowKey);
+      log("Added to session allowlist:", pending.allowKey);
+    }
+    return writeControlResponse(state, requestId, {
+      behavior: "allow",
+      updatedInput: updatedInput || pending.request.input || {},
+    });
+  }
+
+  return writeControlResponse(state, requestId, {
+    behavior: "deny",
+    message: message || "User denied permission",
+  });
+}
+
 function cancelAgent(conversationId) {
   const state = activeAgents.get(conversationId);
   if (state?.child) {
     log("Cancelling agent:", conversationId);
     state.cancelled = true;
+    if (state.pendingPermissions?.size) {
+      for (const requestId of state.pendingPermissions.keys()) {
+        writeControlResponse(state, requestId, {
+          behavior: "deny",
+          message: "Cancelled",
+        });
+      }
+      state.pendingPermissions.clear();
+    }
+    try { state.endStdin?.(); } catch {}
     state.child.kill("SIGTERM");
   }
 }
@@ -507,6 +684,7 @@ function cancelAll() {
   for (const [, state] of activeAgents) {
     if (!state?.child) continue;
     state.cancelled = true;
+    try { state.endStdin?.(); } catch {}
     state.child.kill("SIGTERM");
   }
 }
@@ -565,4 +743,4 @@ function rewindFiles({ sessionId, messageUuid, cwd }) {
   });
 }
 
-module.exports = { startAgent, cancelAgent, cancelAll, rewindFiles };
+module.exports = { startAgent, cancelAgent, cancelAll, rewindFiles, respondPermission };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -2,7 +2,7 @@ const { app, BrowserWindow, ipcMain, dialog, nativeImage, shell, clipboard } = r
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { startAgent, cancelAgent, cancelAll, rewindFiles } = require("./agent-manager.cjs");
+const { startAgent, cancelAgent, cancelAll, rewindFiles, respondPermission } = require("./agent-manager.cjs");
 const { startCodexAgent, cancelCodexAgent, cancelAllCodex } = require("./codex-agent-manager.cjs");
 const {
   startMulticaAgent,
@@ -577,6 +577,14 @@ ipcMain.on("agent-edit-resend", (event, opts) => {
     startCodexAgent({ ...opts, resumeSessionId: opts.resumeSessionId }, event.sender);
   } else {
     startAgent({ ...opts, forkSession: true }, event.sender);
+  }
+});
+
+ipcMain.on("agent-permission-respond", (_event, opts) => {
+  try {
+    respondPermission(opts);
+  } catch (err) {
+    console.error("[agent] permission respond failed:", err?.message || err);
   }
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -23,6 +23,17 @@ contextBridge.exposeInMainWorld("api", {
     ipcRenderer.on("agent-error", handler);
     return () => ipcRenderer.removeListener("agent-error", handler);
   },
+  agentPermissionRespond: (opts) => ipcRenderer.send("agent-permission-respond", opts),
+  onAgentPermissionRequest: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on("agent-permission-request", handler);
+    return () => ipcRenderer.removeListener("agent-permission-request", handler);
+  },
+  onAgentPermissionCancelled: (cb) => {
+    const handler = (_e, data) => cb(data);
+    ipcRenderer.on("agent-permission-cancelled", handler);
+    return () => ipcRenderer.removeListener("agent-permission-cancelled", handler);
+  },
   pickFolder: () => ipcRenderer.invoke("folder-pick"),
   selectWallpaper: (previousPath) => ipcRenderer.invoke("select-wallpaper", previousPath),
   deleteWallpaper: (filePath) => ipcRenderer.invoke("delete-wallpaper", filePath),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1064,6 +1064,7 @@ export default function App() {
   const queueInterruptRequestedRef = useRef(new Set());
   const activeConversationIdRef = useRef(null);
   const [queuedMessages, setQueuedMessages] = useState([]);
+  const [permissionRequests, setPermissionRequests] = useState([]);
   const labControlTimersRef = useRef(new Map());
   const persistableConversations = useMemo(
     () =>
@@ -1129,6 +1130,43 @@ export default function App() {
     () => queuedMessages.filter((item) => item?.conversationId === active),
     [active, queuedMessages]
   );
+  const activePermissionRequests = useMemo(
+    () => permissionRequests.filter((item) => item?.conversationId === active),
+    [active, permissionRequests]
+  );
+
+  useEffect(() => {
+    if (!window.api?.onAgentPermissionRequest) return undefined;
+    const offRequest = window.api.onAgentPermissionRequest((data) => {
+      if (!data?.requestId) return;
+      setPermissionRequests((prev) => {
+        if (prev.some((p) => p.requestId === data.requestId)) return prev;
+        return [...prev, data];
+      });
+    });
+    const offCancelled = window.api.onAgentPermissionCancelled?.(({ requestId }) => {
+      if (!requestId) return;
+      setPermissionRequests((prev) => prev.filter((p) => p.requestId !== requestId));
+    });
+    const offDone = window.api.onAgentDone?.(({ conversationId }) => {
+      if (!conversationId) return;
+      setPermissionRequests((prev) => prev.filter((p) => p.conversationId !== conversationId));
+    });
+    return () => {
+      offRequest?.();
+      offCancelled?.();
+      offDone?.();
+    };
+  }, []);
+
+  const respondPermission = useCallback(({ requestId, behavior, scope, message }) => {
+    if (!window.api?.agentPermissionRespond) return;
+    const req = permissionRequests.find((p) => p.requestId === requestId);
+    const conversationId = req?.conversationId;
+    if (!conversationId) return;
+    window.api.agentPermissionRespond({ conversationId, requestId, behavior, scope, message });
+    setPermissionRequests((prev) => prev.filter((p) => p.requestId !== requestId));
+  }, [permissionRequests]);
 
   useEffect(() => {
     activeConversationIdRef.current = active;
@@ -3350,6 +3388,8 @@ export default function App() {
           queuedMessages={activeQueuedMessages}
           onUpdateQueuedMessage={updateQueuedMessage}
           onRemoveQueuedMessage={removeQueuedMessage}
+          permissionRequests={activePermissionRequests}
+          onRespondPermission={respondPermission}
           onToggleTerminal={handleToggleTerminal}
           terminalOpen={terminal.drawerOpen}
           terminalCount={terminal.sessions.length}

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -90,7 +90,7 @@ const ChatTranscript = memo(function ChatTranscript({
   );
 });
 
-export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSidebar, sidebarOpen, onNew, onModelChange, defaultModel, queuedMessages, onUpdateQueuedMessage, onRemoveQueuedMessage, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, onCwdChange, onRefocusTerminal, showNewChatCard, onCreateChat, onCancelNewChat, allCwdRoots, projects, defaultPrBranch, newChatDefaultCwd, coauthorEnabled = false, coauthorTrailer = "", onControlChange, canControlTarget, developerMode = true, tabs = [], activeTabId = null, onSelectTab, onCloseTab }) {
+export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSidebar, sidebarOpen, onNew, onModelChange, defaultModel, queuedMessages, onUpdateQueuedMessage, onRemoveQueuedMessage, permissionRequests, onRespondPermission, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, onCwdChange, onRefocusTerminal, showNewChatCard, onCreateChat, onCancelNewChat, allCwdRoots, projects, defaultPrBranch, newChatDefaultCwd, coauthorEnabled = false, coauthorTrailer = "", onControlChange, canControlTarget, developerMode = true, tabs = [], activeTabId = null, onSelectTab, onCloseTab }) {
   const s = useFontScale();
   const [input, setInput]             = useState("");
   const [inputFocused, setInputFocused] = useState(false);
@@ -775,6 +775,112 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, onToggleSide
         style={{ padding: "12px 28px 24px", display: "flex", justifyContent: "center" }}
       >
         <div style={{ width: "100%", maxWidth: 560 }}>
+          {permissionRequests && permissionRequests.length > 0 && (
+            <div style={{ marginBottom: 8 }}>
+              {permissionRequests.map((req) => {
+                const actionButtonStyle = {
+                  height: 24,
+                  padding: "0 9px",
+                  borderRadius: 7,
+                  border: "1px solid rgba(255,255,255,0.04)",
+                  background: "transparent",
+                  color: "rgba(255,255,255,0.3)",
+                  cursor: "pointer",
+                  fontSize: s(9),
+                  fontFamily: "'JetBrains Mono',monospace",
+                  letterSpacing: ".05em",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                };
+                const labelText = req.isSensitiveFile ? "SENSITIVE" : "PERMISSION";
+                const tool = req.toolName || "Tool";
+                const summary = req.summary || "";
+                return (
+                  <div
+                    key={req.requestId}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "6px 8px",
+                      marginBottom: 4,
+                      background: "rgba(255,255,255,0.014)",
+                      border: "1px solid rgba(255,255,255,0.035)",
+                      borderRadius: 12,
+                      fontSize: s(12),
+                      color: "rgba(255,255,255,0.44)",
+                      fontFamily: "system-ui,sans-serif",
+                    }}
+                  >
+                    <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, minWidth: 0 }}>
+                      <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+                        <span style={{
+                          fontSize: s(9),
+                          fontFamily: "'JetBrains Mono',monospace",
+                          color: "rgba(255,255,255,0.14)",
+                          letterSpacing: ".06em",
+                          flexShrink: 0,
+                        }}>
+                          {labelText}
+                        </span>
+                        <span style={{
+                          fontSize: s(9),
+                          fontFamily: "'JetBrains Mono',monospace",
+                          color: "rgba(255,255,255,0.28)",
+                          letterSpacing: ".06em",
+                        }}>
+                          {String(tool).toUpperCase()}
+                        </span>
+                      </div>
+                      <div style={{
+                        flex: 1,
+                        minWidth: 0,
+                        padding: "2px 8px",
+                        transform: "translateY(-1.5px)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                        lineHeight: "18px",
+                        color: "rgba(255,255,255,0.62)",
+                      }}
+                        title={summary}
+                      >
+                        {summary}
+                      </div>
+                    </div>
+                    <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+                      <button
+                        onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "allow", scope: "once" })}
+                        style={{
+                          ...actionButtonStyle,
+                          background: "rgba(255,255,255,0.06)",
+                          color: "rgba(255,255,255,0.54)",
+                        }}
+                        title="Allow this request once"
+                      >
+                        ALLOW ONCE
+                      </button>
+                      <button
+                        onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "allow", scope: "session" })}
+                        style={actionButtonStyle}
+                        title="Allow this tool + target for the rest of the session"
+                      >
+                        ALLOW SESSION
+                      </button>
+                      <button
+                        onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "deny" })}
+                        style={actionButtonStyle}
+                        title="Deny this request"
+                      >
+                        DENY
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
           {queuedMessages && queuedMessages.length > 0 && (
             <div style={{ marginBottom: 8 }}>
               {queuedMessages.map((q, i) => {


### PR DESCRIPTION
## Summary
- Closes #154
- Replaces `--dangerously-skip-permissions` with `--permission-mode bypassPermissions --permission-prompt-tool stdio`, so the CLI auto-allows safe tools but routes sensitive-file decisions to RayLine via `control_request` (bidirectional stream-json).
- Adds a compact permission pill above the input matching the queued-message style, with three actions: ALLOW ONCE / ALLOW SESSION / DENY.
- Session-scope allowlist is in-memory (keyed by tool+path), not persisted across app restarts.

## Test plan
- [x] Verified the CLI emits `can_use_tool` `control_request` for `Edit` on `~/.zshrc` under the new flags (direct smoke test).
- [x] Safe tools (e.g. `Read` on non-sensitive paths) pass through without prompting under `bypassPermissions`.
- [x] `npm run build` clean; only pre-existing lint issues outside touched files.
- [ ] End-to-end manual: ask Claude to edit `~/.zshrc` inside the app, verify pill appears with ALLOW ONCE / ALLOW SESSION / DENY and that each choice is honored.
- [ ] Manual: confirm ALLOW SESSION scope persists within a single RayLine session only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)