### PR TITLE
feat(theme): WS-A Settings + Sidebar var化

### DIFF
--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -244,7 +244,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             height: 28,
             borderRadius: 7,
             background: backHover
-              ? "var(--control-bg)"
+              ? "var(--control-bg-hover)"
               : "var(--control-bg)",
             border: "1px solid var(--control-border)",
             color: backHover
@@ -499,7 +499,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                       padding: "6px 14px",
                       borderRadius: 7,
                       background: removeHover
-                        ? "var(--control-bg)"
+                        ? "var(--control-bg-hover)"
                         : "var(--control-bg)",
                       border: "1px solid var(--control-border)",
                       color: "color-mix(in srgb, var(--text-primary) 49%, transparent)",

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -158,7 +158,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
 
   // Slider track style helper
   const sliderTrack = (pct) =>
-    `linear-gradient(to right, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0.5) ${pct}%, rgba(255,255,255,0.08) ${pct}%, rgba(255,255,255,0.08) 100%)`;
+    `linear-gradient(to right, color-mix(in srgb, var(--text-primary) 54%, transparent) 0%, color-mix(in srgb, var(--text-primary) 54%, transparent) ${pct}%, var(--control-border) ${pct}%, var(--control-border) 100%)`;
 
   const sliderStyle = (pct) => ({
     width: "100%",
@@ -169,7 +169,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
     background: sliderTrack(pct),
     outline: "none",
     cursor: "pointer",
-    accentColor: "white",
+    accentColor: "var(--text-primary)",
   });
 
   // Hover state refs for buttons
@@ -214,7 +214,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
         position: "relative",
         zIndex: 10,
         ...getPaneSurfaceStyle(Boolean(local.dataUrl)),
-        color: "rgba(255,255,255,0.85)",
+        color: "var(--text-primary)",
         fontFamily: "system-ui, sans-serif",
       }}
     >
@@ -244,12 +244,12 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             height: 28,
             borderRadius: 7,
             background: backHover
-              ? "rgba(255,255,255,0.05)"
-              : "rgba(255,255,255,0.02)",
-            border: "1px solid rgba(255,255,255,0.04)",
+              ? "var(--control-bg)"
+              : "var(--control-bg)",
+            border: "1px solid var(--control-border)",
             color: backHover
-              ? "rgba(255,255,255,0.75)"
-              : "rgba(255,255,255,0.5)",
+              ? "color-mix(in srgb, var(--text-primary) 82%, transparent)"
+              : "color-mix(in srgb, var(--text-primary) 54%, transparent)",
             cursor: "pointer",
             transition: "all .2s",
           }}
@@ -260,7 +260,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
           style={{
             fontSize: s(14),
             fontWeight: 600,
-            color: "rgba(255,255,255,0.85)",
+            color: "var(--text-primary)",
           }}
         >
           {t("settings.title")}
@@ -283,7 +283,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               fontFamily: "'JetBrains Mono', monospace",
               fontSize: s(10),
               fontWeight: 600,
-              color: "rgba(255,255,255,0.25)",
+              color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
               letterSpacing: ".12em",
               textTransform: "uppercase",
               marginBottom: 20,
@@ -292,12 +292,132 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             {t("settings.appearance")}
           </div>
 
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                fontSize: s(13),
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
+                marginBottom: 2,
+              }}
+            >
+              {t("settings.language")}
+            </div>
+            <div
+              style={{
+                fontSize: s(11),
+                color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
+                marginBottom: 10,
+              }}
+            >
+              {t("settings.languageDescription")}
+            </div>
+            <div style={{ position: "relative", display: "flex", alignItems: "center" }}>
+              <select
+                value={locale}
+                onChange={(e) => onLocaleChange?.(e.target.value)}
+                style={{
+                  width: "100%",
+                  height: 32,
+                  padding: "0 28px 0 10px",
+                  background: "var(--control-bg)",
+                  border: "1px solid var(--control-border)",
+                  borderRadius: 7,
+                  color: "var(--text-primary)",
+                  fontFamily: "system-ui, sans-serif",
+                  fontSize: s(12),
+                  outline: "none",
+                  WebkitAppearance: "none",
+                  MozAppearance: "none",
+                  appearance: "none",
+                }}
+              >
+                <option value="en-US">{t("settings.languageEnglish")}</option>
+                <option value="zh-CN">{t("settings.languageChinese")}</option>
+              </select>
+              <ChevronDown
+                size={12}
+                strokeWidth={2}
+                style={{
+                  position: "absolute",
+                  right: 10,
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  color: "color-mix(in srgb, var(--text-primary) 54%, transparent)",
+                  pointerEvents: "none",
+                }}
+              />
+            </div>
+          </div>
+
+          <div style={{ marginBottom: 24 }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 12,
+              }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: s(13),
+                    color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
+                    marginBottom: 2,
+                  }}
+                >
+                  {t("settings.chromeControlsOnHover")}
+                </div>
+                <div
+                  style={{
+                    fontSize: s(11),
+                    color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
+                  }}
+                >
+                  {t("settings.chromeControlsOnHoverDescription")}
+                </div>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={chromeControlsOnHover}
+                onClick={() => onChromeControlsOnHoverChange?.(!chromeControlsOnHover)}
+                style={{
+                  flexShrink: 0,
+                  width: 38,
+                  height: 22,
+                  borderRadius: 999,
+                  border: "1px solid var(--control-border)",
+                  background: chromeControlsOnHover ? "rgba(180,220,255,0.35)" : "var(--control-bg)",
+                  position: "relative",
+                  cursor: "pointer",
+                  padding: 0,
+                  transition: "background 120ms ease",
+                }}
+              >
+                <span
+                  style={{
+                    position: "absolute",
+                    top: 2,
+                    left: chromeControlsOnHover ? 18 : 2,
+                    width: 16,
+                    height: 16,
+                    borderRadius: "50%",
+                    background: "var(--text-primary)",
+                    transition: "left 120ms ease",
+                  }}
+                />
+              </button>
+            </div>
+          </div>
+
+
           {/* Wallpaper subsection */}
           <div style={{ marginBottom: 28 }}>
             <div
               style={{
                 fontSize: s(13),
-                color: "rgba(255,255,255,0.8)",
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                 marginBottom: 2,
               }}
             >
