### PR TITLE
fix: run ldconfig after pacman install to refresh shared library cache

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -243,7 +243,9 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Install system dependencies
-        run: pacman -Sy --noconfirm git base-devel nodejs npm python github-cli libxcrypt-compat
+        run: |
+          pacman -Sy --noconfirm git base-devel nodejs npm python github-cli libxcrypt-compat
+          ldconfig
 
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
In an Arch Linux Docker container, pacman post-install hooks do not reliably invoke ldconfig, so libxcrypt-compat's libcrypt.so.1 is not registered in the dynamic linker cache. Calling ldconfig explicitly ensures fpm can find the library at runtime.