### PR TITLE
chore: sync package lock version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ensue",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ensue",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@xterm/addon-fit": "^0.12.0-beta.199",


### PR DESCRIPTION
## Summary
- Aligns the top-level `package-lock.json` version metadata with `package.json` at `0.1.8`.
- Leaves dependency resolutions unchanged.

## Validation
- Confirmed `package.json`, `package-lock.json.version`, and `package-lock.json.packages[""].version` all report `0.1.8`.
- `npm run build` passes; only the existing Vite large chunk / dynamic import warnings remain.