@@ -306,7 +426,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(11),
-                color: "rgba(255,255,255,0.3)",
+                color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                 marginBottom: 12,
               }}
             >
@@ -328,10 +448,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   width: 120,
                   height: 72,
                   borderRadius: 8,
-                  border: "1px solid rgba(255,255,255,0.08)",
+                  border: "1px solid var(--control-border)",
                   background: local.dataUrl
                     ? `url("${local.dataUrl}") center/cover no-repeat`
-                    : "rgba(255,255,255,0.03)",
+                    : "var(--control-bg)",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
@@ -343,7 +463,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   <Image
                     size={24}
                     strokeWidth={1.2}
-                    color="rgba(255,255,255,0.12)"
+                    color="color-mix(in srgb, var(--text-primary) 13%, transparent)"
                   />
                 )}
               </div>
@@ -358,10 +478,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     padding: "6px 14px",
                     borderRadius: 7,
                     background: chooseHover
-                      ? "rgba(255,255,255,0.1)"
-                      : "rgba(255,255,255,0.06)",
-                    border: "1px solid rgba(255,255,255,0.06)",
-                    color: "rgba(255,255,255,0.75)",
+                      ? "color-mix(in srgb, var(--control-bg), var(--text-primary) 7%)"
+                      : "var(--control-bg)",
+                    border: "1px solid var(--control-border)",
+                    color: "color-mix(in srgb, var(--text-primary) 82%, transparent)",
                     fontSize: s(12),
                     cursor: "pointer",
                     transition: "all .2s",
@@ -379,10 +499,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                       padding: "6px 14px",
                       borderRadius: 7,
                       background: removeHover
-                        ? "rgba(255,255,255,0.07)"
-                        : "rgba(255,255,255,0.03)",
-                      border: "1px solid rgba(255,255,255,0.06)",
-                      color: "rgba(255,255,255,0.45)",
+                        ? "var(--control-bg)"
+                        : "var(--control-bg)",
+                      border: "1px solid var(--control-border)",
+                      color: "color-mix(in srgb, var(--text-primary) 49%, transparent)",
                       fontSize: s(12),
                       cursor: "pointer",
                       transition: "all .2s",
@@ -401,7 +521,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 style={{
                   fontFamily: "'JetBrains Mono', monospace",
                   fontSize: s(10),
-                  color: "rgba(255,255,255,0.15)",
+                  color: "color-mix(in srgb, var(--text-primary) 16%, transparent)",
                   marginTop: 4,
                   marginLeft: 2,
                 }}
@@ -416,7 +536,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(13),
-                color: "rgba(255,255,255,0.8)",
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                 marginBottom: 10,
               }}
             >
@@ -437,7 +557,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(13),
-                color: "rgba(255,255,255,0.8)",
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                 marginBottom: 10,
               }}
             >
@@ -454,7 +574,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(10),
-                color: "rgba(255,255,255,0.3)",
+                color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                 marginTop: 8,
               }}
             >
@@ -467,7 +587,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(13),
-                color: "rgba(255,255,255,0.8)",
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                 marginBottom: 10,
               }}
             >
@@ -484,7 +604,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(10),
-                color: "rgba(255,255,255,0.3)",
+                color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                 marginTop: 8,
               }}
             >
