### PR TITLE
fix(theme): P0 dark logo + P1 light hint contrast (delta from #188)

### DIFF
--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -1210,7 +1210,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
               marginTop: 8,
               fontSize: s(8),
               fontFamily: "'JetBrains Mono',monospace",
-              color: "rgba(255,255,255,0.30)",
+              color: "var(--text-muted)",
               letterSpacing: ".1em",
             }}
           >

--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import { useFontScale } from "../contexts/FontSizeContext";
 
-const ACCENT = "#FF4422";
-const PRIMARY = "rgb(200, 200, 200)";
+const ACCENT = "var(--accent)";
+const PRIMARY = "var(--text-secondary)";
 
 export default function EmptyState() {
   const s = useFontScale();
@@ -99,19 +99,19 @@ export default function EmptyState() {
         }}>
           <div className="rl-sys-1" style={{
             fontSize: s(13),
-            color: "rgba(255,255,255,0.55)",
+            color: "var(--text-secondary)",
             letterSpacing: ".06em",
             fontWeight: 500,
           }}>
             {info.user}@{info.hostname}
           </div>
-          <div className="rl-sys-2" style={{ fontSize: s(11), color: "rgba(255,255,255,0.32)", letterSpacing: ".04em" }}>
+          <div className="rl-sys-2" style={{ fontSize: s(11), color: "var(--text-muted)", letterSpacing: ".04em" }}>
             {info.platform} {info.arch} · {info.cpus} cores · {info.memory}
           </div>
-          <div className="rl-sys-3" style={{ fontSize: s(11), color: "rgba(255,255,255,0.22)", letterSpacing: ".04em" }}>
+          <div className="rl-sys-3" style={{ fontSize: s(11), color: "var(--text-muted)", letterSpacing: ".04em" }}>
             node {info.nodeVersion} · electron {info.electronVersion}
           </div>
-          <div className="rl-sys-4" style={{ fontSize: s(11), color: "rgba(255,255,255,0.16)", letterSpacing: ".04em" }}>
+          <div className="rl-sys-4" style={{ fontSize: s(11), color: "var(--text-muted)", letterSpacing: ".04em" }}>
             {info.shell}
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **P0 EmptyState**: `ACCENT`/`PRIMARY` 常量从硬编码颜色改为 `var(--accent)` / `var(--text-secondary)`，`rl-sys-*` 四处 rgba 改为 CSS token（修复深色主题下 logo 不可见问题）
- **P1 ChatArea:1213**: `rgba(255,255,255,0.30)` → `var(--text-muted)`（修复浅色主题下底部 hint 对比度不足问题）

## 背景

本 PR 是从 PR #188（`theme/fix-dark-logo-hint`，42 文件 +1455/-1023）中提取的真正 delta。
#188 其余 1400+ 行与 WS-0~WS-I 系列（#175~#187）100% 重叠，本 PR 只包含两个 bug fix 的净增量：**7 行改动，2 个文件**。

## 与 WS 系列关系

- 本 PR 独立于 WS 系列，可直接合入 main
- 合入后 #188 可安全关闭

## Test plan

- [ ] dark mode：EmptyState logo 文字和系统信息应可见
- [ ] light mode：ChatArea 底部 hint 文字对比度 ≥ 3:1
- [ ] 不影响其他主题切换逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)