### PR TITLE
feat(theme): WS-H Mermaid palette + tokens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import { useMulticaModels } from "./data/multicaModels.jsx";
 import { buildConversationPrime, buildCrossProviderPrime, decoratePromptWithPrime } from "./utils/crossProviderPrime";
 import { resolveSafeCwd, buildMissingCwdReminder, decoratePromptWithReminder, getMainRepoRoot as getMainRepoRootUtil } from "./utils/cwdRecovery";
 import { FontSizeContext } from "./contexts/FontSizeContext";
+import { ThemeProvider } from "./contexts/ThemeContext";
 import { getPaneSurfaceStyle } from "./utils/paneSurface";
 import { DEFAULT_WALLPAPER, getPersistedWallpaper, getWallpaperImageFilter, normalizeWallpaper } from "./utils/wallpaper";
 import { detectDefaultLocale, normalizeLocale } from "./i18n";
@@ -1161,6 +1162,7 @@ export default function App() {
   const [wallpaper, setWallpaper] = useState(null);
   const [locale, setLocale] = useState(() => detectDefaultLocale());
   const [fontSize, setFontSize] = useState(DEFAULT_FONT_SIZE);
+  const [appTheme, setAppTheme] = useState("dark");
   const [sidebarActiveOpacity, setSidebarActiveOpacity] = useState(DEFAULT_SIDEBAR_ACTIVE_OPACITY);
   const [defaultPrBranch, setDefaultPrBranch] = useState("main");
   const [coauthorEnabled, setCoauthorEnabled] = useState(true);
@@ -1237,6 +1239,7 @@ export default function App() {
     defaultModel,
     locale,
     fontSize,
+    appTheme,
     sidebarActiveOpacity,
     wallpaper: getPersistedWallpaper(wallpaper),
     projects,
@@ -1255,6 +1258,7 @@ export default function App() {
   }), [
     appBlur,
     appOpacity,
+    appTheme,
     coauthorEnabled,
     coauthorTrailer,
     chromeControlsOnHover,
@@ -1523,6 +1527,7 @@ export default function App() {
         if (state.defaultModel) setDefaultModel(normalizeModelId(state.defaultModel));
         if (state.locale) setLocale(normalizeLocale(state.locale));
         if (state.fontSize) setFontSize(state.fontSize);
+        if (state.appTheme) setAppTheme(state.appTheme);
         if (state.sidebarActiveOpacity != null) {
           setSidebarActiveOpacity(clampNumber(state.sidebarActiveOpacity, 0, 20, DEFAULT_SIDEBAR_ACTIVE_OPACITY));
         }
@@ -3555,6 +3560,7 @@ export default function App() {
     : "width .34s cubic-bezier(.16,1,.3,1), min-width .34s cubic-bezier(.16,1,.3,1), border-color .18s ease";
 
   return (
+    <ThemeProvider externalTheme={appTheme} onThemeChange={setAppTheme}>
     <FontSizeContext.Provider value={fontSize}>
     <div style={{ display: "flex", height: "100vh", width: "100vw", overflow: "hidden", position: "relative" }}>
       {wallpaper?.dataUrl ? (
@@ -3801,5 +3807,6 @@ export default function App() {
       </div>
     </div>
     </FontSizeContext.Provider>
+    </ThemeProvider>
   );
 }

--- a/src/components/MermaidBlock.jsx
+++ b/src/components/MermaidBlock.jsx
@@ -3,122 +3,234 @@ import mermaid from "mermaid";
 import { useFontScale } from "../contexts/FontSizeContext";
 
 let mermaidInitialized = false;
+let mermaidMode = null;
 let renderCounter = 0;
 
-function initMermaid() {
-  if (mermaidInitialized) return;
+const DARK_THEME_VARIABLES = {
+  darkMode: true,
+  background: "#0a0a0a",
+  mainBkg: "#1a1a1a",
+  nodeBorder: "rgba(255,255,255,0.25)",
+  clusterBkg: "#111111",
+  clusterBorder: "rgba(255,255,255,0.15)",
+  titleColor: "rgba(255,255,255,0.85)",
+
+  // Text colors
+  primaryTextColor: "rgba(255,255,255,0.85)",
+  secondaryTextColor: "rgba(255,255,255,0.6)",
+  tertiaryTextColor: "rgba(255,255,255,0.5)",
+
+  // Line/edge colors
+  lineColor: "rgba(255,255,255,0.35)",
+  textColor: "rgba(255,255,255,0.8)",
+
+  // Node colors - soft blues/teals instead of pink
+  primaryColor: "#1e3a5f",
+  primaryBorderColor: "#3b82c4",
+  secondaryColor: "#1a2e3e",
+  secondaryBorderColor: "#4a90b8",
+  tertiaryColor: "#1e2d3d",
+  tertiaryBorderColor: "#5a9ab5",
+
+  // Git graph - white lines, dark text on light labels
+  git0: "#ffffff",
+  git1: "#aaaaaa",
+  git2: "#cccccc",
+  git3: "#888888",
+  git4: "#dddddd",
+  git5: "#bbbbbb",
+  git6: "#999999",
+  git7: "#eeeeee",
+  gitBranchLabel0: "#000000",
+  gitBranchLabel1: "#000000",
+  gitBranchLabel2: "#000000",
+  gitBranchLabel3: "#000000",
+  gitBranchLabel4: "#000000",
+  gitBranchLabel5: "#000000",
+  gitBranchLabel6: "#000000",
+  gitBranchLabel7: "#000000",
+  gitInv0: "#000000",
+  commitLabelColor: "rgba(255,255,255,0.7)",
+  commitLabelBackground: "rgba(255,255,255,0.08)",
+
+  // Pie chart
+  pie1: "#3b82c4",
+  pie2: "#6ab04c",
+  pie3: "#e2b93d",
+  pie4: "#e07b4c",
+  pie5: "#9b59b6",
+  pie6: "#1abc9c",
+  pie7: "#e67e22",
+  pie8: "#2ecc71",
+  pieTitleTextColor: "rgba(255,255,255,0.85)",
+  pieSectionTextColor: "rgba(255,255,255,0.9)",
+  pieLegendTextColor: "rgba(255,255,255,0.7)",
+  pieStrokeColor: "rgba(255,255,255,0.1)",
+  pieSectionTextSize: "14px",
+  pieOuterStrokeColor: "rgba(255,255,255,0.1)",
+
+  // Notes
+  noteBkgColor: "#1a2530",
+  noteTextColor: "rgba(255,255,255,0.8)",
+  noteBorderColor: "rgba(255,255,255,0.15)",
+
+  // Sequence diagram
+  actorBkg: "#1a2530",
+  actorBorder: "rgba(255,255,255,0.25)",
+  actorTextColor: "rgba(255,255,255,0.85)",
+  signalColor: "rgba(255,255,255,0.7)",
+  labelBoxBkgColor: "#1a2530",
+
+  // Flowchart
+  edgeLabelBackground: "#0a0a0a",
+
+  // Class diagram
+  classText: "rgba(255,255,255,0.8)",
+
+  // Font
+  fontFamily: "system-ui,-apple-system,sans-serif",
+  fontSize: "13px",
+};
+
+const LIGHT_THEME_VARIABLES = {
+  darkMode: false,
+  background: "#ffffff",
+  mainBkg: "#ffffff",
+  nodeBorder: "#cbd5e1",
+  clusterBkg: "#f8fafc",
+  clusterBorder: "#cbd5e1",
+  titleColor: "#1f2937",
+
+  // Text colors
+  primaryTextColor: "#1f2937",
+  secondaryTextColor: "#1f2937",
+  tertiaryTextColor: "#1f2937",
+
+  // Line/edge colors
+  lineColor: "#475569",
+  textColor: "#1f2937",
+
+  // Node colors
+  primaryColor: "#ffffff",
+  primaryBorderColor: "#2563eb",
+  secondaryColor: "#f8fafc",
+  secondaryBorderColor: "#0f766e",
+  tertiaryColor: "#f8fafc",
+  tertiaryBorderColor: "#64748b",
+
+  // Git graph
+  git0: "#2563eb",
+  git1: "#0f766e",
+  git2: "#7c3aed",
+  git3: "#b45309",
+  git4: "#475569",
+  git5: "#0369a1",
+  git6: "#be123c",
+  git7: "#4d7c0f",
+  gitBranchLabel0: "#1f2937",
+  gitBranchLabel1: "#1f2937",
+  gitBranchLabel2: "#1f2937",
+  gitBranchLabel3: "#1f2937",
+  gitBranchLabel4: "#1f2937",
+  gitBranchLabel5: "#1f2937",
+  gitBranchLabel6: "#1f2937",
+  gitBranchLabel7: "#1f2937",
+  gitInv0: "#ffffff",
+  commitLabelColor: "#1f2937",
+  commitLabelBackground: "#f8fafc",
+
+  // Pie chart
+  pie1: "#2563eb",
+  pie2: "#0f766e",
+  pie3: "#b45309",
+  pie4: "#be123c",
+  pie5: "#7c3aed",
+  pie6: "#0369a1",
+  pie7: "#4d7c0f",
+  pie8: "#9333ea",
+  pieTitleTextColor: "#1f2937",
+  pieSectionTextColor: "#1f2937",
+  pieLegendTextColor: "#1f2937",
+  pieStrokeColor: "#cbd5e1",
+  pieSectionTextSize: "14px",
+  pieOuterStrokeColor: "#cbd5e1",
+
+  // Notes
+  noteBkgColor: "#f8fafc",
+  noteTextColor: "#1f2937",
+  noteBorderColor: "#cbd5e1",
+
+  // Sequence diagram
+  actorBkg: "#ffffff",
+  actorBorder: "#cbd5e1",
+  actorTextColor: "#1f2937",
+  signalColor: "#475569",
+  labelBoxBkgColor: "#ffffff",
+
+  // Flowchart
+  edgeLabelBackground: "#ffffff",
+
+  // Class diagram
+  classText: "#1f2937",
+
+  // Font
+  fontFamily: "system-ui,-apple-system,sans-serif",
+  fontSize: "13px",
+};
+
+function getThemeMode() {
+  if (typeof document === "undefined") return "dark";
+  const root = document.documentElement;
+  return root.dataset.theme === "light" || root.classList.contains("light") ? "light" : "dark";
+}
+
+function initMermaid(mode = getThemeMode()) {
+  if (mermaidInitialized && mermaidMode === mode) return;
   mermaid.initialize({
     startOnLoad: false,
     theme: "base",
     suppressErrorRendering: true,
-    themeVariables: {
-      darkMode: true,
-      background: "#0a0a0a",
-      mainBkg: "#1a1a1a",
-      nodeBorder: "rgba(255,255,255,0.25)",
-      clusterBkg: "#111111",
-      clusterBorder: "rgba(255,255,255,0.15)",
-      titleColor: "rgba(255,255,255,0.85)",
-
-      // Text colors
-      primaryTextColor: "rgba(255,255,255,0.85)",
-      secondaryTextColor: "rgba(255,255,255,0.6)",
-      tertiaryTextColor: "rgba(255,255,255,0.5)",
-
-      // Line/edge colors
-      lineColor: "rgba(255,255,255,0.35)",
-      textColor: "rgba(255,255,255,0.8)",
-
-      // Node colors — soft blues/teals instead of pink
-      primaryColor: "#1e3a5f",
-      primaryBorderColor: "#3b82c4",
-      secondaryColor: "#1a2e3e",
-      secondaryBorderColor: "#4a90b8",
-      tertiaryColor: "#1e2d3d",
-      tertiaryBorderColor: "#5a9ab5",
-
-      // Git graph — white lines, dark text on light labels
-      git0: "#ffffff",
-      git1: "#aaaaaa",
-      git2: "#cccccc",
-      git3: "#888888",
-      git4: "#dddddd",
-      git5: "#bbbbbb",
-      git6: "#999999",
-      git7: "#eeeeee",
-      gitBranchLabel0: "#000000",
-      gitBranchLabel1: "#000000",
-      gitBranchLabel2: "#000000",
-      gitBranchLabel3: "#000000",
-      gitBranchLabel4: "#000000",
-      gitBranchLabel5: "#000000",
-      gitBranchLabel6: "#000000",
-      gitBranchLabel7: "#000000",
-      gitInv0: "#000000",
-      commitLabelColor: "rgba(255,255,255,0.7)",
-      commitLabelBackground: "rgba(255,255,255,0.08)",
-
-      // Pie chart
-      pie1: "#3b82c4",
-      pie2: "#6ab04c",
-      pie3: "#e2b93d",
-      pie4: "#e07b4c",
-      pie5: "#9b59b6",
-      pie6: "#1abc9c",
-      pie7: "#e67e22",
-      pie8: "#2ecc71",
-      pieTitleTextColor: "rgba(255,255,255,0.85)",
-      pieSectionTextColor: "rgba(255,255,255,0.9)",
-      pieLegendTextColor: "rgba(255,255,255,0.7)",
-      pieStrokeColor: "rgba(255,255,255,0.1)",
-      pieSectionTextSize: "14px",
-      pieOuterStrokeColor: "rgba(255,255,255,0.1)",
-
-      // Notes
-      noteBkgColor: "#1a2530",
-      noteTextColor: "rgba(255,255,255,0.8)",
-      noteBorderColor: "rgba(255,255,255,0.15)",
-
-      // Sequence diagram
-      actorBkg: "#1a2530",
-      actorBorder: "rgba(255,255,255,0.25)",
-      actorTextColor: "rgba(255,255,255,0.85)",
-      signalColor: "rgba(255,255,255,0.7)",
-      labelBoxBkgColor: "#1a2530",
-
-      // Flowchart
-      edgeLabelBackground: "#0a0a0a",
-
-      // Class diagram
-      classText: "rgba(255,255,255,0.8)",
-
-      // Font
-      fontFamily: "system-ui,-apple-system,sans-serif",
-      fontSize: "13px",
-    },
+    themeVariables: { ...(mode === "light" ? LIGHT_THEME_VARIABLES : DARK_THEME_VARIABLES) },
   });
   mermaidInitialized = true;
+  mermaidMode = mode;
 }
 
 export default function MermaidBlock({ code }) {
   const s = useFontScale();
   const [svg, setSvg] = useState(null);
   const [error, setError] = useState(false);
-  const lastRendered = useRef("");
+  const [themeRevision, setThemeRevision] = useState(0);
+  const lastRendered = useRef({ code: "", mode: "" });
   const timerRef = useRef(null);
   const containerRef = useRef(null);
   const lastHeight = useRef(null);
 
   useEffect(() => {
+    const handleThemeChange = () => {
+      clearTimeout(timerRef.current);
+      lastRendered.current = { code: "", mode: "" };
+      setSvg(null);
+      setError(false);
+      setThemeRevision((revision) => revision + 1);
+    };
+
+    window.addEventListener("rayline:theme-change", handleThemeChange);
+    return () => window.removeEventListener("rayline:theme-change", handleThemeChange);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
     const trimmed = code?.trim();
     if (!trimmed) return;
-    if (trimmed === lastRendered.current && svg) return;
+    const mode = getThemeMode();
+    if (trimmed === lastRendered.current.code && mode === lastRendered.current.mode && svg) return;
 
     // Debounce: wait 600ms after last code change (handles streaming)
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
-      lastRendered.current = trimmed;
-      initMermaid();
+      lastRendered.current = { code: trimmed, mode };
+      initMermaid(mode);
       setError(false);
 
       const id = `mmd-${++renderCounter}-${Date.now()}`;
@@ -127,35 +239,21 @@ export default function MermaidBlock({ code }) {
       document.body.appendChild(offscreen);
 
       mermaid.render(id, trimmed, offscreen).then(({ svg: result }) => {
+        if (cancelled) return;
         setSvg(result);
       }).catch(() => {
+        if (cancelled) return;
         setError(true);
       }).finally(() => {
         try { document.body.removeChild(offscreen); } catch {}
       });
     }, 600);
 
-    return () => clearTimeout(timerRef.current);
-  }, [code]);
-
-  if (error) {
-    return (
-      <pre style={{
-        background: "rgba(0,0,0,0.4)",
-        border: "1px solid rgba(255,255,255,0.06)",
-        borderRadius: 8,
-        padding: "12px 14px",
-        overflow: "auto",
-        fontSize: s(12),
-        fontFamily: "'JetBrains Mono',monospace",
-        margin: "8px 0 12px",
-        lineHeight: 1.6,
-        color: "rgba(255,255,255,0.5)",
-      }}>
-        <code>{code}</code>
-      </pre>
-    );
-  }
+    return () => {
+      cancelled = true;
+      clearTimeout(timerRef.current);
+    };
+  }, [code, themeRevision]);
 
   // Capture height when SVG is rendered
   useEffect(() => {
@@ -164,16 +262,35 @@ export default function MermaidBlock({ code }) {
     }
   }, [svg]);
 
+  if (error) {
+    return (
+      <pre style={{
+        background: "var(--mermaid-bg)",
+        border: "1px solid var(--mermaid-node-border)",
+        borderRadius: 8,
+        padding: "12px 14px",
+        overflow: "auto",
+        fontSize: s(12),
+        fontFamily: "'JetBrains Mono',monospace",
+        margin: "8px 0 12px",
+        lineHeight: 1.6,
+        color: "var(--mermaid-text)",
+      }}>
+        <code>{code}</code>
+      </pre>
+    );
+  }
+
   if (!svg) {
     return (
       <div style={{
-        background: "rgba(0,0,0,0.2)",
-        border: "1px solid rgba(255,255,255,0.06)",
+        background: "var(--mermaid-bg)",
+        border: "1px solid var(--mermaid-node-border)",
         borderRadius: 8,
         padding: "24px",
         margin: "8px 0 12px",
         textAlign: "center",
-        color: "rgba(255,255,255,0.25)",
+        color: "var(--mermaid-text)",
         fontSize: s(11),
         fontFamily: "'JetBrains Mono',monospace",
         // Preserve last known height to prevent scroll jumps
@@ -191,8 +308,8 @@ export default function MermaidBlock({ code }) {
     <div
       ref={containerRef}
       style={{
-        background: "rgba(0,0,0,0.2)",
-        border: "1px solid rgba(255,255,255,0.06)",
+        background: "var(--mermaid-bg)",
+        border: "1px solid var(--mermaid-node-border)",
         borderRadius: 8,
         padding: "16px",
         margin: "8px 0 12px",

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,0 +1,80 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+
+export const ThemeContext = createContext({ theme: "dark", setTheme: () => {} });
+
+/**
+ * Returns { theme, setTheme } where theme is "light" | "dark" | "auto".
+ * Calling setTheme applies data-theme to <html> and dispatches rayline:theme-change.
+ */
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+function resolveTheme(theme) {
+  if (theme === "auto") {
+    return window.matchMedia?.("(prefers-color-scheme: light)").matches ? "light" : "dark";
+  }
+  return theme;
+}
+
+function applyThemeToDOM(theme) {
+  const resolved = resolveTheme(theme);
+  const root = document.documentElement;
+  root.dataset.theme = resolved;
+  if (resolved === "light") {
+    root.classList.add("light");
+    root.classList.remove("dark");
+  } else {
+    root.classList.add("dark");
+    root.classList.remove("light");
+  }
+  window.dispatchEvent(
+    new CustomEvent("rayline:theme-change", { detail: { theme: resolved } })
+  );
+}
+
+/**
+ * ThemeProvider manages the theme state.
+ * Pass `externalTheme` if you want to initialize from a persisted value.
+ * Pass `onThemeChange` to keep an external state in sync.
+ */
+export function ThemeProvider({ children, externalTheme, onThemeChange }) {
+  const [theme, setThemeState] = useState(externalTheme || "dark");
+  const prevExternalRef = useRef(externalTheme);
+
+  // Sync when externalTheme changes from outside (e.g. loaded from persisted state)
+  useEffect(() => {
+    if (externalTheme && externalTheme !== prevExternalRef.current) {
+      prevExternalRef.current = externalTheme;
+      setThemeState(externalTheme);
+      applyThemeToDOM(externalTheme);
+    }
+  }, [externalTheme]);
+
+  const setTheme = useCallback((t) => {
+    setThemeState(t);
+    applyThemeToDOM(t);
+    onThemeChange?.(t);
+  }, [onThemeChange]);
+
+  // Apply once on mount
+  useEffect(() => {
+    applyThemeToDOM(theme);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-apply when "auto" and system preference changes
+  useEffect(() => {
+    if (theme !== "auto") return;
+    const mq = window.matchMedia?.("(prefers-color-scheme: light)");
+    if (!mq) return;
+    const handler = () => applyThemeToDOM("auto");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,24 @@
   --pane-interaction-hover-shadow: none;
   --pane-interaction-active-shadow: none;
   --pane-border: rgba(255,255,255,0.06);
+  --mermaid-bg: #0a0a0a;
+  --mermaid-node-bg: #1a1a1a;
+  --mermaid-node-border: rgba(255,255,255,0.25);
+  --mermaid-text: rgba(255,255,255,0.85);
+  --mermaid-line: rgba(255,255,255,0.35);
+  --mermaid-cluster-bg: #111111;
+  --mermaid-edge-label-bg: #0a0a0a;
+}
+
+:root[data-theme="light"],
+:root.light {
+  --mermaid-bg: #ffffff;
+  --mermaid-node-bg: #ffffff;
+  --mermaid-node-border: #cbd5e1;
+  --mermaid-text: #1f2937;
+  --mermaid-line: #475569;
+  --mermaid-cluster-bg: #f8fafc;
+  --mermaid-edge-label-bg: #ffffff;
 }
 
 *, *::before, *::after {


### PR DESCRIPTION
## Summary
WS-H：Mermaid 图表 light palette + theme-change listener。Mermaid 默认 dark theme，light 模式下需主动重渲染并切色板。

## Changes
- `MermaidBlock.jsx`：333 行（净 +225），加 light palette、监听 `data-theme` 变化重 init、节点/连线/标签色彩重映射
- `index.css`：+18 行，Mermaid 容器外层 token 覆盖

**2 files, +243/-108**

## Depends on
- WS-0 (`theme/ws0-foundation`)

## Test plan
- [ ] Mermaid 图在 light/dark 切换后立即重绘
- [ ] 节点/连线对比度达标
- [ ] flowchart / sequence / class 三类图都验
