### PR TITLE
  feat(Windows): macOS-style fixed chrome header for sidebar  

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import AuroraCanvas from "./components/AuroraCanvas";
 import Grain        from "./components/Grain";
 import Sidebar      from "./components/Sidebar";
 import SidebarChromeRail from "./components/SidebarChromeRail";
+import SidebarWindowsHeader from "./components/SidebarWindowsHeader";
 import DispatchCard from "./components/DispatchCard.jsx";
 import ChatArea     from "./components/ChatArea";
 import TerminalDrawer from "./components/TerminalDrawer";
@@ -1292,9 +1293,7 @@ export default function App() {
   );
   const showWindowControls = platform === "win32";
   const useWindowsSidebarChrome = showWindowControls;
-  const sidebarWidth = useWindowsSidebarChrome
-    ? (sidebarOpen ? 220 : 52)
-    : (sidebarOpen ? SIDEBAR_WIDTH : 0);
+  const sidebarWidth = sidebarOpen ? (useWindowsSidebarChrome ? 220 : SIDEBAR_WIDTH) : 0;
 
   useEffect(() => {
     window.api?.getSystemInfo?.().then((info) => {
@@ -3634,7 +3633,16 @@ export default function App() {
 
       <WindowControls visible={showWindowControls} />
 
-      {!useWindowsSidebarChrome && (
+      {useWindowsSidebarChrome ? (
+        <SidebarWindowsHeader
+          sidebarOpen={sidebarOpen}
+          settingsOpen={showSettings}
+          onToggleSidebar={() => setSidebarOpen((o) => !o)}
+          onNew={handleNew}
+          onOpenSettings={() => setShowSettings((open) => !open)}
+          hasUpdate={hasUpdate}
+        />
+      ) : (
         <SidebarChromeRail
           sidebarOpen={sidebarOpen}
           settingsOpen={showSettings}
@@ -3658,7 +3666,7 @@ export default function App() {
         style={{
           width: sidebarWidth,
           minWidth: sidebarWidth,
-          borderRight: `1px solid ${sidebarOpen || useWindowsSidebarChrome ? "rgba(255,255,255,0.025)" : "rgba(255,255,255,0)"}`,
+          borderRight: `1px solid ${sidebarOpen ? "rgba(255,255,255,0.025)" : "rgba(255,255,255,0)"}`,
           display: "flex",
           flexDirection: "column",
           position: "relative",

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -520,7 +520,7 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
           inside the drag hit-area. On macOS, WindowDragSpacer reserves the
           sidebar chrome rail as a no-drag zone. */}
       <div style={{ marginRight: windowControlsVisible ? topTabsRight : 0 }}>
-        <WindowDragSpacer />
+        <WindowDragSpacer reserveWindowsHeader={windowControlsVisible && !sidebarOpen} />
       </div>
 
       {showHeaderTabs && (

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -164,12 +164,12 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
   const searchActive = search.length > 0;
 
   const cwdShort = cwd ? (() => {
-    const parts = cwd.split("/");
+    const parts = cwd.split(/[\\/]+/);
     const wtIdx = parts.indexOf(".worktrees");
     if (wtIdx >= 0 && wtIdx + 1 < parts.length) {
       return `${parts[wtIdx - 1]} / ${parts[wtIdx + 1]}`;
     }
-    return parts.slice(-2).join("/");
+    return parts.filter(Boolean).slice(-2).join("/");
   })() : null;
 
   // ── Windows collapsed: sidebar fully hidden; SidebarWindowsHeader overlay takes over ──

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,9 +1,9 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { useFontScale } from "../contexts/FontSizeContext";
 import { createTranslator } from "../i18n";
-import { Plus, Search, Trash2, PanelLeftClose, PanelLeftOpen, FolderOpen, Settings as SettingsIcon, ChevronRight, Workflow, FolderPlus } from "lucide-react";
+import { Plus, Search, Trash2, FolderOpen, ChevronRight, Workflow, FolderPlus } from "lucide-react";
 import WindowDragSpacer from "./WindowDragSpacer";
-import { SIDEBAR_TOGGLE_SIZE, SIDEBAR_TOGGLE_TOP, WINDOW_DRAG_HEIGHT } from "../windowChrome";
+import { WINDOW_DRAG_HEIGHT } from "../windowChrome";
 import ProjectGroup from "./ProjectGroup";
 import { getMOrMulticaFallback } from "../data/models";
 import { applyPaneInteractionStyle, getPaneInteractionStyle } from "../utils/paneSurface";
@@ -82,26 +82,6 @@ function groupConvosByProject(convos, projectsMeta, draftsPath) {
   return { projectGroups: sorted, drafts };
 }
 
-function IconRailBtn({ onClick, title, children }) {
-  return (
-    <button
-      onClick={onClick}
-      title={title}
-      style={{
-        display: "flex", alignItems: "center", justifyContent: "center",
-        width: 40, height: 40, borderRadius: 8,
-        background: "none", border: "none", cursor: "pointer",
-        color: "rgba(255,255,255,0.55)", transition: "background .15s, color .15s",
-        WebkitAppRegion: "no-drag",
-        flexShrink: 0,
-      }}
-      onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(255,255,255,0.07)"; e.currentTarget.style.color = "rgba(255,255,255,0.88)"; }}
-      onMouseLeave={(e) => { e.currentTarget.style.background = "none"; e.currentTarget.style.color = "rgba(255,255,255,0.55)"; }}
-    >
-      {children}
-    </button>
-  );
-}
 
 function GitHubIcon({ size = 12 }) {
   return (
@@ -192,141 +172,14 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
     return parts.slice(-2).join("/");
   })() : null;
 
-  // ── Icon-rail collapsed state ──────────────────────────────────────────────
-  if (windowsChrome && !isOpen) {
-    return (
-      <div style={{ display: "flex", flexDirection: "column", height: "100%", alignItems: "center", WebkitAppRegion: "no-drag" }}>
-        {/* Drag region: logo on top, expand toggle below */}
-        <div style={{ height: WINDOW_DRAG_HEIGHT, width: "100%", WebkitAppRegion: "drag", flexShrink: 0, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 0, position: "relative" }}>
-          <button
-            onClick={() => window.open("https://ensuechat.com")}
-            title="Ensue Chat"
-            style={{
-              position: "absolute", top: 10,
-              display: "flex", alignItems: "center", justifyContent: "center",
-              width: 24, height: 24, padding: 0,
-              background: "none", border: "none", cursor: "pointer",
-              borderRadius: 6, opacity: 0.82, transition: "opacity .15s, transform .15s",
-              WebkitAppRegion: "no-drag",
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; e.currentTarget.style.transform = "scale(1.08)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.82"; e.currentTarget.style.transform = "scale(1)"; }}
-          >
-            <img src={`${import.meta.env.BASE_URL}favicon.svg`} style={{ width: 24, height: 24, borderRadius: 5, display: "block" }} draggable={false} />
-          </button>
-        </div>
-
-        {/* Action icons */}
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3, padding: "6px 0" }}>
-          <IconRailBtn onClick={onToggleSidebar} title={t("chromeRail.expandSidebar")}><PanelLeftOpen size={17} strokeWidth={1.5} /></IconRailBtn>
-          <IconRailBtn onClick={onNew} title={t("sidebar.newChat")}><Plus size={17} strokeWidth={1.5} /></IconRailBtn>
-          <IconRailBtn onClick={onOpenDispatch} title={t("sidebar.dispatch")}><Workflow size={17} strokeWidth={1.5} /></IconRailBtn>
-          <IconRailBtn onClick={onOpenNewProject} title={t("sidebar.newProject")}><FolderPlus size={17} strokeWidth={1.5} /></IconRailBtn>
-          {developerMode && <IconRailBtn onClick={onOpenProjectManager} title={t("sidebar.githubProjects")}><GitHubIcon size={17} /></IconRailBtn>}
-        </div>
-
-        <div style={{ flex: 1 }} />
-
-        {/* Footer icons */}
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 3, padding: "10px 0 14px" }}>
-          <IconRailBtn onClick={onPickFolder} title={cwdShort || t("sidebar.selectFolder")}><FolderOpen size={16} strokeWidth={1.5} /></IconRailBtn>
-          <div style={{ position: "relative" }}>
-            <IconRailBtn onClick={onOpenSettings} title={t("settings.title")}><SettingsIcon size={16} strokeWidth={1.5} /></IconRailBtn>
-            {hasUpdate && (
-              <span style={{
-                position: "absolute",
-                top: 4,
-                right: 4,
-                width: 7,
-                height: 7,
-                borderRadius: "50%",
-                background: "#FF8C42",
-                boxShadow: "0 0 5px rgba(255,140,66,0.8)",
-                pointerEvents: "none",
-              }} />
-            )}
-          </div>
-        </div>
-      </div>
-    );
-  }
+  // ── Windows collapsed: sidebar fully hidden; SidebarWindowsHeader overlay takes over ──
+  if (windowsChrome && !isOpen) return null;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
       {windowsChrome ? (
-        <div
-          style={{
-            height: WINDOW_DRAG_HEIGHT,
-            WebkitAppRegion: "drag",
-            flexShrink: 0,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-start",
-            paddingLeft: 18,
-            position: "relative",
-          }}
-        >
-          <button
-            onClick={() => window.open("https://ensuechat.com")}
-            title="RayLine"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              padding: 0,
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              opacity: 0.82,
-              transition: "opacity .15s",
-              WebkitAppRegion: "no-drag",
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.82"; }}
-          >
-            <img src={`${import.meta.env.BASE_URL}favicon.svg`} style={{ width: 22, height: 22, borderRadius: 5, display: "block", flexShrink: 0 }} draggable={false} />
-            <span style={{
-              fontFamily: "'Barlow Condensed', 'Inter Tight', sans-serif",
-              fontWeight: 600,
-              fontSize: 18,
-              letterSpacing: "0.12em",
-              color: "rgba(218,218,222,0.95)",
-              userSelect: "none",
-              lineHeight: 1,
-            }}>
-              R<span style={{ color: "#FF4422", letterSpacing: 0 }}>/</span>YLINE<span style={{ color: "#FF4422", letterSpacing: 0 }}>.</span>
-            </span>
-          </button>
-
-          <button
-            onClick={onToggleSidebar}
-            style={{
-              position: "absolute",
-              top: SIDEBAR_TOGGLE_TOP,
-              right: 10,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: SIDEBAR_TOGGLE_SIZE,
-              height: SIDEBAR_TOGGLE_SIZE,
-              borderRadius: 6,
-              background: "none",
-              border: "none",
-              color: "rgba(255,255,255,0.4)",
-              cursor: "pointer",
-              transition: "all .2s",
-              WebkitAppRegion: "no-drag",
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = "rgba(255,255,255,0.7)";
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = "rgba(255,255,255,0.4)";
-            }}
-          >
-            <PanelLeftClose size={17} strokeWidth={1.5} />
-          </button>
-        </div>
+        /* SidebarWindowsHeader (fixed overlay) 自己提供拖拽区域，这里不再设 drag */
+        <div style={{ height: WINDOW_DRAG_HEIGHT, flexShrink: 0 }} />
       ) : (
         <WindowDragSpacer />
       )}
@@ -765,43 +618,6 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, onT
           <FolderOpen size={10} strokeWidth={1.5} />
           {cwdShort || t("sidebar.selectFolder")}
         </button>
-        {windowsChrome && (
-          <button
-            onClick={onOpenSettings}
-            style={{
-              position: "relative",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: 22,
-              height: 22,
-              borderRadius: 5,
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              color: "rgba(255,255,255,0.45)",
-              transition: "color .2s",
-              padding: 0,
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.72)"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.color = "rgba(255,255,255,0.45)"; }}
-          >
-            <SettingsIcon size={12} strokeWidth={1.5} />
-            {hasUpdate && (
-              <span style={{
-                position: "absolute",
-                top: 0,
-                right: 0,
-                width: 6,
-                height: 6,
-                borderRadius: "50%",
-                background: "#FF8C42",
-                boxShadow: "0 0 4px rgba(255,140,66,0.7)",
-                pointerEvents: "none",
-              }} />
-            )}
-          </button>
-        )}
         <span style={{ fontSize: s(8), fontFamily: "'JetBrains Mono',monospace", color: "rgba(255,255,255,0.38)", letterSpacing: ".06em" }}>
           {t("sidebar.chatsCount", { value: convos.length })}
         </span>

--- a/src/components/SidebarWindowsHeader.jsx
+++ b/src/components/SidebarWindowsHeader.jsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import { PanelLeftClose, PanelLeftOpen, Plus, Settings } from "lucide-react";
+import { WINDOW_DRAG_HEIGHT } from "../windowChrome";
+
+const BTN_SIZE = 28;
+
+const SIDEBAR_WIDTH = 220;
+
+function WinBtn({ label, onClick, active = false, children }) {
+  const [hov, setHov] = useState(false);
+  return (
+    <button
+      type="button"
+      title={label}
+      onClick={onClick}
+      onMouseDownCapture={(e) => e.stopPropagation()}
+      onPointerDownCapture={(e) => e.stopPropagation()}
+      onMouseEnter={() => setHov(true)}
+      onMouseLeave={() => setHov(false)}
+      style={{
+        width: BTN_SIZE,
+        height: BTN_SIZE,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        border: "none", borderRadius: 6, padding: 0, cursor: "pointer",
+        background: active ? "rgba(255,255,255,0.055)" : hov ? "rgba(255,255,255,0.07)" : "transparent",
+        color: hov || active ? "rgba(255,255,255,0.82)" : "rgba(255,255,255,0.42)",
+        transition: "background .15s, color .15s",
+        WebkitAppRegion: "no-drag",
+        userSelect: "none",
+        flexShrink: 0,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function SidebarWindowsHeader({
+  sidebarOpen,
+  settingsOpen,
+  onToggleSidebar,
+  onNew,
+  onOpenSettings,
+  hasUpdate = false,
+}) {
+  return (
+    <div
+      onMouseDownCapture={(e) => e.stopPropagation()}
+      onPointerDownCapture={(e) => e.stopPropagation()}
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        width: SIDEBAR_WIDTH,
+        height: WINDOW_DRAG_HEIGHT,
+        zIndex: 1000,
+        display: "flex",
+        alignItems: "center",
+        paddingLeft: 18,
+        paddingRight: 6,
+        WebkitAppRegion: "drag",
+        userSelect: "none",
+        pointerEvents: "auto",
+      }}
+    >
+      {/* Logo — fixed anchor replacing Mac traffic lights */}
+      <button
+        onClick={() => window.open("https://ensuechat.com")}
+        title="RayLine"
+        onMouseDownCapture={(e) => e.stopPropagation()}
+        onPointerDownCapture={(e) => e.stopPropagation()}
+        style={{
+          display: "flex", alignItems: "center", gap: 8,
+          padding: 0, background: "none", border: "none", cursor: "pointer",
+          opacity: 0.82, transition: "opacity .15s",
+          WebkitAppRegion: "no-drag",
+        }}
+        onMouseEnter={(e) => { e.currentTarget.style.opacity = "1"; }}
+        onMouseLeave={(e) => { e.currentTarget.style.opacity = "0.82"; }}
+      >
+        <img
+          src={`${import.meta.env.BASE_URL}favicon.svg`}
+          style={{ width: 22, height: 22, borderRadius: 5, display: "block", flexShrink: 0 }}
+          draggable={false}
+        />
+        <span style={{
+          fontFamily: "'Barlow Condensed', 'Inter Tight', sans-serif",
+          fontWeight: 600, fontSize: 18, letterSpacing: "0.12em",
+          color: "rgba(218,218,222,0.95)", userSelect: "none", lineHeight: 1,
+        }}>
+          R<span style={{ color: "#FF4422", letterSpacing: 0 }}>/</span>YLINE
+          <span style={{ color: "#FF4422", letterSpacing: 0 }}>.</span>
+        </span>
+      </button>
+
+      {/* 三个按钮紧凑排列，整体与 logo 保持距离 */}
+      <div style={{ display: "flex", alignItems: "center", gap: 2, marginLeft: 16 }}>
+
+      {/* Expand / Collapse */}
+      <WinBtn
+        label={sidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+        onClick={onToggleSidebar}
+      >
+        {sidebarOpen
+          ? <PanelLeftClose size={15} strokeWidth={1.55} />
+          : <PanelLeftOpen size={15} strokeWidth={1.55} />}
+      </WinBtn>
+
+      {/* New chat */}
+      <WinBtn label="New chat" onClick={onNew}>
+        <Plus size={15} strokeWidth={1.6} />
+      </WinBtn>
+
+      {/* Settings */}
+      <div style={{ position: "relative" }}>
+        <WinBtn
+          label={settingsOpen ? "Close settings" : "Settings"}
+          onClick={onOpenSettings}
+          active={settingsOpen}
+        >
+          <Settings size={14} strokeWidth={1.55} />
+        </WinBtn>
+        {hasUpdate && (
+          <span style={{
+            position: "absolute", top: 4, right: 4,
+            width: 6, height: 6, borderRadius: "50%",
+            background: "#FF8C42", boxShadow: "0 0 4px rgba(255,140,66,0.7)",
+            pointerEvents: "none",
+          }} />
+        )}
+      </div>
+
+      </div>{/* end button group */}
+    </div>
+  );
+}

--- a/src/components/WindowDragSpacer.jsx
+++ b/src/components/WindowDragSpacer.jsx
@@ -8,8 +8,10 @@ import {
 } from "../windowChrome";
 
 const RAIL_HIT_PADDING = 8;
+// Width of the Windows fixed header overlay (SidebarWindowsHeader)
+const WIN_HEADER_RESERVE_WIDTH = 220;
 
-export default function WindowDragSpacer({ reserveSidebarRail = true }) {
+export default function WindowDragSpacer({ reserveSidebarRail = true, reserveWindowsHeader = false }) {
   const showRailReserve = reserveSidebarRail && IS_MAC;
   return (
     <div
@@ -29,6 +31,22 @@ export default function WindowDragSpacer({ reserveSidebarRail = true }) {
             left: Math.max(0, SIDEBAR_CHROME_RAIL_LEFT - RAIL_HIT_PADDING),
             width: SIDEBAR_CHROME_RAIL_WIDTH + RAIL_HIT_PADDING * 2,
             height: SIDEBAR_CHROME_RAIL_HEIGHT + RAIL_HIT_PADDING * 2,
+            WebkitAppRegion: "no-drag",
+            pointerEvents: "auto",
+            zIndex: 1,
+          }}
+        />
+      )}
+      {reserveWindowsHeader && (
+        /* Carve out the SidebarWindowsHeader zone so its buttons stay clickable.
+           pointerEvents must be "auto" — Electron ignores no-drag on pointer-events:none elements. */
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: WIN_HEADER_RESERVE_WIDTH,
+            height: WINDOW_DRAG_HEIGHT,
             WebkitAppRegion: "no-drag",
             pointerEvents: "auto",
             zIndex: 1,


### PR DESCRIPTION
 ## Summary / 概述                                                                                                                                                                                                                                                                                                                                   将 Windows 平台侧边栏交互体验对齐 macOS 风格：                                                                                                                            - Logo 作为固定锚点（替代 Mac 的系统控制按钮位置）                                                                                                                        - 展开/收起、新建对话、设置三个按钮始终固定在相同位置，不随侧边栏状态变化                                                                                                 - 侧边栏收起时完全隐藏（宽度归零），菜单列表消失，与 macOS 行为一致                                                                                                     

  ## Changes / 改动

  ### feat — Fixed chrome header overlay
  - New SidebarWindowsHeader.jsx: position:fixed overlay (220×52px, z=1000)，Logo + 3 按钮
  - App.jsx: Windows 下挂载新组件，sidebar 宽度收起时 52→0
  - Sidebar.jsx: 移除 icon-rail 分支，header 改为纯高度 spacer，清理未使用 import

  ### fix — Drag region unblocking
  - WindowDragSpacer.jsx: 新增 reserveWindowsHeader prop，插入 no-drag cutout（pointerEvents:auto）
  - ChatArea.jsx: Windows + sidebar 收起时传入 reserveWindowsHeader
  - Sidebar.jsx: 移除 Windows spacer 的 WebkitAppRegion:drag

  ### fix — Windows path display
  - Sidebar.jsx cwdShort: 改用 /[\\/]+/ 兼容反斜杠，filter(Boolean) 处理盘符空段