@@ -497,7 +617,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(13),
-                color: "rgba(255,255,255,0.8)",
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                 marginBottom: 10,
               }}
             >
@@ -514,7 +634,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(10),
-                color: "rgba(255,255,255,0.3)",
+                color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                 marginTop: 8,
               }}
             >
@@ -528,7 +648,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               fontFamily: "'JetBrains Mono', monospace",
               fontSize: s(10),
               fontWeight: 600,
-              color: "rgba(255,255,255,0.25)",
+              color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
               letterSpacing: ".12em",
               textTransform: "uppercase",
               marginBottom: 20,
@@ -543,7 +663,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(13),
-                color: "rgba(255,255,255,0.8)",
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                 marginBottom: 10,
               }}
             >
@@ -565,7 +685,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               fontFamily: "'JetBrains Mono', monospace",
               fontSize: s(10),
               fontWeight: 600,
-              color: "rgba(255,255,255,0.25)",
+              color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
               letterSpacing: ".12em",
               textTransform: "uppercase",
               marginBottom: 20,
@@ -579,7 +699,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(13),
-                color: "rgba(255,255,255,0.8)",
+                color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                 marginBottom: 2,
               }}
             >
@@ -588,7 +708,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
             <div
               style={{
                 fontSize: s(11),
-                color: "rgba(255,255,255,0.3)",
+                color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                 marginBottom: 12,
               }}
             >
@@ -599,7 +719,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               <div
                 style={{
                   fontSize: s(12),
-                  color: multicaConnected ? "rgba(205,255,214,0.88)" : "rgba(255,255,255,0.72)",
+                  color: multicaConnected ? "rgba(205,255,214,0.88)" : "color-mix(in srgb, var(--text-primary) 78%, transparent)",
                   marginBottom: 4,
                 }}
               >
@@ -609,7 +729,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 <div
                   style={{
                     fontSize: s(11),
-                    color: "rgba(255,255,255,0.42)",
+                    color: "color-mix(in srgb, var(--text-primary) 46%, transparent)",
                     marginBottom: 2,
                   }}
                 >
@@ -620,7 +740,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 <div
                   style={{
                     fontSize: s(11),
-                    color: "rgba(255,255,255,0.42)",
+                    color: "color-mix(in srgb, var(--text-primary) 46%, transparent)",
                   }}
                 >
                   {t("settings.workspace", { value: multica.workspaceSlug || multica.workspaceId })}
@@ -632,7 +752,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               <div
                 style={{
                   fontSize: s(13),
-                  color: "rgba(255,255,255,0.8)",
+                  color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                   marginBottom: 2,
                 }}
               >
@@ -641,7 +761,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               <div
                 style={{
                   fontSize: s(11),
-                  color: "rgba(255,255,255,0.3)",
+                  color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                   marginBottom: 10,
                 }}
               >
@@ -658,10 +778,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   boxSizing: "border-box",
                   height: 32,
                   padding: "0 10px",
-                  background: "rgba(255,255,255,0.04)",
-                  border: "1px solid rgba(255,255,255,0.08)",
+                  background: "var(--control-bg)",
+                  border: "1px solid var(--control-border)",
                   borderRadius: 7,
-                  color: "rgba(255,255,255,0.9)",
+                  color: "var(--text-primary)",
                   fontFamily: "'JetBrains Mono', monospace",
                   fontSize: s(12),
                   outline: "none",
