### PR TITLE
feat(theme): WS-G xterm+Aurora+iframe 子系统 light 分支

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,5 @@
+PR #185 WS-G xterm+Aurora+iframe。GPT-5.5 提：23 var 未定 + xterm 主题切换重建丢状态 + iframe stale。**任务**：
+1. 补 23 个 var（src/index.css 双侧）
+2. xterm 主题切换：不要 dispose+new Terminal()，改为 term.options.theme = newTheme; term.refresh(0, term.rows-1)
+3. iframe：监听 ThemeContext 变化，postMessage 给 iframe 让它自己刷 data-theme，不要 reload
+git add . && git commit -m 'fix(theme): WS-G 补 23 var + xterm/iframe 平滑切换' && git push fork pf-ws-g-subsystems:theme/ws-g-subsystems

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import { FontSizeContext } from "./contexts/FontSizeContext";
 import { getPaneSurfaceStyle } from "./utils/paneSurface";
 import { DEFAULT_WALLPAPER, getPersistedWallpaper, getWallpaperImageFilter, normalizeWallpaper } from "./utils/wallpaper";
 import { detectDefaultLocale, normalizeLocale } from "./i18n";
+import { ThemeProvider } from "./contexts/ThemeContext";
 import {
   pinTabPatch,
   runEndedPatch,
@@ -3388,6 +3389,7 @@ export default function App() {
     : "width .34s cubic-bezier(.16,1,.3,1), min-width .34s cubic-bezier(.16,1,.3,1), border-color .18s ease";
 
   return (
+    <ThemeProvider>
     <FontSizeContext.Provider value={fontSize}>
     <div style={{ display: "flex", height: "100vh", width: "100vw", overflow: "hidden", position: "relative" }}>
       {wallpaper?.dataUrl ? (
@@ -3601,5 +3603,6 @@ export default function App() {
       </div>
     </div>
     </FontSizeContext.Provider>
+    </ThemeProvider>
   );
 }

--- a/src/components/AuroraCanvas.jsx
+++ b/src/components/AuroraCanvas.jsx
@@ -6,10 +6,23 @@ const FOCUSED_FRAME_MS = 1000 / 60;
 const BACKGROUND_FRAME_MS = 1000 / 12;
 const REDUCED_MOTION_FRAME_MS = 1000 / 8;
 
+function readRootCssVar(name, fallback) {
+  if (typeof document === "undefined") return fallback;
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
+function getAuroraStops() {
+  return {
+    bg: readRootCssVar("--aurora-bg", "#0D0D0F"),
+    glow: readRootCssVar("--aurora-glow", "rgba(255,255,255,0.018)"),
+  };
+}
+
 export default function AuroraCanvas() {
   const ref = useRef(null);
   const tRef = useRef(0);
   const lastFrameAtRef = useRef(0);
+  const stopsRef = useRef(getAuroraStops());
   const { isVisible, isFocused, prefersReducedMotion } = useWindowActivity();
 
   useEffect(() => {
@@ -34,7 +47,8 @@ export default function AuroraCanvas() {
     resize();
 
     const renderFrame = () => {
-      ctx.fillStyle = "#0D0D0F";
+      const stops = stopsRef.current;
+      ctx.fillStyle = stops.bg;
       ctx.fillRect(0, 0, w, h);
 
       // Compute orb positions
@@ -53,7 +67,7 @@ export default function AuroraCanvas() {
       for (var gi = 0; gi < orbPositions.length; gi++) {
         var gp = orbPositions[gi];
         var grad = ctx.createRadialGradient(gp.x, gp.y, 0, gp.x, gp.y, gp.r * 0.7);
-        grad.addColorStop(0, "rgba(255,255,255,0.018)");
+        grad.addColorStop(0, stops.glow);
         grad.addColorStop(1, "transparent");
         ctx.fillStyle = grad;
         ctx.beginPath();
@@ -86,10 +100,16 @@ export default function AuroraCanvas() {
     if (isVisible) {
       raf = requestAnimationFrame(draw);
     }
+    const handleThemeChange = () => {
+      stopsRef.current = getAuroraStops();
+      renderFrame();
+    };
     window.addEventListener("resize", resize);
+    window.addEventListener("rayline:theme-change", handleThemeChange);
     return () => {
       if (raf != null) cancelAnimationFrame(raf);
       window.removeEventListener("resize", resize);
+      window.removeEventListener("rayline:theme-change", handleThemeChange);
     };
   }, [isFocused, isVisible, prefersReducedMotion]);
 

--- a/src/components/InteractiveBlock.jsx
+++ b/src/components/InteractiveBlock.jsx
@@ -1,73 +1,24 @@
-import { useRef, useEffect, useState } from "react";
+import { useCallback, useRef, useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
-
-function getResolvedThemeMode(detail) {
-  const candidate = detail?.resolved || detail?.mode || detail?.theme;
-  if (candidate === "light" || candidate === "dark") return candidate;
-
-  if (typeof document !== "undefined") {
-    const root = document.documentElement;
-    if (root.dataset.theme === "light" || root.dataset.theme === "dark") {
-      return root.dataset.theme;
-    }
-    if (root.classList.contains("light")) return "light";
-  }
-
-  return "dark";
-}
+import { useResolvedThemeMode } from "../contexts/ThemeContext";
 
 export default function InteractiveBlock({ code, isStreaming }) {
   const s = useFontScale();
-  const [resolvedMode] = useState(() => getResolvedThemeMode());
-
-  // While streaming, show a generating placeholder
-  if (isStreaming) {
-    return (
-      <div style={{
-        margin: "12px 0",
-        borderRadius: 10,
-        border: "1px solid rgba(255,255,255,0.06)",
-        background: "#0a0a0a",
-        padding: "24px",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 10,
-        minHeight: 120,
-      }}>
-        <Loader2
-          size={16}
-          strokeWidth={1.5}
-          style={{
-            color: "rgba(255,255,255,0.2)",
-            animation: "spin 1s linear infinite",
-          }}
-        />
-        <span style={{
-          fontSize: s(9),
-          fontFamily: "'JetBrains Mono',monospace",
-          color: "rgba(255,255,255,0.2)",
-          letterSpacing: ".1em",
-        }}>
-          GENERATING VISUALIZATION
-        </span>
-      </div>
-    );
-  }
-
-  // Wrap user code in a full HTML document with theme defaults + auto-resize
-  const srcdoc = `<!DOCTYPE html>
-<html data-theme="${resolvedMode}">
+  const resolvedMode = useResolvedThemeMode();
+  const initialResolvedModeRef = useRef(resolvedMode);
+  const srcdoc = useMemo(() => {
+    const initialResolvedMode = initialResolvedModeRef.current;
+    return `<!DOCTYPE html>
+<html data-theme="${initialResolvedMode}">
 <head>
 <meta charset="utf-8">
 <style>
   :root {
-    color-scheme: ${resolvedMode};
-    --bg: ${resolvedMode === "light" ? "#ffffff" : "#0a0a0a"};
-    --fg: ${resolvedMode === "light" ? "rgba(15,23,42,0.78)" : "rgba(255,255,255,0.75)"};
-    --line: ${resolvedMode === "light" ? "rgba(15,23,42,0.18)" : "rgba(255,255,255,0.15)"};
+    color-scheme: ${initialResolvedMode};
+    --bg: ${initialResolvedMode === "light" ? "#ffffff" : "#0a0a0a"};
+    --fg: ${initialResolvedMode === "light" ? "rgba(15,23,42,0.78)" : "rgba(255,255,255,0.75)"};
+    --line: ${initialResolvedMode === "light" ? "rgba(15,23,42,0.18)" : "rgba(255,255,255,0.15)"};
   }
   :root[data-theme="light"] {
     color-scheme: light;
@@ -119,6 +70,43 @@ ${code}
 </script>
 </body>
 </html>`;
+  }, [code]);
+
+  // While streaming, show a generating placeholder
+  if (isStreaming) {
+    return (
+      <div style={{
+        margin: "12px 0",
+        borderRadius: 10,
+        border: "1px solid rgba(255,255,255,0.06)",
+        background: "#0a0a0a",
+        padding: "24px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10,
+        minHeight: 120,
+      }}>
+        <Loader2
+          size={16}
+          strokeWidth={1.5}
+          style={{
+            color: "rgba(255,255,255,0.2)",
+            animation: "spin 1s linear infinite",
+          }}
+        />
+        <span style={{
+          fontSize: s(9),
+          fontFamily: "'JetBrains Mono',monospace",
+          color: "rgba(255,255,255,0.2)",
+          letterSpacing: ".1em",
+        }}>
+          GENERATING VISUALIZATION
+        </span>
+      </div>
+    );
+  }
 
   return (
     <div style={{
@@ -138,15 +126,18 @@ ${code}
       }}>
         INTERACTIVE
       </div>
-      <IframeRenderer srcdoc={srcdoc} />
+      <IframeRenderer srcdoc={srcdoc} resolvedMode={resolvedMode} />
     </div>
   );
 }
 
 // Separate component so iframe doesn't re-mount on every parent render
-function IframeRenderer({ srcdoc }) {
+function IframeRenderer({ srcdoc, resolvedMode }) {
   const iframeRef = useRef(null);
   const [height, setHeight] = useState(300);
+  const postTheme = useCallback(() => {
+    iframeRef.current?.contentWindow?.postMessage({ type: "rayline:theme", resolved: resolvedMode }, "*");
+  }, [resolvedMode]);
 
   useEffect(() => {
     const handler = (e) => {
@@ -159,19 +150,14 @@ function IframeRenderer({ srcdoc }) {
   }, []);
 
   useEffect(() => {
-    const handleThemeChange = (event) => {
-      const resolved = getResolvedThemeMode(event.detail);
-      iframeRef.current?.contentWindow?.postMessage({ type: "rayline:theme", resolved }, "*");
-    };
-
-    window.addEventListener("rayline:theme-change", handleThemeChange);
-    return () => window.removeEventListener("rayline:theme-change", handleThemeChange);
-  }, []);
+    postTheme();
+  }, [postTheme]);
 
   return (
     <iframe
       ref={iframeRef}
       srcDoc={srcdoc}
+      onLoad={postTheme}
       style={{
         width: "100%",
         height,

--- a/src/components/InteractiveBlock.jsx
+++ b/src/components/InteractiveBlock.jsx
@@ -2,11 +2,24 @@ import { useRef, useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
 
+function getResolvedThemeMode(detail) {
+  const candidate = detail?.resolved || detail?.mode || detail?.theme;
+  if (candidate === "light" || candidate === "dark") return candidate;
+
+  if (typeof document !== "undefined") {
+    const root = document.documentElement;
+    if (root.dataset.theme === "light" || root.dataset.theme === "dark") {
+      return root.dataset.theme;
+    }
+    if (root.classList.contains("light")) return "light";
+  }
+
+  return "dark";
+}
+
 export default function InteractiveBlock({ code, isStreaming }) {
   const s = useFontScale();
-  const iframeRef = useRef(null);
-  const [height, setHeight] = useState(300);
-  const [loaded, setLoaded] = useState(false);
+  const [resolvedMode] = useState(() => getResolvedThemeMode());
 
   // While streaming, show a generating placeholder
   if (isStreaming) {
@@ -44,28 +57,57 @@ export default function InteractiveBlock({ code, isStreaming }) {
     );
   }
 
-  // Wrap user code in a full HTML document with dark theme defaults + auto-resize
+  // Wrap user code in a full HTML document with theme defaults + auto-resize
   const srcdoc = `<!DOCTYPE html>
-<html>
+<html data-theme="${resolvedMode}">
 <head>
 <meta charset="utf-8">
 <style>
+  :root {
+    color-scheme: ${resolvedMode};
+    --bg: ${resolvedMode === "light" ? "#ffffff" : "#0a0a0a"};
+    --fg: ${resolvedMode === "light" ? "rgba(15,23,42,0.78)" : "rgba(255,255,255,0.75)"};
+    --line: ${resolvedMode === "light" ? "rgba(15,23,42,0.18)" : "rgba(255,255,255,0.15)"};
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --bg: #ffffff;
+    --fg: rgba(15,23,42,0.78);
+    --line: rgba(15,23,42,0.18);
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --bg: #0a0a0a;
+    --fg: rgba(255,255,255,0.75);
+    --line: rgba(255,255,255,0.15);
+  }
   *, *::before, *::after { box-sizing: border-box; }
   html, body {
     margin: 0; padding: 12px;
-    background: #0a0a0a;
-    color: rgba(255,255,255,0.75);
+    background: var(--bg);
+    color: var(--fg);
     font-family: system-ui, -apple-system, sans-serif;
     font-size: 14px;
     overflow: hidden;
   }
-  svg text { fill: rgba(255,255,255,0.75); }
-  svg line, svg path { stroke: rgba(255,255,255,0.15); }
+  svg text { fill: var(--fg); }
+  svg line, svg path { stroke: var(--line); }
 </style>
 </head>
 <body>
 ${code}
 <script>
+  function applyTheme(resolved) {
+    if (resolved !== 'light' && resolved !== 'dark') return;
+    document.documentElement.dataset.theme = resolved;
+    postHeight();
+  }
+  window.addEventListener('message', (event) => {
+    if (event.data?.type === 'rayline:theme') {
+      applyTheme(event.data.resolved);
+    }
+  });
+
   // Auto-resize: post height to parent
   function postHeight() {
     const h = Math.max(document.body.scrollHeight, document.body.offsetHeight, 60);
@@ -114,6 +156,16 @@ function IframeRenderer({ srcdoc }) {
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
+  }, []);
+
+  useEffect(() => {
+    const handleThemeChange = (event) => {
+      const resolved = getResolvedThemeMode(event.detail);
+      iframeRef.current?.contentWindow?.postMessage({ type: "rayline:theme", resolved }, "*");
+    };
+
+    window.addEventListener("rayline:theme-change", handleThemeChange);
+    return () => window.removeEventListener("rayline:theme-change", handleThemeChange);
   }, []);
 
   return (

--- a/src/components/TerminalDrawer.jsx
+++ b/src/components/TerminalDrawer.jsx
@@ -31,31 +31,78 @@ function getTerminalWallpaperOverlayAlpha(wallpaper) {
   return 0.52 + getWallpaperOpacityValue(wallpaper) * 0.18;
 }
 
-function getTerminalTheme(opaqueBackground) {
+function getResolvedThemeMode(detail) {
+  const candidate = detail?.resolved || detail?.mode || detail?.theme;
+  if (candidate === "light" || candidate === "dark") return candidate;
+
+  if (typeof document !== "undefined") {
+    const root = document.documentElement;
+    if (root.dataset.theme === "light" || root.dataset.theme === "dark") {
+      return root.dataset.theme;
+    }
+    if (root.classList.contains("light")) return "light";
+  }
+
+  return "dark";
+}
+
+function readRootCssVar(name, fallback) {
+  if (typeof document === "undefined") return fallback;
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
+function getTerminalTheme(opaqueBackground, mode = "dark") {
+  const background = mode === "light" ? "#f8fafc" : TERMINAL_OPAQUE_BG;
+  const foreground = mode === "light" ? "rgba(15,23,42,0.88)" : "rgba(244,247,250,0.88)";
+  const cursor = mode === "light" ? "rgba(15,23,42,0.96)" : "rgba(245,247,251,0.98)";
+  const selectionBackground = mode === "light" ? "rgba(37,99,235,0.18)" : "rgba(120,182,255,0.18)";
+  const selectionInactiveBackground = mode === "light" ? "rgba(37,99,235,0.1)" : "rgba(120,182,255,0.1)";
+
   return {
-    background: opaqueBackground ? TERMINAL_OPAQUE_BG : XTERM_TRANSPARENT,
-    foreground: "rgba(244,247,250,0.88)",
-    cursor: "rgba(245,247,251,0.98)",
-    cursorAccent: opaqueBackground ? TERMINAL_OPAQUE_BG : XTERM_TRANSPARENT,
-    selectionBackground: "rgba(120,182,255,0.18)",
-    selectionInactiveBackground: "rgba(120,182,255,0.1)",
-    black: "#0f1116",
-    red: "#f38ba8",
-    green: "#7ed7b9",
-    yellow: "#f5c97a",
-    blue: "#89b4fa",
-    magenta: "#cba6f7",
-    cyan: "#74c7ec",
-    white: "#bac2de",
-    brightBlack: "#585b70",
-    brightRed: "#f7a6bc",
-    brightGreen: "#9ce8cf",
-    brightYellow: "#f8d99c",
-    brightBlue: "#a6c9ff",
-    brightMagenta: "#d9b8fb",
-    brightCyan: "#98dbf3",
-    brightWhite: "#f5f7fb",
+    background: opaqueBackground ? readRootCssVar("--term-background", background) : XTERM_TRANSPARENT,
+    foreground: readRootCssVar("--term-foreground", foreground),
+    cursor: readRootCssVar("--term-cursor", cursor),
+    cursorAccent: opaqueBackground ? readRootCssVar("--term-background", background) : XTERM_TRANSPARENT,
+    selectionBackground: readRootCssVar("--term-selection-background", selectionBackground),
+    selectionInactiveBackground: readRootCssVar("--term-selection-inactive-background", selectionInactiveBackground),
+    black: readRootCssVar("--term-black", "#0f1116"),
+    red: readRootCssVar("--term-red", "#f38ba8"),
+    green: readRootCssVar("--term-green", "#7ed7b9"),
+    yellow: readRootCssVar("--term-yellow", "#f5c97a"),
+    blue: readRootCssVar("--term-blue", "#89b4fa"),
+    magenta: readRootCssVar("--term-magenta", "#cba6f7"),
+    cyan: readRootCssVar("--term-cyan", "#74c7ec"),
+    white: readRootCssVar("--term-white", "#bac2de"),
+    brightBlack: readRootCssVar("--term-bright-black", "#585b70"),
+    brightRed: readRootCssVar("--term-bright-red", "#f7a6bc"),
+    brightGreen: readRootCssVar("--term-bright-green", "#9ce8cf"),
+    brightYellow: readRootCssVar("--term-bright-yellow", "#f8d99c"),
+    brightBlue: readRootCssVar("--term-bright-blue", "#a6c9ff"),
+    brightMagenta: readRootCssVar("--term-bright-magenta", "#d9b8fb"),
+    brightCyan: readRootCssVar("--term-bright-cyan", "#98dbf3"),
+    brightWhite: readRootCssVar("--term-bright-white", "#f5f7fb"),
   };
+}
+
+function serializeTerminalBuffer(term) {
+  const serializeAddon = term?.__raylineSerializeAddon;
+  if (serializeAddon?.serialize) {
+    try {
+      return serializeAddon.serialize();
+    } catch {
+      // Fall through to the public buffer API fallback.
+    }
+  }
+
+  const buffer = term?.buffer?.active;
+  if (!buffer?.getLine || !Number.isFinite(buffer.length)) return "";
+
+  const lines = [];
+  for (let row = 0; row < buffer.length; row += 1) {
+    const line = buffer.getLine(row);
+    lines.push(line?.translateToString(true) ?? "");
+  }
+  return lines.join("\r\n");
 }
 
 function emitTerminalDebug(event, details = {}) {
@@ -425,6 +472,9 @@ function SessionTerminal({
   const fitTimersRef = useRef([]);
   const lastSyncedPtySizeRef = useRef("");
   const mouseGestureRef = useRef(null);
+  const themeModeRef = useRef(getResolvedThemeMode());
+  const pendingScrollbackRef = useRef("");
+  const [themeRevision, setThemeRevision] = useState(0);
 
   // Stable refs so the async IIFE captures up-to-date callbacks without
   // restarting the effect every time parent re-renders.
@@ -438,6 +488,17 @@ function SessionTerminal({
   useEffect(() => { registerRef.current = registerTerminal; }, [registerTerminal]);
   useEffect(() => { unregRef.current = unregisterTerminal; }, [unregisterTerminal]);
   useEffect(() => { activeRef.current = isActive; }, [isActive]);
+
+  useEffect(() => {
+    const handleThemeChange = (event) => {
+      themeModeRef.current = getResolvedThemeMode(event.detail);
+      pendingScrollbackRef.current = serializeTerminalBuffer(termRef.current);
+      setThemeRevision((revision) => revision + 1);
+    };
+
+    window.addEventListener("rayline:theme-change", handleThemeChange);
+    return () => window.removeEventListener("rayline:theme-change", handleThemeChange);
+  }, []);
 
   const teardown = useCallback(() => {
     fitTimersRef.current.forEach((timer) => window.clearTimeout(timer));
@@ -480,7 +541,7 @@ function SessionTerminal({
       containerRef.current.appendChild(el);
 
       const term = new Terminal({
-        theme: getTerminalTheme(opaqueBackground),
+        theme: getTerminalTheme(opaqueBackground, themeModeRef.current),
         fontFamily: FONT_FAMILY,
         fontSize: 13,
         fontWeight: "400",
@@ -719,7 +780,11 @@ function SessionTerminal({
 
       registerRef.current(sessionName, term);
 
-      if (window.api?.terminalRead) {
+      const pendingScrollback = pendingScrollbackRef.current;
+      pendingScrollbackRef.current = "";
+      if (pendingScrollback) {
+        term.write(pendingScrollback);
+      } else if (window.api?.terminalRead) {
         try {
           const result = await window.api.terminalRead({ name: sessionName, lines: 500 });
           if (!cancelled && result?.ok && result.lines?.length) {
@@ -773,7 +838,7 @@ function SessionTerminal({
       emitTerminalDebug("session:teardown", { sessionName });
       teardown();
     };
-  }, [opaqueBackground, plainClickMovesCursor, promptSelectionEditing, promptUndoShortcut, sessionName, teardown]);
+  }, [opaqueBackground, plainClickMovesCursor, promptSelectionEditing, promptUndoShortcut, sessionName, teardown, themeRevision]);
 
   useEffect(() => {
     const logActiveState = (phase) => {

--- a/src/components/TerminalDrawer.jsx
+++ b/src/components/TerminalDrawer.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { X, Plus, Terminal as TerminalIcon } from "lucide-react";
 import { useFontScale } from "../contexts/FontSizeContext";
+import { getResolvedThemeMode } from "../contexts/ThemeContext";
 import { getPaneSurfaceStyle } from "../utils/paneSurface";
 import { getWallpaperImageFilter } from "../utils/wallpaper";
 import { MAC_TRAFFIC_LIGHT_SAFE_WIDTH, WINDOW_DRAG_HEIGHT } from "../windowChrome";
@@ -29,21 +30,6 @@ function getWallpaperOpacityValue(wallpaper) {
 
 function getTerminalWallpaperOverlayAlpha(wallpaper) {
   return 0.52 + getWallpaperOpacityValue(wallpaper) * 0.18;
-}
-
-function getResolvedThemeMode(detail) {
-  const candidate = detail?.resolved || detail?.mode || detail?.theme;
-  if (candidate === "light" || candidate === "dark") return candidate;
-
-  if (typeof document !== "undefined") {
-    const root = document.documentElement;
-    if (root.dataset.theme === "light" || root.dataset.theme === "dark") {
-      return root.dataset.theme;
-    }
-    if (root.classList.contains("light")) return "light";
-  }
-
-  return "dark";
 }
 
 function readRootCssVar(name, fallback) {
@@ -82,27 +68,6 @@ function getTerminalTheme(opaqueBackground, mode = "dark") {
     brightCyan: readRootCssVar("--term-bright-cyan", "#98dbf3"),
     brightWhite: readRootCssVar("--term-bright-white", "#f5f7fb"),
   };
-}
-
-function serializeTerminalBuffer(term) {
-  const serializeAddon = term?.__raylineSerializeAddon;
-  if (serializeAddon?.serialize) {
-    try {
-      return serializeAddon.serialize();
-    } catch {
-      // Fall through to the public buffer API fallback.
-    }
-  }
-
-  const buffer = term?.buffer?.active;
-  if (!buffer?.getLine || !Number.isFinite(buffer.length)) return "";
-
-  const lines = [];
-  for (let row = 0; row < buffer.length; row += 1) {
-    const line = buffer.getLine(row);
-    lines.push(line?.translateToString(true) ?? "");
-  }
-  return lines.join("\r\n");
 }
 
 function emitTerminalDebug(event, details = {}) {
@@ -473,8 +438,6 @@ function SessionTerminal({
   const lastSyncedPtySizeRef = useRef("");
   const mouseGestureRef = useRef(null);
   const themeModeRef = useRef(getResolvedThemeMode());
-  const pendingScrollbackRef = useRef("");
-  const [themeRevision, setThemeRevision] = useState(0);
 
   // Stable refs so the async IIFE captures up-to-date callbacks without
   // restarting the effect every time parent re-renders.
@@ -491,14 +454,17 @@ function SessionTerminal({
 
   useEffect(() => {
     const handleThemeChange = (event) => {
-      themeModeRef.current = getResolvedThemeMode(event.detail);
-      pendingScrollbackRef.current = serializeTerminalBuffer(termRef.current);
-      setThemeRevision((revision) => revision + 1);
+      const nextMode = getResolvedThemeMode(event.detail);
+      themeModeRef.current = nextMode;
+      const term = termRef.current;
+      if (!term) return;
+      term.options.theme = getTerminalTheme(opaqueBackground, nextMode);
+      term.refresh(0, term.rows - 1);
     };
 
     window.addEventListener("rayline:theme-change", handleThemeChange);
     return () => window.removeEventListener("rayline:theme-change", handleThemeChange);
-  }, []);
+  }, [opaqueBackground]);
 
   const teardown = useCallback(() => {
     fitTimersRef.current.forEach((timer) => window.clearTimeout(timer));
@@ -536,7 +502,7 @@ function SessionTerminal({
 
       const el = document.createElement("div");
       el.className = `rayline-terminal-host${opaqueBackground ? " rayline-terminal-host--opaque" : ""}`;
-      el.style.cssText = `width:100%;height:100%;background:${opaqueBackground ? TERMINAL_OPAQUE_BG : "transparent"};`;
+      el.style.cssText = `width:100%;height:100%;background:${opaqueBackground ? "var(--term-background)" : "transparent"};`;
       xtermElRef.current = el;
       containerRef.current.appendChild(el);
 
@@ -780,11 +746,7 @@ function SessionTerminal({
 
       registerRef.current(sessionName, term);
 
-      const pendingScrollback = pendingScrollbackRef.current;
-      pendingScrollbackRef.current = "";
-      if (pendingScrollback) {
-        term.write(pendingScrollback);
-      } else if (window.api?.terminalRead) {
+      if (window.api?.terminalRead) {
         try {
           const result = await window.api.terminalRead({ name: sessionName, lines: 500 });
           if (!cancelled && result?.ok && result.lines?.length) {
@@ -838,7 +800,7 @@ function SessionTerminal({
       emitTerminalDebug("session:teardown", { sessionName });
       teardown();
     };
-  }, [opaqueBackground, plainClickMovesCursor, promptSelectionEditing, promptUndoShortcut, sessionName, teardown, themeRevision]);
+  }, [opaqueBackground, plainClickMovesCursor, promptSelectionEditing, promptUndoShortcut, sessionName, teardown]);
 
   useEffect(() => {
     const logActiveState = (phase) => {

--- a/src/contexts/ThemeContext.js
+++ b/src/contexts/ThemeContext.js
@@ -1,0 +1,51 @@
+import { createContext, createElement, useContext, useEffect, useMemo, useState } from "react";
+
+export function getResolvedThemeMode(detail) {
+  const candidate = detail?.resolved || detail?.mode || detail?.theme;
+  if (candidate === "light" || candidate === "dark") return candidate;
+
+  if (typeof document !== "undefined") {
+    const root = document.documentElement;
+    if (root.dataset.theme === "light" || root.dataset.theme === "dark") {
+      return root.dataset.theme;
+    }
+    if (root.classList.contains("light")) return "light";
+  }
+
+  return "dark";
+}
+
+export const ThemeContext = createContext({
+  mode: "dark",
+  resolved: "dark",
+  theme: "dark",
+});
+
+export function ThemeProvider({ children }) {
+  const [resolved, setResolved] = useState(() => getResolvedThemeMode());
+
+  useEffect(() => {
+    const handleThemeChange = (event) => {
+      setResolved(getResolvedThemeMode(event.detail));
+    };
+
+    window.addEventListener("rayline:theme-change", handleThemeChange);
+    return () => window.removeEventListener("rayline:theme-change", handleThemeChange);
+  }, []);
+
+  const value = useMemo(() => ({
+    mode: resolved,
+    resolved,
+    theme: resolved,
+  }), [resolved]);
+
+  return createElement(ThemeContext.Provider, { value }, children);
+}
+
+export function useThemeContext() {
+  return useContext(ThemeContext);
+}
+
+export function useResolvedThemeMode() {
+  return useThemeContext().resolved;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700&family=Lato:wght@300;400;700&family=Newsreader:ital,wght@0,300;0,400;0,600;1,300;1,400&family=JetBrains+Mono:wght@300;400;500&display=swap');
 
-:root {
+:root,
+:root[data-theme="dark"] {
+  color-scheme: dark;
   --pane-background: #0D0D10;
   --pane-background-rgb: 13, 13, 16;
   --pane-overlay-alpha: 0.82;
@@ -18,6 +20,74 @@
   --pane-interaction-hover-shadow: none;
   --pane-interaction-active-shadow: none;
   --pane-border: rgba(255,255,255,0.06);
+  --term-background: #0D0D10;
+  --term-foreground: rgba(244,247,250,0.88);
+  --term-cursor: rgba(245,247,251,0.98);
+  --term-selection-background: rgba(120,182,255,0.18);
+  --term-selection-inactive-background: rgba(120,182,255,0.1);
+  --term-black: #0f1116;
+  --term-red: #f38ba8;
+  --term-green: #7ed7b9;
+  --term-yellow: #f5c97a;
+  --term-blue: #89b4fa;
+  --term-magenta: #cba6f7;
+  --term-cyan: #74c7ec;
+  --term-white: #bac2de;
+  --term-bright-black: #585b70;
+  --term-bright-red: #f7a6bc;
+  --term-bright-green: #9ce8cf;
+  --term-bright-yellow: #f8d99c;
+  --term-bright-blue: #a6c9ff;
+  --term-bright-magenta: #d9b8fb;
+  --term-bright-cyan: #98dbf3;
+  --term-bright-white: #f5f7fb;
+  --aurora-bg: #0D0D0F;
+  --aurora-glow: rgba(255,255,255,0.018);
+}
+
+:root[data-theme="light"],
+:root.light {
+  color-scheme: light;
+  --pane-background: #f8fafc;
+  --pane-background-rgb: 248, 250, 252;
+  --pane-overlay-alpha: 0.82;
+  --pane-background-overlay: rgba(var(--pane-background-rgb), var(--pane-overlay-alpha));
+  --pane-hover-overlay: rgba(226, 232, 240, var(--pane-overlay-alpha));
+  --pane-active-overlay: rgba(203, 213, 225, var(--pane-overlay-alpha));
+  --pane-elevated-rgb: 255, 255, 255;
+  --pane-elevated: rgba(var(--pane-elevated-rgb), 0.72);
+  --pane-hover: #edf2f7;
+  --pane-active: #e2e8f0;
+  --pane-interaction-hover-fill: var(--pane-hover);
+  --pane-interaction-active-fill: var(--pane-active);
+  --pane-interaction-hover-filter: none;
+  --pane-interaction-active-filter: none;
+  --pane-interaction-hover-shadow: none;
+  --pane-interaction-active-shadow: none;
+  --pane-border: rgba(15,23,42,0.1);
+  --term-background: #f8fafc;
+  --term-foreground: rgba(15,23,42,0.88);
+  --term-cursor: rgba(15,23,42,0.96);
+  --term-selection-background: rgba(37,99,235,0.18);
+  --term-selection-inactive-background: rgba(37,99,235,0.1);
+  --term-black: #0f172a;
+  --term-red: #dc2626;
+  --term-green: #047857;
+  --term-yellow: #b45309;
+  --term-blue: #2563eb;
+  --term-magenta: #9333ea;
+  --term-cyan: #0891b2;
+  --term-white: #475569;
+  --term-bright-black: #64748b;
+  --term-bright-red: #ef4444;
+  --term-bright-green: #059669;
+  --term-bright-yellow: #d97706;
+  --term-bright-blue: #3b82f6;
+  --term-bright-magenta: #a855f7;
+  --term-bright-cyan: #06b6d4;
+  --term-bright-white: #0f172a;
+  --aurora-bg: #f8fafc;
+  --aurora-glow: rgba(37,99,235,0.055);
 }
 
 *, *::before, *::after {


### PR DESCRIPTION
## Summary
WS-G：富交互子系统的 light 分支适配（xterm 终端、AuroraCanvas 着色、InteractiveBlock iframe sandbox）。子系统原本只跑 dark，本 PR 加 light palette 分支。

## Changes
- `AuroraCanvas.jsx`：+24 行，light 模式柔化色板
- `InteractiveBlock.jsx`：+70 行，iframe srcdoc 注入主题变量
- `TerminalDrawer.jsx`：+117 行，xterm theme 跟随 `data-theme` 切换

**3 files, +174/-37**

## Depends on
- WS-0 (`theme/ws0-foundation`)
- WS-F (TerminalDrawer 已 var 化的基础上扩展)

## Test plan
- [ ] xterm 终端 light/dark 切换前景/背景对比清晰
- [ ] AuroraCanvas 在 light 下不刺眼
- [ ] InteractiveBlock iframe 内主题与外层一致
