### PR TITLE
fix(sidebar): match draft preview font to normal project rows

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -846,7 +846,7 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, cwd
                           overflow: "hidden",
                           textOverflow: "ellipsis",
                           whiteSpace: "nowrap",
-                          fontFamily: "var(--font-content)",
+                          fontFamily: "'Lato',system-ui,sans-serif",
                           fontWeight: 300,
                         }}
                       >


### PR DESCRIPTION
## Problem
Draft conversation rows in the sidebar rendered their secondary (preview) text with `var(--font-content)` — which resolves to `'Newsreader', serif` — while normal project rows (`ProjectGroup.jsx`) use `'Lato', system-ui, sans-serif`. The result was a serif preview line under drafts that visually clashed with the sans-serif preview used everywhere else.

## Fix
Use the same `'Lato', system-ui, sans-serif` stack for the draft preview text so it matches normal project rows. Font weight (300), size, and color are already identical.

`src/components/Sidebar.jsx` — 1 line.

## Test
Open the sidebar with at least one draft and one normal project conversation; the secondary preview lines should now use the same font.

🤖 Generated with [Claude Code](https://claude.com/claude-code)