### PR TITLE
fix: linux pacman safe.directory and correct artifact filenames

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -262,6 +262,7 @@ jobs:
         run: |
           useradd -m builder
           chown -R builder:builder .
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Create GitHub release (tag push only)
         if: startsWith(github.ref, 'refs/tags/')

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -85,6 +85,7 @@ module.exports = {
     category: "Development",
     icon: "public/icon.png",
     maintainer: "Ensue Laboratories <contact@ensue.dev>",
+    artifactName: "${productName}-${version}.${ext}",
     target: ["AppImage", "deb", "rpm", "pacman", "tar.gz"],
   },
   asarUnpack: [


### PR DESCRIPTION
## Summary

Two follow-up fixes after merging the Linux packaging pipeline:

- **safe.directory**: `gh release upload` failed with *"detected dubious ownership"* because the workspace was `chown`'d to the `builder` user but `gh` runs as root. Added `git config --global --add safe.directory` immediately after the `chown` step.
- **artifactName**: `deb`, `rpm`, and `tar.gz` artifacts were named `ensue-*` (the npm package name) instead of `RayLine-*`. Set `artifactName: "${productName}-${version}.${ext}"` in the linux section of `electron-builder.config.cjs` to match the naming of AppImage, DMG, and EXE artifacts.

## Test plan

- [ ] Trigger `workflow_dispatch` and verify `rayline-linux-pacman` artifact is uploaded successfully
- [ ] Verify Linux artifact filenames are `RayLine-x.x.x.*` for all formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)