@@ -677,9 +797,9 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 style={{
                   padding: "6px 14px",
                   borderRadius: 7,
-                  background: multicaServerDirty ? "rgba(255,255,255,0.1)" : "rgba(255,255,255,0.03)",
-                  border: "1px solid rgba(255,255,255,0.06)",
-                  color: multicaServerDirty ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.38)",
+                  background: multicaServerDirty ? "color-mix(in srgb, var(--control-bg), var(--text-primary) 7%)" : "var(--control-bg)",
+                  border: "1px solid var(--control-border)",
+                  color: multicaServerDirty ? "color-mix(in srgb, var(--text-primary) 89%, transparent)" : "color-mix(in srgb, var(--text-primary) 41%, transparent)",
                   fontSize: s(12),
                   cursor: multicaServerDirty ? "pointer" : "not-allowed",
                   transition: "all .2s",
@@ -694,9 +814,9 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 style={{
                   padding: "6px 14px",
                   borderRadius: 7,
-                  background: "rgba(255,255,255,0.06)",
-                  border: "1px solid rgba(255,255,255,0.06)",
-                  color: "rgba(255,255,255,0.75)",
+                  background: "var(--control-bg)",
+                  border: "1px solid var(--control-border)",
+                  color: "color-mix(in srgb, var(--text-primary) 82%, transparent)",
                   fontSize: s(12),
                   cursor: "pointer",
                   transition: "all .2s",
@@ -712,9 +832,9 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   style={{
                     padding: "6px 14px",
                     borderRadius: 7,
-                    background: "rgba(255,255,255,0.03)",
-                    border: "1px solid rgba(255,255,255,0.06)",
-                    color: "rgba(255,255,255,0.65)",
+                    background: "var(--control-bg)",
+                    border: "1px solid var(--control-border)",
+                    color: "color-mix(in srgb, var(--text-primary) 71%, transparent)",
                     fontSize: s(12),
                     cursor: "pointer",
                     transition: "all .2s",
@@ -733,7 +853,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               fontFamily: "'JetBrains Mono', monospace",
               fontSize: s(10),
               fontWeight: 600,
-              color: "rgba(255,255,255,0.25)",
+              color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
               letterSpacing: ".12em",
               textTransform: "uppercase",
               marginBottom: 20,
@@ -757,7 +877,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 <div
                   style={{
                     fontSize: s(13),
-                    color: "rgba(255,255,255,0.8)",
+                    color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                     marginBottom: 2,
                   }}
                 >
@@ -766,7 +886,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 <div
                   style={{
                     fontSize: s(11),
-                    color: "rgba(255,255,255,0.3)",
+                    color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                   }}
                 >
                   {t("settings.developerModeDescription")}
@@ -782,8 +902,8 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   width: 38,
                   height: 22,
                   borderRadius: 999,
-                  border: "1px solid rgba(255,255,255,0.12)",
-                  background: developerMode ? "rgba(180,220,255,0.35)" : "rgba(255,255,255,0.06)",
+                  border: "1px solid var(--control-border)",
+                  background: developerMode ? "rgba(180,220,255,0.35)" : "var(--control-bg)",
                   position: "relative",
                   cursor: "pointer",
                   padding: 0,
@@ -798,7 +918,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     width: 16,
                     height: 16,
                     borderRadius: "50%",
-                    background: "rgba(255,255,255,0.9)",
+                    background: "var(--text-primary)",
                     transition: "left 120ms ease",
                   }}
                 />
@@ -892,7 +1012,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   fontFamily: "'JetBrains Mono', monospace",
                   fontSize: s(10),
                   fontWeight: 600,
-                  color: "rgba(255,255,255,0.25)",
+                  color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
                   letterSpacing: ".12em",
                   textTransform: "uppercase",
                   marginBottom: 20,
@@ -903,10 +1023,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
               </div>
 
               <div style={{ marginBottom: 20 }}>
-                <div style={{ fontSize: s(13), color: "rgba(255,255,255,0.8)", marginBottom: 2 }}>
+                <div style={{ fontSize: s(13), color: "color-mix(in srgb, var(--text-primary) 87%, transparent)", marginBottom: 2 }}>
                   {t("settings.completionChime")}
                 </div>
-                <div style={{ fontSize: s(11), color: "rgba(255,255,255,0.3)", marginBottom: 10 }}>
+                <div style={{ fontSize: s(11), color: "color-mix(in srgb, var(--text-primary) 33%, transparent)", marginBottom: 10 }}>
                   {t("settings.completionChimeDescription")}
                 </div>
 
@@ -920,10 +1040,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                         width: "100%",
                         height: 32,
                         padding: "0 28px 0 10px",
-                        background: "rgba(255,255,255,0.04)",
-                        border: "1px solid rgba(255,255,255,0.08)",
+                        background: "var(--control-bg)",
+                        border: "1px solid var(--control-border)",
                         borderRadius: 7,
-                        color: "rgba(255,255,255,0.9)",
+                        color: "var(--text-primary)",
                         fontFamily: "system-ui, sans-serif",
                         fontSize: s(12),
                         outline: "none",
@@ -945,7 +1065,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                         right: 10,
                         top: "50%",
                         transform: "translateY(-50%)",
-                        color: "rgba(255,255,255,0.5)",
+                        color: "color-mix(in srgb, var(--text-primary) 54%, transparent)",
                         pointerEvents: "none",
                         opacity: notificationsMuted ? 0.4 : 1,
                       }}
@@ -958,10 +1078,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     style={{
                       height: 32,
                       padding: "0 12px",
-                      background: "rgba(255,255,255,0.04)",
-                      border: "1px solid rgba(255,255,255,0.08)",
+                      background: "var(--control-bg)",
+                      border: "1px solid var(--control-border)",
                       borderRadius: 7,
-                      color: "rgba(255,255,255,0.8)",
+                      color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                       fontSize: s(12),
                       cursor: notificationsMuted ? "not-allowed" : "pointer",
                       opacity: notificationsMuted ? 0.4 : 1,
@@ -999,12 +1119,12 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     width: 18,
                     height: 18,
                     borderRadius: 5,
-                    border: "1px solid rgba(255,255,255,0.18)",
+                    border: "1px solid var(--control-border)",
                     background: "transparent",
                     display: "inline-flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    boxShadow: notificationsMuted ? "inset 0 0 0 1px rgba(255,255,255,0.06)" : "none",
+                    boxShadow: notificationsMuted ? "inset 0 0 0 1px var(--control-border)" : "none",
                     flexShrink: 0,
                     transition: "border-color .15s, background .15s, box-shadow .15s",
                   }}
@@ -1012,7 +1132,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   <Check
                     size={12}
                     strokeWidth={2.2}
-                    color="rgba(255,255,255,0.86)"
+                    color="var(--text-primary)"
                     style={{
                       opacity: notificationsMuted ? 1 : 0,
                       transform: notificationsMuted ? "scale(1)" : "scale(0.75)",
@@ -1020,7 +1140,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     }}
                   />
                 </span>
-                <span style={{ fontSize: s(13), color: "rgba(255,255,255,0.8)" }}>
+                <span style={{ fontSize: s(13), color: "color-mix(in srgb, var(--text-primary) 87%, transparent)" }}>
                   {t("settings.muteCompletionChime")}
                 </span>
               </label>
@@ -1031,7 +1151,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                   fontFamily: "'JetBrains Mono', monospace",
                   fontSize: s(10),
                   fontWeight: 600,
-                  color: "rgba(255,255,255,0.25)",
+                  color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
                   letterSpacing: ".12em",
                   textTransform: "uppercase",
                   marginBottom: 20,
@@ -1046,7 +1166,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 <div
                   style={{
                     fontSize: s(13),
-                    color: "rgba(255,255,255,0.8)",
+                    color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                     marginBottom: 2,
                   }}
                 >
@@ -1055,7 +1175,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                 <div
                   style={{
                     fontSize: s(11),
-                    color: "rgba(255,255,255,0.3)",
+                    color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                     marginBottom: 10,
                   }}
                 >
@@ -1076,10 +1196,10 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     boxSizing: "border-box",
                     height: 32,
                     padding: "0 10px",
-                    background: "rgba(255,255,255,0.04)",
-                    border: "1px solid rgba(255,255,255,0.08)",
+                    background: "var(--control-bg)",
+                    border: "1px solid var(--control-border)",
                     borderRadius: 7,
-                    color: "rgba(255,255,255,0.9)",
+                    color: "var(--text-primary)",
                     fontFamily: "'JetBrains Mono', monospace",
                     fontSize: s(12),
                     outline: "none",
@@ -1101,7 +1221,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     <div
                       style={{
                         fontSize: s(13),
-                        color: "rgba(255,255,255,0.8)",
+                        color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
                         marginBottom: 2,
                       }}
                     >
@@ -1110,7 +1230,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                     <div
                       style={{
                         fontSize: s(11),
-                        color: "rgba(255,255,255,0.3)",
+                        color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                       }}
                     >
                       {t("settings.autoCoauthorDescription")}
@@ -1126,8 +1246,8 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                       width: 38,
                       height: 22,
                       borderRadius: 999,
-                      border: "1px solid rgba(255,255,255,0.12)",
-                      background: coauthorEnabled ? "rgba(180,220,255,0.35)" : "rgba(255,255,255,0.06)",
+                      border: "1px solid var(--control-border)",
+                      background: coauthorEnabled ? "rgba(180,220,255,0.35)" : "var(--control-bg)",
                       position: "relative",
                       cursor: "pointer",
                       padding: 0,
@@ -1142,7 +1262,7 @@ export default function Settings({ wallpaper, onWallpaperChange, fontSize, onFon
                         width: 16,
                         height: 16,
                         borderRadius: "50%",
-                        background: "rgba(255,255,255,0.9)",
+                        background: "var(--text-primary)",
                         transition: "left 120ms ease",
                       }}
                     />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -339,12 +339,12 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             display: "flex", alignItems: "center", gap: 10,
             padding: "8px 10px", borderRadius: 7,
             background: "none", border: "none", cursor: "pointer",
-            color: "rgba(255,255,255,0.55)", fontSize: s(12),
+            color: "color-mix(in srgb, var(--text-primary) 60%, transparent)", fontSize: s(12),
             fontFamily: "system-ui, sans-serif", transition: "all .15s",
             textAlign: "left",
           }}
