### PR TITLE
feat: replace fpm-based pacman packaging with a proper PKGBUILD

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -243,9 +243,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Install system dependencies
-        run: |
-          pacman -Sy --noconfirm git base-devel nodejs npm python github-cli libxcrypt-compat
-          ldconfig
+        run: pacman -Sy --noconfirm git base-devel nodejs npm python github-cli
 
       - name: Check out repository
         uses: actions/checkout@v4
@@ -258,11 +256,21 @@ jobs:
       - name: Build renderer
         run: npm run build
 
+      - name: Build app (unpacked)
+        run: npx electron-builder --config electron-builder.config.cjs --linux dir
+
+      - name: Prepare PKGBUILD sources
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          sed -i "s/^pkgver=.*/pkgver=${VERSION}/" build/arch/PKGBUILD
+          tar -czf build/arch/rayline-app.tar.gz -C release linux-unpacked
+          cp public/icon.png build/arch/icon.png
+
       - name: Set up non-root build user
         run: |
           useradd -m builder
-          chown -R builder:builder .
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          chown -R builder:builder build/arch
 
       - name: Create GitHub release (tag push only)
         if: startsWith(github.ref, 'refs/tags/')
@@ -275,29 +283,21 @@ jobs:
             --notes "Automated release for $TAG" \
             || true
 
-      - name: Package Linux (pacman)
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Build pacman package
         shell: bash
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            PUBLISH_FLAG="always"
-          else
-            PUBLISH_FLAG="never"
-          fi
-          sudo -u builder env HOME=/home/builder GH_TOKEN="$GH_TOKEN" \
-            npx electron-builder --config electron-builder.config.cjs --linux pacman \
-            --publish "$PUBLISH_FLAG"
+          cd build/arch
+          sudo -u builder env HOME=/home/builder makepkg -f --nodeps
 
       - name: Collect packaged files
         shell: bash
         run: |
           rm -rf artifact
           mkdir -p artifact
-          find release -maxdepth 1 -type f -name "*.pacman" -exec cp {} artifact/ \;
+          find build/arch -maxdepth 1 -type f -name "*.pkg.tar.zst" -exec cp {} artifact/ \;
           count=$(find artifact -maxdepth 1 -type f | wc -l | tr -d ' ')
           if [ "$count" -eq 0 ]; then
-            echo "No pacman packages found in release/"
+            echo "No pacman packages found"
             exit 1
           fi
           find artifact -maxdepth 1 -type f -print

--- a/build/arch/PKGBUILD
+++ b/build/arch/PKGBUILD
@@ -1,0 +1,46 @@
+# Maintainer: Ensue Laboratories <contact@ensue.dev>
+pkgname=rayline
+pkgver=0.1.7
+pkgrel=1
+pkgdesc="RayLine — a desktop client for Claude Code"
+arch=('x86_64')
+url="https://github.com/EnSue-Laboratories/RAYLINE"
+license=('LicenseRef-proprietary')
+depends=(
+    'c-ares'
+    'ffmpeg'
+    'gtk3'
+    'http-parser'
+    'libevent'
+    'libvpx'
+    'libxslt'
+    'libxss'
+    'minizip'
+    'nss'
+    're2'
+    'snappy'
+    'libnotify'
+    'libappindicator-gtk3'
+)
+options=('!strip')
+source=(
+    'rayline-app.tar.gz'
+    'icon.png'
+    'rayline.desktop'
+)
+sha256sums=('SKIP' 'SKIP' 'SKIP')
+
+package() {
+    install -dm755 "${pkgdir}/opt/RayLine"
+    cp -r "${srcdir}/linux-unpacked/"* "${pkgdir}/opt/RayLine/"
+    chmod 4755 "${pkgdir}/opt/RayLine/chrome-sandbox"
+
+    install -dm755 "${pkgdir}/usr/bin"
+    ln -s "/opt/RayLine/ensue" "${pkgdir}/usr/bin/rayline"
+
+    install -Dm644 "${srcdir}/icon.png" \
+        "${pkgdir}/usr/share/pixmaps/rayline.png"
+
+    install -Dm644 "${srcdir}/rayline.desktop" \
+        "${pkgdir}/usr/share/applications/rayline.desktop"
+}

--- a/build/arch/rayline.desktop
+++ b/build/arch/rayline.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=RayLine
+Comment=RayLine — a desktop client for Claude Code
+Exec=/opt/RayLine/ensue %U
+Icon=rayline
+Terminal=false
+Type=Application
+Categories=Development;
+StartupNotify=true

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -86,7 +86,7 @@ module.exports = {
     icon: "public/icon.png",
     maintainer: "Ensue Laboratories <contact@ensue.dev>",
     artifactName: "${productName}-${version}.${ext}",
-    target: ["AppImage", "deb", "rpm", "pacman", "tar.gz"],
+    target: ["AppImage", "deb", "rpm", "tar.gz"],
   },
   asarUnpack: [
     "electron/shell-init/**",


### PR DESCRIPTION
Adds build/arch/PKGBUILD and build/arch/rayline.desktop for packaging RayLine as a native Arch Linux package via makepkg. The CI job now:
- Builds the app with electron-builder --linux dir (unpacked only)
- Tars the unpacked directory as the PKGBUILD source
- Runs makepkg as a non-root builder user

This eliminates the fpm Ruby dependency and all associated libcrypt.so.1 compatibility issues. Also removes pacman from electron-builder targets since it is now handled entirely by the PKGBUILD.