### PR TITLE
fix: add libxcrypt-compat to Arch container for fpm ruby compatibility

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -243,7 +243,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Install system dependencies
-        run: pacman -Sy --noconfirm git base-devel nodejs npm python github-cli
+        run: pacman -Sy --noconfirm git base-devel nodejs npm python github-cli libxcrypt-compat
 
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
electron-builder's bundled fpm binary requires libcrypt.so.1, which is no longer provided by default on modern Arch Linux. libxcrypt-compat restores the legacy libcrypt.so.1 shared library.