-          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "rgba(255,255,255,0.8)"; }}
-          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "rgba(255,255,255,0.55)"; }}
+          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 87%, transparent)"; }}
+          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 60%, transparent)"; }}
         >
           <Plus size={15} strokeWidth={1.5} />
           {t("sidebar.newChat")}
@@ -355,12 +355,12 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             display: "flex", alignItems: "center", gap: 10,
             padding: "8px 10px", borderRadius: 7,
             background: "none", border: "none", cursor: "pointer",
-            color: "rgba(255,255,255,0.55)", fontSize: s(12),
+            color: "color-mix(in srgb, var(--text-primary) 60%, transparent)", fontSize: s(12),
             fontFamily: "system-ui, sans-serif", transition: "all .15s",
             textAlign: "left",
           }}
-          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "rgba(255,255,255,0.8)"; }}
-          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "rgba(255,255,255,0.55)"; }}
+          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 87%, transparent)"; }}
+          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 60%, transparent)"; }}
         >
           <Workflow size={15} strokeWidth={1.5} />
           {t("sidebar.dispatch")}
@@ -371,12 +371,12 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             display: "flex", alignItems: "center", gap: 10,
             padding: "8px 10px", borderRadius: 7,
             background: "none", border: "none", cursor: "pointer",
-            color: "rgba(255,255,255,0.55)", fontSize: s(12),
+            color: "color-mix(in srgb, var(--text-primary) 60%, transparent)", fontSize: s(12),
             fontFamily: "system-ui, sans-serif", transition: "all .15s",
             textAlign: "left",
           }}
