### PR TITLE
fix: correct pacman artifact glob from *.pkg.tar.zst to *.pacman

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -293,7 +293,7 @@ jobs:
         run: |
           rm -rf artifact
           mkdir -p artifact
-          find release -maxdepth 1 -type f -name "*.pkg.tar.zst" -exec cp {} artifact/ \;
+          find release -maxdepth 1 -type f -name "*.pacman" -exec cp {} artifact/ \;
           count=$(find artifact -maxdepth 1 -type f | wc -l | tr -d ' ')
           if [ "$count" -eq 0 ]; then
             echo "No pacman packages found in release/"


### PR DESCRIPTION
electron-builder outputs pacman packages with a .pacman extension, not the standard .pkg.tar.zst used by makepkg directly.