### PR TITLE
images and terminal

### DIFF
--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -89,7 +89,7 @@ function buildClaudeArgs({ model, sessionId, resumeSessionId, forkSession }) {
 The user is interacting via a chat interface, not a terminal.
 Keep responses concise and conversational.
 Use markdown formatting — the client renders headings, code blocks, tables, lists, and mermaid diagrams.
-To show images inline, emit raw Markdown image syntax like ![alt text](https://example.com/image.png).
+To show an image inline, output the raw Markdown image itself, not a code block or a description: ![alt text](https://example.com/image.png). RayLine supports http/https image URLs, data: URLs, file:// URLs, absolute local paths, and ~/ paths like ![a](~/Downloads/a.jpg).
 When showing diagrams, prefer mermaid code blocks.
 Do not ask the user to run terminal commands — you have full tool access.
 For math, use LaTeX: $inline$ and $$block$$. Never wrap LaTeX in code blocks.

--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -89,6 +89,7 @@ function buildClaudeArgs({ model, sessionId, resumeSessionId, forkSession }) {
 The user is interacting via a chat interface, not a terminal.
 Keep responses concise and conversational.
 Use markdown formatting — the client renders headings, code blocks, tables, lists, and mermaid diagrams.
+To show images inline, emit raw Markdown image syntax like ![alt text](https://example.com/image.png).
 When showing diagrams, prefer mermaid code blocks.
 Do not ask the user to run terminal commands — you have full tool access.
 For math, use LaTeX: $inline$ and $$block$$. Never wrap LaTeX in code blocks.

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -143,7 +143,7 @@ You are running inside RayLine, a desktop GUI client for coding agents.
 The user is interacting via a chat interface, not a terminal.
 Keep responses concise and conversational.
 Use markdown formatting; the client renders headings, code blocks, tables, lists, and mermaid diagrams.
-To show images inline, emit raw Markdown image syntax like ![alt text](https://example.com/image.png).
+To show an image inline, output the raw Markdown image itself, not a code block or a description: ![alt text](https://example.com/image.png). RayLine supports http/https image URLs, data: URLs, file:// URLs, absolute local paths, and ~/ paths like ![a](~/Downloads/a.jpg).
 When showing diagrams, prefer mermaid code blocks.
 Do not ask the user to run terminal commands when you can do the work yourself.
 For math, use LaTeX: $inline$ and $$block$$. Never wrap LaTeX in code blocks.

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -143,6 +143,7 @@ You are running inside RayLine, a desktop GUI client for coding agents.
 The user is interacting via a chat interface, not a terminal.
 Keep responses concise and conversational.
 Use markdown formatting; the client renders headings, code blocks, tables, lists, and mermaid diagrams.
+To show images inline, emit raw Markdown image syntax like ![alt text](https://example.com/image.png).
 When showing diagrams, prefer mermaid code blocks.
 Do not ask the user to run terminal commands when you can do the work yourself.
 For math, use LaTeX: $inline$ and $$block$$. Never wrap LaTeX in code blocks.

--- a/electron/opencode-agent-manager.cjs
+++ b/electron/opencode-agent-manager.cjs
@@ -38,7 +38,7 @@ You are running inside RayLine, a desktop GUI client for coding agents.
 The user is interacting via a chat interface, not a terminal.
 Keep responses concise and conversational.
 Use markdown formatting; the client renders headings, code blocks, tables, lists, and mermaid diagrams.
-To show images inline, emit raw Markdown image syntax like ![alt text](https://example.com/image.png).
+To show an image inline, output the raw Markdown image itself, not a code block or a description: ![alt text](https://example.com/image.png). RayLine supports http/https image URLs, data: URLs, file:// URLs, absolute local paths, and ~/ paths like ![a](~/Downloads/a.jpg).
 When showing diagrams, prefer mermaid code blocks.
 Do not ask the user to run terminal commands when you can do the work yourself.
 For math, use LaTeX: $inline$ and $$block$$. Never wrap LaTeX in code blocks.

--- a/electron/opencode-agent-manager.cjs
+++ b/electron/opencode-agent-manager.cjs
@@ -38,6 +38,7 @@ You are running inside RayLine, a desktop GUI client for coding agents.
 The user is interacting via a chat interface, not a terminal.
 Keep responses concise and conversational.
 Use markdown formatting; the client renders headings, code blocks, tables, lists, and mermaid diagrams.
+To show images inline, emit raw Markdown image syntax like ![alt text](https://example.com/image.png).
 When showing diagrams, prefer mermaid code blocks.
 Do not ask the user to run terminal commands when you can do the work yourself.
 For math, use LaTeX: $inline$ and $$block$$. Never wrap LaTeX in code blocks.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3696,10 +3696,15 @@ export default function App() {
 
   const handleRefocusTerminal = () => {
     if (sidebarTerminalEnabled) {
-      setSidebarTerminalOpen(true);
+      if (sidebarTerminalOpen) {
+        terminal.focusActiveSession();
+        terminal.refitActiveSession();
+      }
       return;
     }
-    terminal.openWindow();
+    if (terminal.windowOpen) {
+      terminal.openWindow();
+    }
   };
 
   // ── Render ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- **fix: only focus terminal if already open; add inline image hint to agent prompts**
- **docs: clarify inline image instructions and list supported URL schemes**