-          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "rgba(255,255,255,0.8)"; }}
-          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "rgba(255,255,255,0.55)"; }}
+          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 87%, transparent)"; }}
+          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 60%, transparent)"; }}
         >
           <FolderPlus size={15} strokeWidth={1.5} />
           {t("sidebar.newProject")}
@@ -388,12 +388,12 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
               display: "flex", alignItems: "center", gap: 10,
               padding: "8px 10px", borderRadius: 7,
               background: "none", border: "none", cursor: "pointer",
-              color: "rgba(255,255,255,0.55)", fontSize: s(12),
+              color: "color-mix(in srgb, var(--text-primary) 60%, transparent)", fontSize: s(12),
               fontFamily: "system-ui, sans-serif", transition: "all .15s",
               textAlign: "left",
             }}
-            onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "rgba(255,255,255,0.8)"; }}
-            onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "rgba(255,255,255,0.55)"; }}
+            onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 87%, transparent)"; }}
+            onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 60%, transparent)"; }}
           >
             <GitHubIcon size={15} />
             {t("sidebar.githubProjects")}
@@ -405,12 +405,12 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             display: "flex", alignItems: "center", gap: 10,
             padding: "8px 10px", borderRadius: 7,
             background: "none", border: "none", cursor: "pointer",
-            color: "rgba(255,255,255,0.55)", fontSize: s(12),
+            color: "color-mix(in srgb, var(--text-primary) 60%, transparent)", fontSize: s(12),
             fontFamily: "system-ui, sans-serif", transition: "all .15s",
             textAlign: "left",
           }}
-          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "rgba(255,255,255,0.8)"; }}
-          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "rgba(255,255,255,0.55)"; }}
+          onMouseEnter={(e) => { applyPaneInteractionStyle(e.currentTarget, "hover"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 87%, transparent)"; }}
+          onMouseLeave={(e) => { applyPaneInteractionStyle(e.currentTarget, "idle"); e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 60%, transparent)"; }}
         >
           <Search size={15} strokeWidth={1.5} />
           {t("sidebar.search")}
@@ -422,7 +422,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             gap: 7,
             marginTop: 6,
             padding: "6px 10px",
-            border: "1px solid " + (searchFocused ? "rgba(255,255,255,0.12)" : "var(--pane-border)"),
+            border: "1px solid " + (searchFocused ? "var(--control-border)" : "var(--pane-border)"),
             borderRadius: 8,
             transition: "background .2s, color .2s, border-color .2s, box-shadow .2s, backdrop-filter .2s",
             ...(searchFocused ? getPaneInteractionStyle("active") : {
@@ -432,7 +432,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             }),
           }}
         >
-          <span style={{ color: "rgba(255,255,255,0.45)", flexShrink: 0, display: "flex" }}>
+          <span style={{ color: "color-mix(in srgb, var(--text-primary) 49%, transparent)", flexShrink: 0, display: "flex" }}>
             <Search size={13} strokeWidth={1.5} />
           </span>
           <input
@@ -447,7 +447,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
               flex: 1,
               background: "transparent",
               border: "none",
-              color: "rgba(255,255,255,0.8)",
+              color: "color-mix(in srgb, var(--text-primary) 87%, transparent)",
               fontSize: s(11),
               fontFamily: "'JetBrains Mono',monospace",
             }}
