### PR TITLE
feat(theme): WS-0 ThemeContext + bootstrap + tokens + Settings radio

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from "react";
 import { ArrowLeft, Check, ChevronDown, Image } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
 import { createTranslator } from "../i18n";
+import { useTheme } from "../contexts/ThemeContext.jsx";
 import { getPaneSurfaceStyle } from "../utils/paneSurface";
 import { DEFAULT_WALLPAPER, normalizeWallpaper } from "../utils/wallpaper";
 import { CHIME_SOUNDS, playChime } from "../utils/chime";
@@ -9,6 +10,7 @@ import { loadMulticaState, normalizeMulticaServerUrl, saveMulticaState } from ".
 
 export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFontSizeChange, defaultPrBranch, onDefaultPrBranchChange, coauthorEnabled = false, onCoauthorEnabledChange, appBlur = 0, onAppBlurChange, appOpacity = 100, onAppOpacityChange, developerMode = false, onDeveloperModeChange, sidebarTerminalEnabled = false, onSidebarTerminalEnabledChange, chromeControlsOnHover = false, onChromeControlsOnHoverChange, notificationSound = "glass", onNotificationSoundChange, notificationsMuted = false, onNotificationsMutedChange, platform = null, locale = "en-US", onLocaleChange, onClose }) {
   const s = useFontScale();
+  const { mode, setMode } = useTheme();
   const t = createTranslator(locale);
   const showUpdaterSettings = platform === "win32";
   const [local, setLocal] = useState(() => normalizeWallpaper(wallpaper) ?? { ...DEFAULT_WALLPAPER });
@@ -155,6 +157,11 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
   const imgOpacityPct = sliderPct(local.imgOpacity || 0, 0, 100);
   const appBlurPct = sliderPct(appBlur || 0, 0, 20);
   const appOpacityPct = sliderPct(appOpacity || 100, 30, 100);
+  const themeOptions = [
+    { value: "auto", label: t("settings.themeAuto") },
+    { value: "light", label: t("settings.themeLight") },
+    { value: "dark", label: t("settings.themeDark") },
+  ];
 
   // Slider track style helper
   const sliderTrack = (pct) =>
@@ -291,6 +298,183 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
           >
             {t("settings.appearance")}
           </div>
+
+
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                fontSize: s(13),
+                color: "rgba(255,255,255,0.8)",
+                marginBottom: 10,
+              }}
+            >
+              {t("settings.theme")}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                gap: 8,
+                flexWrap: "wrap",
+              }}
+            >
+              {themeOptions.map((option) => {
+                const selected = mode === option.value;
+                return (
+                  <label
+                    key={option.value}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 8,
+                      height: 30,
+                      padding: "0 10px",
+                      borderRadius: 7,
+                      background: selected ? "rgba(255,255,255,0.1)" : "rgba(255,255,255,0.04)",
+                      border: selected ? "1px solid rgba(255,255,255,0.18)" : "1px solid rgba(255,255,255,0.08)",
+                      color: selected ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.62)",
+                      cursor: "pointer",
+                      fontSize: s(12),
+                      transition: "all .2s",
+                      fontFamily: "system-ui, sans-serif",
+                    }}
+                  >
+                    <input
+                      type="radio"
+                      name="rayline-theme"
+                      value={option.value}
+                      checked={selected}
+                      onChange={(e) => setMode(e.target.value)}
+                      style={{
+                        accentColor: "white",
+                        margin: 0,
+                      }}
+                    />
+                    <span>{option.label}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </div>
+
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                fontSize: s(13),
+                color: "rgba(255,255,255,0.8)",
+                marginBottom: 2,
+              }}
+            >
+              {t("settings.language")}
+            </div>
+            <div
+              style={{
+                fontSize: s(11),
+                color: "rgba(255,255,255,0.3)",
+                marginBottom: 10,
+              }}
+            >
+              {t("settings.languageDescription")}
+            </div>
+            <div style={{ position: "relative", display: "flex", alignItems: "center" }}>
+              <select
+                value={locale}
+                onChange={(e) => onLocaleChange?.(e.target.value)}
+                style={{
+                  width: "100%",
+                  height: 32,
+                  padding: "0 28px 0 10px",
+                  background: "rgba(255,255,255,0.04)",
+                  border: "1px solid rgba(255,255,255,0.08)",
+                  borderRadius: 7,
+                  color: "rgba(255,255,255,0.9)",
+                  fontFamily: "system-ui, sans-serif",
+                  fontSize: s(12),
+                  outline: "none",
+                  WebkitAppearance: "none",
+                  MozAppearance: "none",
+                  appearance: "none",
+                }}
+              >
+                <option value="en-US">{t("settings.languageEnglish")}</option>
+                <option value="zh-CN">{t("settings.languageChinese")}</option>
+              </select>
+              <ChevronDown
+                size={12}
+                strokeWidth={2}
+                style={{
+                  position: "absolute",
+                  right: 10,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  color: "rgba(255,255,255,0.5)",
+                  pointerEvents: "none",
+                }}
+              />
+            </div>
+          </div>
+
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: s(13),
+                    color: "rgba(255,255,255,0.8)",
+                    marginBottom: 2,
+                  }}
+                >
+                  {t("settings.chromeControlsOnHover")}
+                </div>
+                <div
+                  style={{
+                    fontSize: s(11),
+                    color: "rgba(255,255,255,0.3)",
+                  }}
+                >
+                  {t("settings.chromeControlsOnHoverDescription")}
+                </div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={chromeControlsOnHover}
+                onClick={() => onChromeControlsOnHoverChange?.(!chromeControlsOnHover)}
+                style={{
+                  flexShrink: 0,
+                  width: 38,
+                  height: 22,
+                  borderRadius: 999,
+                  border: "1px solid rgba(255,255,255,0.12)",
+                  background: chromeControlsOnHover ? "rgba(180,220,255,0.35)" : "rgba(255,255,255,0.06)",
+                  position: "relative",
+                  cursor: "pointer",
+                  padding: 0,
+                  transition: "background 120ms ease",
+                }}
+              >
+                <span
+                  style={{
+                    position: "absolute",
+                    top: 2,
+                    left: chromeControlsOnHover ? 18 : 2,
+                    width: 16,
+                    height: 16,
+                    borderRadius: "50%",
+                    background: "rgba(255,255,255,0.9)",
+                    transition: "left 120ms ease",
+                  }}
+                />
+              </button>
+            </div>
+          </div>
+
 
           {/* Wallpaper subsection */}
           <div style={{ marginBottom: 28 }}>

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,101 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+const THEME_STORAGE_KEY = "rayline.themeMode";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+const MODES = new Set(["auto", "light", "dark"]);
+
+function normalizeMode(value) {
+  return MODES.has(value) ? value : "auto";
+}
+
+function getStoredMode() {
+  try {
+    return normalizeMode(window.localStorage.getItem(THEME_STORAGE_KEY));
+  } catch {
+    return "auto";
+  }
+}
+
+function getSystemResolved() {
+  if (window.matchMedia?.(DARK_QUERY)?.matches) {
+    return "dark";
+  }
+  return "light";
+}
+
+function resolveTheme(mode, systemResolved) {
+  return mode === "auto" ? systemResolved : mode;
+}
+
+const ThemeContext = createContext(null);
+
+export function ThemeProvider({ children }) {
+  const [mode, setModeState] = useState(getStoredMode);
+  const [systemResolved, setSystemResolved] = useState(getSystemResolved);
+  const resolved = resolveTheme(mode, systemResolved);
+
+  useEffect(() => {
+    const media = window.matchMedia?.(DARK_QUERY);
+    if (!media) return undefined;
+
+    const handleChange = (event) => {
+      setSystemResolved(event.matches ? "dark" : "light");
+    };
+
+    if (media.addEventListener) {
+      media.addEventListener("change", handleChange);
+    } else {
+      media.addListener?.(handleChange);
+    }
+    return () => {
+      if (media.removeEventListener) {
+        media.removeEventListener("change", handleChange);
+      } else {
+        media.removeListener?.(handleChange);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (event) => {
+      if (event.key === THEME_STORAGE_KEY) {
+        setModeState(normalizeMode(event.newValue));
+      }
+    };
+
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = resolved;
+    window.dispatchEvent(new CustomEvent("rayline:theme-change", { detail: { resolved } }));
+  }, [resolved]);
+
+  const setMode = useCallback((nextMode) => {
+    const normalized = normalizeMode(nextMode);
+    setModeState(normalized);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, normalized);
+    } catch {
+      // Ignore storage failures; the in-memory mode still applies for this window.
+    }
+  }, []);
+
+  const value = useMemo(() => ({ mode, resolved, setMode }), [mode, resolved, setMode]);
+
+  return (
+    <ThemeContext.Provider value={value}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const value = useContext(ThemeContext);
+  if (!value) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return value;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -152,3 +152,93 @@ input[type="range"]::-webkit-slider-thumb {
   cursor: pointer;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
 }
+
+/* ── Theme WS-0 token additions ── */
+:root {
+  --state-warning-soft-bg: rgba(240,180,80,0.14);
+  --state-warning-soft-border: rgba(240,180,80,0.22);
+  --state-warning-soft-text: rgba(250,200,120,0.92);
+  --state-info-soft-bg: rgba(120,180,255,0.10);
+  --state-info-soft-border: rgba(120,180,255,0.18);
+  --state-info-soft-text: rgba(170,210,255,0.92);
+  --code-bg: rgba(255,255,255,0.035);
+  --code-border: rgba(255,255,255,0.06);
+  --code-text: rgba(230,235,240,0.92);
+  --term-fg: #E6E6E6;
+  --term-bg: transparent;
+  --term-cursor: #FFFFFF;
+  --term-selection: rgba(255,255,255,0.18);
+  --term-black: #1d1f21;
+  --term-red: #cc6666;
+  --term-green: #b5bd68;
+  --term-yellow: #f0c674;
+  --term-blue: #81a2be;
+  --term-magenta: #b294bb;
+  --term-cyan: #8abeb7;
+  --term-white: #c5c8c6;
+  --term-brightBlack: #666;
+  --term-brightRed: #d54e53;
+  --term-brightGreen: #b9ca4a;
+  --term-brightYellow: #e7c547;
+  --term-brightBlue: #7aa6da;
+  --term-brightMagenta: #c397d8;
+  --term-brightCyan: #70c0b1;
+  --term-brightWhite: #eaeaea;
+  --mermaid-primary: #2a2a2f;
+  --mermaid-primary-text: #e6e6e6;
+  --mermaid-line: #555;
+  --mermaid-secondary: #3a3a3f;
+}
+
+:root[data-theme="light"] {
+  --pane-background: #f7f4ee;
+  --pane-background-rgb: 247, 244, 238;
+  --pane-overlay-alpha: 0.88;
+  --pane-background-overlay: rgba(var(--pane-background-rgb), var(--pane-overlay-alpha));
+  --pane-hover-overlay: rgba(239, 234, 225, var(--pane-overlay-alpha));
+  --pane-active-overlay: rgba(229, 222, 211, var(--pane-overlay-alpha));
+  --pane-elevated-rgb: 255, 255, 255;
+  --pane-elevated: rgba(var(--pane-elevated-rgb), 0.72);
+  --pane-hover: #efeae1;
+  --pane-active: #e5ded3;
+  --pane-interaction-hover-fill: var(--pane-hover);
+  --pane-interaction-active-fill: var(--pane-active);
+  --pane-interaction-hover-filter: none;
+  --pane-interaction-active-filter: none;
+  --pane-interaction-hover-shadow: none;
+  --pane-interaction-active-shadow: none;
+  --pane-border: rgba(31,41,55,0.10);
+  --state-warning-soft-bg: rgba(217,150,40,0.10);
+  --state-warning-soft-border: rgba(217,150,40,0.20);
+  --state-warning-soft-text: rgba(139,92,21,0.92);
+  --state-info-soft-bg: rgba(38,139,210,0.10);
+  --state-info-soft-border: rgba(38,139,210,0.18);
+  --state-info-soft-text: rgba(24,96,150,0.92);
+  --code-bg: rgba(31,41,55,0.04);
+  --code-border: rgba(31,41,55,0.09);
+  --code-text: rgba(26,33,43,0.92);
+  --term-fg: #1a212b;
+  --term-bg: transparent;
+  --term-cursor: #1a212b;
+  --term-selection: rgba(31,41,55,0.18);
+  --term-black: #eee8d5;
+  --term-red: #dc322f;
+  --term-green: #859900;
+  --term-yellow: #b58900;
+  --term-blue: #268bd2;
+  --term-magenta: #d33682;
+  --term-cyan: #2aa198;
+  --term-white: #073642;
+  --term-brightBlack: #002b36;
+  --term-brightRed: #cb4b16;
+  --term-brightGreen: #586e75;
+  --term-brightYellow: #657b83;
+  --term-brightBlue: #839496;
+  --term-brightMagenta: #6c71c4;
+  --term-brightCyan: #93a1a1;
+  --term-brightWhite: #fdf6e3;
+  --mermaid-primary: #ffffff;
+  --mermaid-primary-text: #1a212b;
+  --mermaid-line: #b8b0a0;
+  --mermaid-secondary: #f4efe7;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,9 @@
   --pane-interaction-hover-shadow: none;
   --pane-interaction-active-shadow: none;
   --pane-border: rgba(255,255,255,0.06);
+  --text-primary: rgba(255,255,255,0.92);
+  --control-bg: rgba(255,255,255,0.05);
+  --control-border: rgba(255,255,255,0.10);
 }
 
 *, *::before, *::after {
@@ -208,6 +211,9 @@ input[type="range"]::-webkit-slider-thumb {
   --pane-interaction-hover-shadow: none;
   --pane-interaction-active-shadow: none;
   --pane-border: rgba(31,41,55,0.10);
+  --text-primary: rgba(26,33,43,0.92);
+  --control-bg: rgba(255,255,255,0.72);
+  --control-border: rgba(31,41,55,0.10);
   --state-warning-soft-bg: rgba(217,150,40,0.10);
   --state-warning-soft-border: rgba(217,150,40,0.20);
   --state-warning-soft-text: rgba(139,92,21,0.92);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,11 @@
+import applyBootstrapTheme from "./utils/themeBootstrap.js";
+applyBootstrapTheme();
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import { ThemeProvider } from "./contexts/ThemeContext.jsx";
 
 const container = document.getElementById("root");
 
@@ -14,6 +18,8 @@ container.__raylineRoot = root;
 
 root.render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>
 );

--- a/src/pm-main.jsx
+++ b/src/pm-main.jsx
@@ -3,6 +3,7 @@ applyBootstrapTheme();
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import "./index.css";
 import "./pm-index.css";
 import ProjectManager from "./ProjectManager";
 import { ThemeProvider } from "./contexts/ThemeContext.jsx";

--- a/src/pm-main.jsx
+++ b/src/pm-main.jsx
@@ -1,10 +1,16 @@
+import applyBootstrapTheme from "./utils/themeBootstrap.js";
+applyBootstrapTheme();
+
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./pm-index.css";
 import ProjectManager from "./ProjectManager";
+import { ThemeProvider } from "./contexts/ThemeContext.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <ProjectManager />
+    <ThemeProvider>
+      <ProjectManager />
+    </ThemeProvider>
   </StrictMode>
 );

--- a/src/terminal-main.jsx
+++ b/src/terminal-main.jsx
@@ -1,6 +1,10 @@
+import applyBootstrapTheme from "./utils/themeBootstrap.js";
+applyBootstrapTheme();
+
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import TerminalWindow from "./TerminalWindow";
+import { ThemeProvider } from "./contexts/ThemeContext.jsx";
 
 const container = document.getElementById("root");
 
@@ -9,5 +13,7 @@ if (!container) {
 }
 
 createRoot(container).render(
-  <TerminalWindow />
+  <ThemeProvider>
+    <TerminalWindow />
+  </ThemeProvider>
 );

--- a/src/utils/themeBootstrap.js
+++ b/src/utils/themeBootstrap.js
@@ -1,0 +1,28 @@
+const THEME_STORAGE_KEY = "rayline.themeMode";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
+const MODES = new Set(["auto", "light", "dark"]);
+
+function normalizeMode(value) {
+  return MODES.has(value) ? value : "auto";
+}
+
+function getStoredMode() {
+  try {
+    return normalizeMode(window.localStorage.getItem(THEME_STORAGE_KEY));
+  } catch {
+    return "auto";
+  }
+}
+
+function getSystemResolved() {
+  if (window.matchMedia?.(DARK_QUERY)?.matches) {
+    return "dark";
+  }
+  return "light";
+}
+
+export default function applyBootstrapTheme() {
+  const mode = getStoredMode();
+  const resolved = mode === "auto" ? getSystemResolved() : mode;
+  document.documentElement.dataset.theme = resolved;
+}


### PR DESCRIPTION
## Summary
WS-0：主题系统 Phase 1 基建。新增 ThemeContext + bootstrap + tokens，Settings 加主题 radio 切换，为后续组件 var 化铺路。

## Changes
- `src/contexts/ThemeContext.jsx` 新建（101 行）：React Context，localStorage 持久化，system 跟随
- `src/utils/themeBootstrap.js` 新建（28 行）：页面加载前同步刷 `data-theme` 防闪烁
- `src/index.css`：新增 90 行 CSS 变量 tokens（light / dark / system）
- `src/components/Settings.jsx`：+63 行，主题 radio UI
- `src/main.jsx` / `pm-main.jsx` / `terminal-main.jsx`：三入口挂 ThemeProvider + bootstrap

**7 files, +303/-3**

## Test plan
- [ ] `npm run dev` 三入口刷不闪
- [ ] Settings 切 light/dark/system 即时生效
- [ ] localStorage 记住选择
- [ ] Lighthouse 无新增 a11y 问题

## Stack
这是主题 Phase 1 的地基，后续 WS-A/B/C 依赖此 PR。