@@ -471,14 +471,14 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             <div style={{
               fontSize: s(11),
               fontFamily: "'JetBrains Mono',monospace",
-              color: "rgba(255,255,255,0.15)",
+              color: "color-mix(in srgb, var(--text-primary) 16%, transparent)",
               letterSpacing: ".08em",
             }}>
               {t("sidebar.noConversations")}
             </div>
             <div style={{
               fontSize: s(10),
-              color: "rgba(255,255,255,0.1)",
+              color: "color-mix(in srgb, var(--text-primary) 11%, transparent)",
               fontFamily: "system-ui,sans-serif",
             }}>
               {t("sidebar.noConversationsHint")}
@@ -533,7 +533,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  color: "rgba(255,255,255,0.25)",
+                  color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
                   transform: `rotate(${(searchActive || !draftsCollapsed) ? 90 : 0}deg)`,
                   transition: "transform .15s",
                   flexShrink: 0,
@@ -545,7 +545,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                 style={{
                   fontSize: s(11),
                   fontFamily: "'JetBrains Mono', monospace",
-                  color: "rgba(255,255,255,0.4)",
+                  color: "color-mix(in srgb, var(--text-primary) 43%, transparent)",
                   letterSpacing: ".04em",
                 }}
               >
@@ -576,14 +576,14 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                       justifyContent: "center",
                       background: "none",
                       border: "none",
-                      color: "rgba(255,255,255,0.25)",
+                      color: "color-mix(in srgb, var(--text-primary) 27%, transparent)",
                       cursor: "pointer",
                       padding: 3,
                       borderRadius: 4,
                       transition: "color .15s",
                     }}
-                    onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.65)"; }}
-                    onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.25)"; }}
+                    onMouseEnter={(e) => { e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 71%, transparent)"; }}
+                    onMouseLeave={(e) => { e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 27%, transparent)"; }}
                   >
                     <Plus size={11} strokeWidth={1.5} />
                   </button>
@@ -633,7 +633,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                         <span
                           style={{
                             fontSize: s(12.5),
-                            color: isActive ? "rgba(255,255,255,0.9)" : "rgba(255,255,255,0.45)",
+                            color: isActive ? "var(--text-primary)" : "color-mix(in srgb, var(--text-primary) 49%, transparent)",
                             overflow: "hidden",
                             textOverflow: "ellipsis",
                             whiteSpace: "nowrap",
@@ -655,7 +655,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                       <div
                         style={{
                           fontSize: s(11),
-                          color: "rgba(255,255,255,0.3)",
+                          color: "color-mix(in srgb, var(--text-primary) 33%, transparent)",
                           overflow: "hidden",
                           textOverflow: "ellipsis",
                           whiteSpace: "nowrap",
@@ -670,9 +670,9 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                     <div className="convo-actions" style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 4, flexShrink: 0, opacity: 0, transition: "opacity .15s" }}>
                       <button
                         onClick={(e) => onDelete(c.id, e)}
-                        style={{ background: "none", border: "none", color: "rgba(255,255,255,0.25)", cursor: "pointer", padding: 1, transition: "color .15s", display: "flex" }}
+                        style={{ background: "none", border: "none", color: "color-mix(in srgb, var(--text-primary) 27%, transparent)", cursor: "pointer", padding: 1, transition: "color .15s", display: "flex" }}
                         onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(200,80,80,0.5)"; }}
-                        onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.25)"; }}
+                        onMouseLeave={(e) => { e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 27%, transparent)"; }}
                       >
                         <Trash2 size={12} strokeWidth={1.5} />
                       </button>
@@ -692,7 +692,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
                       style={{
                         fontSize: s(9),
                         fontFamily: "'JetBrains Mono',monospace",
-                        color: "rgba(255,255,255,0.35)",
+                        color: "color-mix(in srgb, var(--text-primary) 38%, transparent)",
                         letterSpacing: ".08em",
                         minWidth: 0,
                       }}
@@ -737,7 +737,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
       <div
         style={{
           padding: "12px 20px",
-          borderTop: "1px solid rgba(255,255,255,0.02)",
+          borderTop: "1px solid var(--control-border)",
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
@@ -754,13 +754,13 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             cursor: "pointer",
             fontSize: s(8),
             fontFamily: "'JetBrains Mono',monospace",
-            color: "rgba(255,255,255,0.45)",
+            color: "color-mix(in srgb, var(--text-primary) 49%, transparent)",
             letterSpacing: ".08em",
             padding: 0,
             transition: "color .2s",
           }}
-          onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.72)"; }}
-          onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.45)"; }}
+          onMouseEnter={(e) => { e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 78%, transparent)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 49%, transparent)"; }}
         >
           <FolderOpen size={10} strokeWidth={1.5} />
           {cwdShort || t("sidebar.selectFolder")}
@@ -779,12 +779,12 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
               background: "none",
               border: "none",
               cursor: "pointer",
-              color: "rgba(255,255,255,0.45)",
+              color: "color-mix(in srgb, var(--text-primary) 45%, transparent)",
               transition: "color .2s",
               padding: 0,
             }}
-            onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.72)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.45)"; }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 72%, transparent)"; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = "color-mix(in srgb, var(--text-primary) 45%, transparent)"; }}
           >
             <SettingsIcon size={12} strokeWidth={1.5} />
             {hasUpdate && (
@@ -802,7 +802,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
             )}
           </button>
         )}
-        <span style={{ fontSize: s(8), fontFamily: "'JetBrains Mono',monospace", color: "rgba(255,255,255,0.38)", letterSpacing: ".06em" }}>
+        <span style={{ fontSize: s(8), fontFamily: "'JetBrains Mono',monospace", color: "color-mix(in srgb, var(--text-primary) 41%, transparent)", letterSpacing: ".06em" }}>
           {t("sidebar.chatsCount", { value: convos.length })}
         </span>
       </div>

--- a/src/components/SidebarChromeRail.jsx
+++ b/src/components/SidebarChromeRail.jsx
@@ -31,11 +31,11 @@ function RailButton({ label, onClick, active = false, visible = true, children }
         border: "none",
         borderRadius: 7,
         background: active
-          ? "rgba(255,255,255,0.055)"
+          ? "var(--control-bg)"
           : hovered
-            ? "rgba(255,255,255,0.07)"
+            ? "var(--control-bg)"
             : "transparent",
-        color: hovered || active ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.42)",
+        color: hovered || active ? "color-mix(in srgb, var(--text-primary) 89%, transparent)" : "color-mix(in srgb, var(--text-primary) 46%, transparent)",
         cursor: "pointer",
         padding: 0,
         opacity: visible ? 1 : 0,

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,10 @@
   --pane-interaction-hover-shadow: none;
   --pane-interaction-active-shadow: none;
   --pane-border: rgba(255,255,255,0.06);
+  --text-primary: rgba(255,255,255,0.92);
+  --control-bg: rgba(255,255,255,0.04);
+  --control-border: rgba(255,255,255,0.08);
+  --app-background: #0D0D10;
 }
 
 *, *::before, *::after {

--- a/src/index.css
+++ b/src/index.css
@@ -20,8 +20,34 @@
   --pane-border: rgba(255,255,255,0.06);
   --text-primary: rgba(255,255,255,0.92);
   --control-bg: rgba(255,255,255,0.04);
+  --control-bg-hover: rgba(255,255,255,0.10);
   --control-border: rgba(255,255,255,0.08);
   --app-background: #0D0D10;
+}
+
+[data-theme="light"] {
+  --pane-background: #F5F5F7;
+  --pane-background-rgb: 245, 245, 247;
+  --pane-overlay-alpha: 0.90;
+  --pane-background-overlay: rgba(var(--pane-background-rgb), var(--pane-overlay-alpha));
+  --pane-hover-overlay: rgba(230, 230, 235, var(--pane-overlay-alpha));
+  --pane-active-overlay: rgba(220, 220, 228, var(--pane-overlay-alpha));
+  --pane-elevated-rgb: 235, 235, 240;
+  --pane-elevated: rgba(var(--pane-elevated-rgb), 0.7);
+  --pane-hover: #EAEAEF;
+  --pane-active: #E2E2E8;
+  --pane-interaction-hover-fill: var(--pane-hover);
+  --pane-interaction-active-fill: var(--pane-active);
+  --pane-interaction-hover-filter: none;
+  --pane-interaction-active-filter: none;
+  --pane-interaction-hover-shadow: none;
+  --pane-interaction-active-shadow: none;
+  --pane-border: rgba(0,0,0,0.06);
+  --text-primary: rgba(0,0,0,0.88);
+  --control-bg: rgba(0,0,0,0.04);
+  --control-bg-hover: rgba(0,0,0,0.10);
+  --control-border: rgba(0,0,0,0.12);
+  --app-background: #F5F5F7;
 }
 
 *, *::before, *::after {


### PR DESCRIPTION
## Summary
WS-A：Settings + Sidebar 组件 var 化。移除硬编码颜色，接入 WS-0 的 CSS tokens，light/dark 无缝切换。

## Changes
- `src/components/Settings.jsx`：190 行重排，颜色全改 `var(--*)`
- `src/components/Sidebar.jsx`：70 行改造，hover/active 态走 token
- `src/components/SidebarChromeRail.jsx`：6 行细节
- `src/index.css`：+4 行补充缺失的 token

**4 files, +137/-133**

## Depends on
- WS-0 (`theme/ws0-foundation`)：必须先合入

## Test plan
- [ ] Settings 面板 light/dark 切换无"顽固黑块"
- [ ] Sidebar 选中/hover 色跟随主题
- [ ] 无 JSX 结构变更，仅颜色/类名替换
