### PR TITLE
perf: optimize streaming, typing & sidebar responsiveness (#226)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,10 @@ import { playChime } from "./utils/chime";
 const logCheckpoint = createLogger("checkpoint-ui");
 const logSendFlow = createLogger("send-flow");
 
+// How often the sidebar's live streaming preview text is allowed to refresh.
+// `isStreaming` still flips immediately; only the preview text is throttled.
+const SIDEBAR_PREVIEW_THROTTLE_MS = 500;
+
 function shouldPreviewRuntimeSetup() {
   if (typeof window === "undefined") return false;
   try {
@@ -2387,10 +2391,18 @@ export default function App() {
     });
   }, [dynamicModels]);
 
-  const handleNew = () => {
+  const handleNew = useCallback(() => {
     setShowSettings(false);
     setShowNewChatCard(true);
-  };
+  }, []);
+
+  // Stable callbacks for the memoized <Sidebar> (avoid new identities per render).
+  const handleOpenDispatch = useCallback(() => setShowDispatchCard(true), []);
+  const handleToggleSidebar = useCallback(() => setSidebarOpen((o) => !o), []);
+  const handleOpenProjectManager = useCallback(() => window.api?.openProjectManager(), []);
+  const handleOpenNewProject = useCallback(() => setShowNewProject(true), []);
+  const handleOpenSettings = useCallback(() => setShowSettings(true), []);
+  const handleToggleDraftsCollapsed = useCallback(() => setDraftsCollapsed((p) => !p), []);
 
   const handleToggleProjectCollapse = useCallback((cwdRoot, nextCollapsed) => {
     const projectRoot = getMainRepoRoot(cwdRoot);
@@ -3284,7 +3296,7 @@ export default function App() {
         titleText: text,
       });
     },
-    [activeConvo, active, activeData, appendLocalMessages, createConversationDraft, cwd, defaultModel, draftsPath, dynamicModels, enqueueQueuedMessage, getConversation, sendMessageToConversation]
+    [activeConvo, active, activeData, appendLocalMessages, createConversationDraft, cwd, defaultModel, draftsPath, dynamicModels, enqueueQueuedMessage, getConversation, handleNew, sendMessageToConversation]
   );
 
   // Process queued messages when streaming ends
@@ -3847,23 +3859,117 @@ export default function App() {
     [activeConvo, activeData.error, activeData.isStreaming, activeData.messages]
   );
 
-  // Build convos for Sidebar
+  // Build convos for Sidebar.
+  // The live preview for a streaming conversation is throttled so the sidebar
+  // row text only refreshes a few times per second (not on every stream commit),
+  // while `isStreaming` still flips promptly and the final preview stays accurate.
+  // Unchanged rows reuse their previous object identity so memoized children skip.
+  const sidebarRowCacheRef = useRef(new Map());
+  const sidebarPreviewMetaRef = useRef(new Map());
+  const [sidebarPreviewTick, setSidebarPreviewTick] = useState(0);
+  const sidebarFlushTimerRef = useRef(null);
+  const sidebarPendingFlushRef = useRef(false);
+
+  useEffect(() => () => {
+    if (sidebarFlushTimerRef.current) {
+      clearTimeout(sidebarFlushTimerRef.current);
+      sidebarFlushTimerRef.current = null;
+    }
+  }, []);
+
   const convosForSidebar = useMemo(() => {
+    // `sidebarPreviewTick` is a re-run trigger for throttled streaming-preview flushes.
+    void sidebarPreviewTick;
+    const now = Date.now();
     const rows = [];
+    const rowCache = sidebarRowCacheRef.current;
+    const previewMeta = sidebarPreviewMetaRef.current;
+    const seen = new Set();
+    let pendingStreamingFlush = false;
+
     for (const c of convoList) {
       const data = getConversation(c.id);
       if (c.id !== active && !hasConversationMessages(c, data)) continue;
+      seen.add(c.id);
 
       const msgs = data.messages || [];
       const lastMsg = msgs.length > 0 ? msgs[msgs.length - 1] : null;
-      rows.push({
+      const isStreaming = !!data.isStreaming;
+      const livePreview = getSidebarMessagePreview(lastMsg) || c.lastPreview || "Empty";
+
+      // Throttle preview updates while streaming; flush immediately when not streaming.
+      const meta = previewMeta.get(c.id);
+      let emittedPreview;
+      if (!isStreaming) {
+        emittedPreview = livePreview;
+        previewMeta.set(c.id, { preview: livePreview, ts: now });
+      } else if (!meta) {
+        emittedPreview = livePreview;
+        previewMeta.set(c.id, { preview: livePreview, ts: now });
+      } else if (livePreview === meta.preview) {
+        emittedPreview = meta.preview;
+      } else if (now - meta.ts >= SIDEBAR_PREVIEW_THROTTLE_MS) {
+        emittedPreview = livePreview;
+        previewMeta.set(c.id, { preview: livePreview, ts: now });
+      } else {
+        // Hold the previously emitted preview; schedule a flush so the latest
+        // streamed text eventually appears even if commits pause.
+        emittedPreview = meta.preview;
+        pendingStreamingFlush = true;
+      }
+
+      const prevRow = rowCache.get(c.id);
+      if (
+        prevRow &&
+        prevRow.__source === c &&
+        prevRow.lastPreview === emittedPreview &&
+        prevRow.isStreaming === isStreaming
+      ) {
+        // Reuse previous object identity so memoized rows skip re-render.
+        rows.push(prevRow);
+        continue;
+      }
+
+      const row = {
         ...c,
-        lastPreview: getSidebarMessagePreview(lastMsg) || c.lastPreview || "Empty",
-        isStreaming: data.isStreaming,
-      });
+        lastPreview: emittedPreview,
+        isStreaming,
+        __source: c,
+      };
+      rowCache.set(c.id, row);
+      rows.push(row);
     }
+
+    // Drop cache entries for conversations no longer rendered.
+    for (const id of rowCache.keys()) {
+      if (!seen.has(id)) rowCache.delete(id);
+    }
+    for (const id of previewMeta.keys()) {
+      if (!seen.has(id)) previewMeta.delete(id);
+    }
+
+    // Record whether a throttled flush is owed; the timer is armed in an effect
+    // (below) to keep this memo free of render-time side effects.
+    sidebarPendingFlushRef.current = pendingStreamingFlush;
     return rows;
-  }, [active, convoList, getConversation]);
+    // sidebarPreviewTick intentionally included so a throttled flush re-runs this memo.
+  }, [active, convoList, getConversation, sidebarPreviewTick]);
+
+  // Arm/disarm the throttled streaming-preview flush based on the latest memo
+  // run. Kept out of the memo body so render stays side-effect free.
+  useEffect(() => {
+    if (sidebarPendingFlushRef.current) {
+      if (!sidebarFlushTimerRef.current) {
+        sidebarFlushTimerRef.current = setTimeout(() => {
+          sidebarFlushTimerRef.current = null;
+          setSidebarPreviewTick((t) => t + 1);
+        }, SIDEBAR_PREVIEW_THROTTLE_MS);
+      }
+    } else if (sidebarFlushTimerRef.current) {
+      clearTimeout(sidebarFlushTimerRef.current);
+      sidebarFlushTimerRef.current = null;
+    }
+  }, [convosForSidebar]);
 
   const tabs = useMemo(
     () => (pinnedTabs.length > 1 ? pinnedTabs : []),
@@ -4119,17 +4225,17 @@ export default function App() {
             active={active}
             onSelect={handleSelect}
             onNew={handleNew}
-            onOpenDispatch={() => setShowDispatchCard(true)}
+            onOpenDispatch={handleOpenDispatch}
             onDelete={handleDelete}
-            onToggleSidebar={() => setSidebarOpen((o) => !o)}
+            onToggleSidebar={handleToggleSidebar}
             isOpen={useWindowsSidebarChrome ? sidebarOpen : true}
             windowsChrome={useWindowsSidebarChrome}
             locale={locale}
             cwd={activeConvo?.cwd === null ? (draftsPath || undefined) : (activeConvo?.cwd || cwd)}
             onPickFolder={handlePickFolder}
-            onOpenSettings={() => setShowSettings(true)}
-            onOpenProjectManager={() => window.api?.openProjectManager()}
-            onOpenNewProject={() => setShowNewProject(true)}
+            onOpenSettings={handleOpenSettings}
+            onOpenProjectManager={handleOpenProjectManager}
+            onOpenNewProject={handleOpenNewProject}
             projects={projects}
             draftsPath={draftsPath}
             onToggleProjectCollapse={handleToggleProjectCollapse}
@@ -4137,7 +4243,7 @@ export default function App() {
             onEditProjectContext={handleEditProjectContext}
             onNewInProject={handleNewInProject}
             draftsCollapsed={draftsCollapsed}
-            onToggleDraftsCollapsed={() => setDraftsCollapsed(p => !p)}
+            onToggleDraftsCollapsed={handleToggleDraftsCollapsed}
             developerMode={developerMode}
             multicaModels={dynamicModels}
             hasUpdate={hasUpdate}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1384,15 +1384,54 @@ export default function App() {
   const [queuedMessages, setQueuedMessages] = useState([]);
   const [permissionRequests, setPermissionRequests] = useState([]);
   const labControlTimersRef = useRef(new Map());
-  const persistableConversations = useMemo(
-    () =>
-      convoList
-        .map((conversation) =>
-          buildPersistedConversationSnapshot(conversation, getConversation(conversation.id))
-        )
-        .filter((conversation) => hasConversationMessages(conversation, getConversation(conversation.id))),
-    [convoList, getConversation]
-  );
+  // Per-conversation snapshot cache. Building the persisted snapshot for a
+  // conversation runs normalizeConversationState over its whole stored history,
+  // and the unmemoized version rebuilt ALL conversations on every stream commit
+  // (getConversation changes identity each commit) — with hundreds of chats that
+  // is a ~200ms main-thread task per commit, which blocks typing and scrolling
+  // while a response streams. Reuse the prior snapshot when the conversation row
+  // and its live data are unchanged, so only the actively-streaming conversation
+  // (whose data ref changes) is rebuilt each commit. Output is identical.
+  const persistSnapshotCacheRef = useRef(new Map());
+  const persistableConversations = useMemo(() => {
+    const cache = persistSnapshotCacheRef.current;
+    const seen = new Set();
+    const out = [];
+    for (const conversation of convoList) {
+      const data = getConversation(conversation.id);
+      // Snapshots with no live messages depend only on `conversation` (the early
+      // return in buildPersistedConversationSnapshot), so unloaded conversations
+      // — whose `data` is a fresh empty object each call — still cache by row
+      // identity alone instead of rebuilding every commit.
+      const hasLive =
+        Array.isArray(data?.messages) && data.messages.some(isPersistableLiveMessage);
+      seen.add(conversation.id);
+      const cached = cache.get(conversation.id);
+      const reusable =
+        cached &&
+        cached.conversation === conversation &&
+        cached.hasLive === hasLive &&
+        (!hasLive || cached.data === data);
+      let entry;
+      if (reusable) {
+        entry = cached;
+      } else {
+        entry = {
+          conversation,
+          data,
+          hasLive,
+          snapshot: buildPersistedConversationSnapshot(conversation, data),
+          keep: hasConversationMessages(conversation, data),
+        };
+        cache.set(conversation.id, entry);
+      }
+      if (entry.keep) out.push(entry.snapshot);
+    }
+    for (const id of [...cache.keys()]) {
+      if (!seen.has(id)) cache.delete(id);
+    }
+    return out;
+  }, [convoList, getConversation]);
   const persistedActive = useMemo(
     () => (
       persistableConversations.some((conversation) => conversation.id === active)

--- a/src/components/ChatArea.jsx
+++ b/src/components/ChatArea.jsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useCallback, useEffect } from "react";
+import { memo, useState, useRef, useCallback, useEffect, useMemo, useImperativeHandle } from "react";
 import { flushSync } from "react-dom";
 import { createTranslator } from "../i18n";
 import { ArrowRight, ArrowDown, Square, Terminal as TerminalIcon } from "lucide-react";
@@ -121,183 +121,72 @@ const ChatTranscript = memo(function ChatTranscript({
   );
 });
 
-export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen, onModelChange, defaultModel, queuedMessages, onUpdateQueuedMessage, onRemoveQueuedMessage, permissionRequests, onRespondPermission, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, draftsPath, onCwdChange, onRefocusTerminal, showNewChatCard, onCreateChat, onCancelNewChat, allCwdRoots, projects, defaultPrBranch, newChatDefaultCwd, coauthorEnabled = false, coauthorTrailer = "", onControlChange, canControlTarget, developerMode = true, tabs = [], activeTabId = null, onSelectTab, onCloseTab, windowControlsVisible = false, locale, runtimeSetup = null, extraModels = [] }) {
-  const s = useFontScale();
-  const t = createTranslator(locale);
-  const isDraftContext = showNewChatCard ? newChatDefaultCwd == null : isDraftConversation(convo, draftsPath);
-  const [input, setInput]             = useState("");
+// Composer subtree (permission banners, queued messages, slash palette, image
+// preview, hints, the input box + send/cancel button, and the hint footer).
+//
+// This owns ALL the URGENT, keystroke-driven local state — `input`,
+// `attachments`, `inputFocused`, slash-command palette selection, drag-over,
+// and queued-message edit drafts — plus the textarea ref and autosize.
+//
+// It is wrapped in `memo` and takes only primitives / stable callbacks (NOT the
+// whole `convo`/`msgs`), so streaming-driven re-renders of the ChatArea body do
+// NOT re-render it. Conversely, typing only re-renders this component, never the
+// transcript, header, or scroll machinery in ChatArea.
+const ChatComposer = memo(function ChatComposer({
+  composerRef,
+  onSend,
+  onCancel,
+  isStreaming,
+  setupRequired,
+  shellLocation,
+  permissionRequests,
+  onRespondPermission,
+  queuedMessages,
+  onUpdateQueuedMessage,
+  onRemoveQueuedMessage,
+  isMulticaModel,
+  showNewChatCard,
+  branchNeedsAttention,
+  branchHintText,
+  convoId,
+  hasWallpaper,
+  t,
+  s,
+}) {
+  const [input, setInput] = useState("");
   const [inputFocused, setInputFocused] = useState(false);
-  const [attachments, setAttachments]   = useState([]);
+  const [attachments, setAttachments] = useState([]);
   const [editingQueueId, setEditingQueueId] = useState(null);
   const [queueDraft, setQueueDraft] = useState("");
-  const endRef  = useRef(null);
-  const inRef   = useRef(null);
+  const [selectedCmd, setSelectedCmd] = useState(0);
+  const [dragOver, setDragOver] = useState(false);
+  const [branchHintDismissedFor, setBranchHintDismissedFor] = useState(null);
+
+  const inRef = useRef(null);
   const queueEditRef = useRef(null);
   const dragDepthRef = useRef(0);
   const composingRef = useRef(false);
-  // Callback ref so the ResizeObserver re-attaches when the message body
-  // re-mounts (e.g. showNewChatCard toggling). Keep the ref object too so
-  // SelectionToolbar can still read .current.
-  const messageBodyRef = useRef(null);
-  const [messageBodyEl, setMessageBodyEl] = useState(null);
-  const setMessageBodyNode = useCallback((node) => {
-    messageBodyRef.current = node;
-    setMessageBodyEl(node);
-  }, []);
 
-  // Scroll to bottom on new messages and during streaming
-  const scrollRef = useRef(null);
-  const msgCount = convo?.msgs?.length || 0;
-  const lastMsg = convo?.msgs?.[msgCount - 1];
-  const lastParts = lastMsg?.parts;
-  const lastPartText = lastParts?.[lastParts.length - 1]?.text || lastMsg?.text;
-  const prevMsgCount = useRef(0);
-  // Sticky follow-mode: true until the user actively scrolls up, flips back
-  // on when they return to the bottom. Ref (not state) so rapid streaming
-  // updates don't trigger re-renders and stay in sync with scroll events.
-  const followingRef = useRef(true);
-
-  // Reset follow state on conversation switch so chat B doesn't inherit
-  // chat A's "user scrolled up" state.
-  useEffect(() => {
-    followingRef.current = true;
-    prevMsgCount.current = 0;
-  }, [convo?.id]);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    // New message (count INCREASED) → force follow on and smooth-scroll to bottom
-    if (msgCount > prevMsgCount.current) {
-      prevMsgCount.current = msgCount;
-      followingRef.current = true;
-      endRef.current?.scrollIntoView({ behavior: "smooth" });
-      return;
-    }
-
-    // Count decreased (edit rewind, /clear, /compact) → track the new count
-    // but don't hijack the user's scroll position.
-    if (msgCount < prevMsgCount.current) {
-      prevMsgCount.current = msgCount;
-      return;
-    }
-
-    // Streaming update → pin to bottom instantly so chunks can't outrun us
-    if (followingRef.current) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [msgCount, convo?.isStreaming, lastPartText]);
-
-  // Pin to bottom whenever content height changes while following. Catches
-  // renders that don't trigger the text-diff effect above — LoadingStatus
-  // growing an extra line when usage arrives, thinking blocks expanding,
-  // mermaid/katex rendering in late, etc.
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el || !messageBodyEl || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => {
-      if (followingRef.current) {
-        el.scrollTop = el.scrollHeight;
-      }
-    });
-    ro.observe(messageBodyEl);
-    return () => ro.disconnect();
-  }, [messageBodyEl]);
-
-  // Track whether the user is near the bottom to toggle the scroll-to-bottom
-  // button, and maintain follow-mode based on user scroll direction.
-  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
-  const showScrollToBottomRef = useRef(false);
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    let lastScrollTop = el.scrollTop;
-    // Gate "user scrolled up" detection behind recent real user input.
-    // Otherwise content shrink (thinking block collapses, images clamping
-    // scrollTop) and trackpad momentum bounce silently kill follow-mode.
-    let userIntentUntil = 0;
-    const markIntent = () => { userIntentUntil = Date.now() + 500; };
-
-    const handleScroll = () => {
-      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-      // Require both a meaningful delta and recent user input to disable follow.
-      if (el.scrollTop < lastScrollTop - 8 && Date.now() < userIntentUntil) {
-        followingRef.current = false;
-      }
-      // Reached the bottom again → resume following
-      if (distanceFromBottom < 40) {
-        followingRef.current = true;
-      }
-      lastScrollTop = el.scrollTop;
-      const nextShowScrollToBottom = distanceFromBottom > 120;
-      if (showScrollToBottomRef.current !== nextShowScrollToBottom) {
-        showScrollToBottomRef.current = nextShowScrollToBottom;
-        setShowScrollToBottom(nextShowScrollToBottom);
-      }
-    };
-    handleScroll();
-    el.addEventListener("scroll", handleScroll, { passive: true });
-    el.addEventListener("wheel", markIntent, { passive: true });
-    el.addEventListener("touchstart", markIntent, { passive: true });
-    el.addEventListener("pointerdown", markIntent, { passive: true });
-    el.addEventListener("keydown", markIntent);
-    return () => {
-      el.removeEventListener("scroll", handleScroll);
-      el.removeEventListener("wheel", markIntent);
-      el.removeEventListener("touchstart", markIntent);
-      el.removeEventListener("pointerdown", markIntent);
-      el.removeEventListener("keydown", markIntent);
-    };
-  }, [convo?.id, msgCount]);
-
-  const scrollToBottom = useCallback(() => {
-    followingRef.current = true;
-    endRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, []);
-
-  const isStreaming = convo?.isStreaming;
-
-  // Slash command suggestions
-  const COMMANDS = [
+  // Slash command suggestions (memoized so streaming/keystrokes don't rebuild
+  // the array; depends only on the translator).
+  const COMMANDS = useMemo(() => [
     { cmd: "/clear", desc: t("chatArea.cmdClearDesc") },
     { cmd: "/new", desc: t("chatArea.cmdClearDesc") },
     { cmd: "/compact", desc: t("chatArea.cmdCompactDesc") },
-  ];
+  ], [t]);
+
   const showCommands = input.startsWith("/") && !input.includes(" ");
   const filteredCommands = showCommands
     ? COMMANDS.filter(c => c.cmd.startsWith(input.toLowerCase()))
     : [];
-  const [selectedCmd, setSelectedCmd] = useState(0);
+
   const trimmedInput = input.trim();
   const shellMode = trimmedInput.startsWith("!");
   const canRunShell = shellMode && trimmedInput.length > 1;
-  const setupRequired = Boolean(runtimeSetup?.required);
   const canSend = shellMode ? canRunShell : !setupRequired && (Boolean(trimmedInput) || attachments.length > 0);
-  const shellLocation = cwd ? (() => {
-    const parts = cwd.split("/");
-    const wtIdx = parts.indexOf(".worktrees");
-    if (wtIdx >= 0 && wtIdx + 1 < parts.length) {
-      return `${parts[wtIdx - 1]} / ${parts[wtIdx + 1]}`;
-    }
-    return parts.slice(-2).join("/") || parts[parts.length - 1] || cwd;
-  })() : "current workspace";
 
-  const activeModelId = convo?.model || defaultModel;
-  const isMulticaModel = isMulticaModelId(activeModelId);
-  const { status: gitStatus } = useGitStatus(cwd);
-  const hasDirtyWorktree = (gitStatus?.files?.length || 0) > 0;
-  const hasNoUpstream = Boolean(gitStatus?.branch) && !gitStatus?.upstream && !gitStatus?.detached;
-  const branchNeedsAttention = hasDirtyWorktree || hasNoUpstream;
-  const convoId = convo?.id ?? null;
-  const [branchHintDismissedFor, setBranchHintDismissedFor] = useState(null);
   const branchHintDismissed = Boolean(convoId && branchHintDismissedFor === convoId);
   const showBranchHint = isMulticaModel && !showNewChatCard && branchNeedsAttention && !branchHintDismissed && !shellMode;
-  const branchHintText = (() => {
-    if (hasDirtyWorktree && hasNoUpstream) return t("chatArea.branchWarnBoth");
-    if (hasDirtyWorktree) return t("chatArea.branchWarnDirty");
-    return t("chatArea.branchWarnNoUpstream");
-  })();
 
   const send = useCallback(() => {
     if (!canSend) return;
@@ -370,8 +259,6 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
     });
   }, []);
 
-  const [dragOver, setDragOver] = useState(false);
-
   const resetDragState = useCallback(() => {
     dragDepthRef.current = 0;
     setDragOver(false);
@@ -389,17 +276,6 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
       setAttachments((prev) => [...prev, ...nextAttachments]);
     });
   }, [resetDragState]);
-
-  const showHeaderTabs = tabs.length > 0 && !showNewChatCard;
-  const showConversationTitle = Boolean(convo && !showNewChatCard);
-  const topTabsLeft = sidebarOpen
-    ? 18
-    : IS_MAC
-      ? SIDEBAR_CHROME_RAIL_LEFT + SIDEBAR_CHROME_RAIL_WIDTH + 16
-      : 18;
-  const topTabsRight = windowControlsVisible ? 126 : 24;
-  const headerContentOffset = showHeaderTabs ? 8 : 0;
-  const headerLeftPadding = sidebarOpen ? 24 : IS_MAC ? 50 : 24;
 
   const handleDragEnter = useCallback((e) => {
     if (!dataTransferHasFiles(e.dataTransfer)) return;
@@ -437,25 +313,9 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
     };
   }, [resetDragState]);
 
-  useEffect(() => {
-    const preventNav = (e) => { e.preventDefault(); };
-    window.addEventListener("dragover", preventNav);
-    window.addEventListener("drop", preventNav);
-    return () => {
-      window.removeEventListener("dragover", preventNav);
-      window.removeEventListener("drop", preventNav);
-    };
-  }, []);
-
   const removeAttachment = useCallback((index) => {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
   }, []);
-
-  const handleTranscriptAnswer = useCallback((text) => {
-    onSend(text);
-  }, [onSend]);
-
-  const handlePickFolder = useCallback(() => window.api?.pickFolder?.(), []);
 
   const startQueuedEdit = useCallback((item) => {
     if (!item?.id) return;
@@ -512,18 +372,715 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
     el.style.height = `${Math.min(Math.max(el.scrollHeight, 24), 52)}px`;
   }, [editingQueueId, queueDraft]);
 
-  // Selection toolbar handlers
-  const handleQuote = useCallback((text) => {
-    const quoted = text.split("\n").map(l => `> ${l}`).join("\n");
-    setInput((prev) => prev ? `${prev}\n\n${quoted}\n\n` : `${quoted}\n\n`);
-    // Expand textarea to fit
-    setTimeout(() => {
-      if (inRef.current) {
-        inRef.current.style.height = "20px";
-        inRef.current.style.height = Math.min(inRef.current.scrollHeight, 120) + "px";
-        inRef.current.focus();
+  // Imperative handle so ChatArea (which owns the full-pane drag region and the
+  // SelectionToolbar) can drive the composer's OWN local state without lifting
+  // `input`/`attachments`/`dragOver` back up — that lift would re-couple typing
+  // with streaming re-renders. Quoting appends to the composer input; the drag
+  // handlers keep the whole-pane drop zone + drag-over highlight working exactly
+  // as before.
+  useImperativeHandle(composerRef, () => ({
+    quote(text) {
+      const quoted = text.split("\n").map(l => `> ${l}`).join("\n");
+      setInput((prev) => prev ? `${prev}\n\n${quoted}\n\n` : `${quoted}\n\n`);
+      // Expand textarea to fit
+      setTimeout(() => {
+        if (inRef.current) {
+          inRef.current.style.height = "20px";
+          inRef.current.style.height = Math.min(inRef.current.scrollHeight, 120) + "px";
+          inRef.current.focus();
+        }
+      }, 0);
+    },
+    handleDrop,
+    handleDragEnter,
+    handleDragOver,
+    handleDragLeave,
+    resetDragState,
+  }), [handleDrop, handleDragEnter, handleDragOver, handleDragLeave, resetDragState]);
+
+  return (
+    <div
+      style={{ padding: "12px 28px 24px", display: "flex", justifyContent: "center" }}
+    >
+      <div style={{ width: "100%", maxWidth: 560 }}>
+        {permissionRequests && permissionRequests.length > 0 && (
+          <div style={{ marginBottom: 8 }}>
+            {permissionRequests.map((req) => {
+              const actionButtonStyle = {
+                height: 24,
+                padding: "0 9px",
+                borderRadius: 7,
+                border: "1px solid var(--control-border)",
+                background: "transparent",
+                color: "var(--text-disabled)",
+                cursor: "pointer",
+                fontSize: s(9),
+                fontFamily: "var(--font-mono)",
+                letterSpacing: ".05em",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+              };
+              const labelText = req.isSensitiveFile ? "SENSITIVE" : "PERMISSION";
+              const tool = req.toolName || "Tool";
+              const summary = req.summary || "";
+              return (
+                <div
+                  key={req.requestId}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "6px 8px",
+                    marginBottom: 4,
+                    background: "var(--control-bg-subtle)",
+                    border: "1px solid var(--control-border-soft)",
+                    borderRadius: 12,
+                    fontSize: s(12),
+                    color: "var(--text-subtle)",
+                    fontFamily: "var(--font-ui)",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+                      <span style={{
+                        fontSize: s(9),
+                        fontFamily: "var(--font-mono)",
+                        color: "var(--text-faint)",
+                        letterSpacing: ".06em",
+                        flexShrink: 0,
+                      }}>
+                        {labelText}
+                      </span>
+                      <span style={{
+                        fontSize: s(9),
+                        fontFamily: "var(--font-mono)",
+                        color: "var(--text-disabled)",
+                        letterSpacing: ".06em",
+                      }}>
+                        {String(tool).toUpperCase()}
+                      </span>
+                    </div>
+                    <div style={{
+                      flex: 1,
+                      minWidth: 0,
+                      padding: "2px 8px",
+                      transform: "translateY(-1.5px)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                      lineHeight: "18px",
+                      color: "var(--text-secondary)",
+                    }}
+                      title={summary}
+                    >
+                      {summary}
+                    </div>
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+                    <button
+                      onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "allow", scope: "once" })}
+                      style={{
+                        ...actionButtonStyle,
+                        background: "var(--control-bg)",
+                        color: "var(--text-secondary)",
+                      }}
+                      title="Allow this request once"
+                    >
+                      ALLOW ONCE
+                    </button>
+                    <button
+                      onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "allow", scope: "session" })}
+                      style={actionButtonStyle}
+                      title="Allow this tool + target for the rest of the session"
+                    >
+                      ALLOW SESSION
+                    </button>
+                    <button
+                      onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "deny" })}
+                      style={actionButtonStyle}
+                      title="Deny this request"
+                    >
+                      DENY
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        {queuedMessages && queuedMessages.length > 0 && (
+          <div style={{ marginBottom: 8 }}>
+            {queuedMessages.map((q, i) => {
+              const isEditingQueueItem = editingQueueId === q.id;
+              const attachmentCount = Array.isArray(q.attachments) ? q.attachments.length : 0;
+              const queueActionButtonStyle = {
+                height: 24,
+                padding: "0 9px",
+                borderRadius: 7,
+                border: "1px solid var(--control-border)",
+                background: "transparent",
+                color: "var(--text-disabled)",
+                cursor: "pointer",
+                fontSize: s(9),
+                fontFamily: "var(--font-mono)",
+                letterSpacing: ".05em",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+              };
+              return (
+                <div
+                  key={q.id || i}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    padding: "6px 8px",
+                    marginBottom: 4,
+                    background: "var(--control-bg-subtle)",
+                    border: "1px solid var(--control-border-soft)",
+                    borderRadius: 12,
+                    fontSize: s(12),
+                    color: "var(--text-subtle)",
+                    fontFamily: "var(--font-ui)",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+                      <span style={{
+                        fontSize: s(9),
+                        fontFamily: "var(--font-mono)",
+                        color: "var(--text-faint)",
+                        letterSpacing: ".06em",
+                        flexShrink: 0,
+                      }}>
+                        {i === 0 ? t("chatArea.queuedNext") : t("chatArea.queued")}
+                      </span>
+                      {attachmentCount > 0 && (
+                        <span style={{
+                          fontSize: s(9),
+                          fontFamily: "var(--font-mono)",
+                          color: "var(--text-faint)",
+                          letterSpacing: ".06em",
+                        }}>
+                          {t("chatArea.attachmentsCount", { value: attachmentCount, suffix: attachmentCount === 1 ? "" : "S" })}
+                        </span>
+                      )}
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      {isEditingQueueItem ? (
+                        <textarea
+                          ref={queueEditRef}
+                          value={queueDraft}
+                          onChange={(event) => setQueueDraft(event.target.value)}
+                          onKeyDown={(event) => handleQueuedDraftKeyDown(event, q.id)}
+                          rows={1}
+                          style={{
+                            width: "100%",
+                            background: "var(--control-bg-subtle)",
+                            border: "1px solid var(--control-border-soft)",
+                            borderRadius: 7,
+                            padding: "2px 8px",
+                            color: "var(--text-primary)",
+                            fontSize: s(12),
+                            lineHeight: "18px",
+                            fontFamily: "inherit",
+                            resize: "none",
+                            minHeight: 24,
+                            maxHeight: 52,
+                            overflowY: "auto",
+                          }}
+                        />
+                      ) : (
+                        <div style={{
+                          minHeight: 24,
+                          display: "flex",
+                          alignItems: "center",
+                          padding: "2px 8px",
+                          transform: "translateY(-1.5px)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          lineHeight: "18px",
+                          color: "var(--text-secondary)",
+                        }}>
+                          {q.text}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 4,
+                      flexShrink: 0,
+                    }}
+                  >
+                    {isEditingQueueItem ? (
+                      <>
+                        <button
+                          onClick={() => saveQueuedEdit(q.id)}
+                          style={{
+                            ...queueActionButtonStyle,
+                            background: "var(--control-bg)",
+                            color: "var(--text-secondary)",
+                          }}
+                        >
+                          {t("common.save")}
+                        </button>
+                        <button
+                          onClick={cancelQueuedEdit}
+                          style={queueActionButtonStyle}
+                        >
+                          {t("common.cancel")}
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => startQueuedEdit(q)}
+                          style={queueActionButtonStyle}
+                        >
+                          {t("common.edit")}
+                        </button>
+                        <button
+                          onClick={() => removeQueuedItem(q.id)}
+                          style={queueActionButtonStyle}
+                        >
+                          {t("common.delete")}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        {/* Slash command palette */}
+        {filteredCommands.length > 0 && (
+          <div style={{
+            marginBottom: 6,
+            background: hasWallpaper ? "var(--pane-elevated)" : "var(--overlay-surface)",
+            border: "1px solid var(--control-border)",
+            borderRadius: 10,
+            padding: "4px",
+            backdropFilter: "blur(20px)",
+            boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
+          }}>
+            {filteredCommands.map((c, i) => (
+              <div
+                key={c.cmd}
+                onClick={() => { setInput(c.cmd); setSelectedCmd(0); }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  padding: "6px 10px",
+                  borderRadius: 7,
+                  cursor: "pointer",
+                  background: i === selectedCmd ? "var(--control-bg)" : "transparent",
+                  transition: "background .1s",
+                }}
+                onMouseEnter={() => setSelectedCmd(i)}
+              >
+                <span style={{
+                  fontSize: s(12),
+                  fontFamily: "var(--font-mono)",
+                  color: "var(--text-secondary)",
+                }}>{c.cmd}</span>
+                <span style={{
+                  fontSize: s(11),
+                  color: "var(--text-disabled)",
+                  fontFamily: "var(--font-ui)",
+                }}>{c.desc}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        <MemoImagePreview items={attachments} onRemove={removeAttachment} />
+        {shellMode && (
+          <div
+            style={{
+              marginBottom: 6,
+              fontSize: s(10),
+              fontFamily: "var(--font-mono)",
+              letterSpacing: ".1em",
+              color: "var(--text-muted)",
+            }}
+          >
+            {canRunShell
+              ? t("chatArea.shellModeReady", { loc: shellLocation })
+              : t("chatArea.shellModeEmpty")}
+          </div>
+        )}
+        {showBranchHint && (
+          <div
+            style={{
+              marginBottom: 6,
+              fontSize: s(10),
+              fontFamily: "var(--font-mono)",
+              letterSpacing: ".1em",
+              color: "var(--warning-text)",
+            }}
+          >
+            {branchHintText}
+          </div>
+        )}
+
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            background: dragOver
+              ? "var(--accent-bg)"
+              : (inputFocused ? "var(--control-bg)" : "var(--control-bg-subtle)"),
+            border: (shellMode ? "2px solid " : "1px solid ") + (
+              dragOver
+                ? "var(--accent-border)"
+                : (inputFocused ? "var(--control-border-strong)" : "var(--control-border)")
+            ),
+            borderRadius: 12,
+            padding: shellMode ? "8px 13px" : "9px 14px",
+            backdropFilter: "blur(20px)",
+            boxShadow: dragOver ? "0 0 0 1px rgba(153,214,255,0.08)" : "none",
+            transition: "border-color .25s, background .25s, box-shadow .25s",
+          }}
+        >
+          <textarea
+            ref={inRef}
+            value={input}
+            onChange={handleInput}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => { composingRef.current = true; }}
+            onCompositionEnd={() => { composingRef.current = false; }}
+            onPaste={handlePaste}
+            onFocus={() => setInputFocused(true)}
+            onBlur={() => {
+              composingRef.current = false;
+              setInputFocused(false);
+            }}
+            placeholder={setupRequired && !shellMode ? "Install a runtime to start chatting" : (shellMode ? t("chatArea.placeholderShell") : t("chatArea.placeholderAsk"))}
+            rows={1}
+            style={{
+              flex: 1,
+              background: "transparent",
+              border: "none",
+              resize: "none",
+              color: "var(--text-primary)",
+              fontSize: s(13),
+              lineHeight: 1.5,
+              fontFamily: "var(--font-ui)",
+              maxHeight: 120,
+              height: "auto",
+              display: "block",
+              overflow: "auto",
+            }}
+          />
+          {isStreaming && !input.trim() ? (
+            <button
+              onClick={onCancel}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: 30,
+                height: 30,
+                borderRadius: 8,
+                flexShrink: 0,
+                background: "var(--control-bg-strong)",
+                border: "1px solid var(--control-border-strong)",
+                color: "var(--text-muted)",
+                cursor: "pointer",
+                transition: "all .2s",
+              }}
+              onMouseEnter={(e) => { e.currentTarget.style.background = "var(--control-bg-active)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "var(--control-bg-strong)"; }}
+            >
+              <Square size={10} fill="currentColor" />
+            </button>
+          ) : (
+            <button
+              onClick={send}
+              disabled={!canSend}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: shellMode ? 6 : 0,
+                width: shellMode ? "auto" : 30,
+                height: 30,
+                padding: shellMode ? "0 12px" : 0,
+                borderRadius: 8,
+                flexShrink: 0,
+                background: canSend ? "var(--text-primary)" : "var(--control-bg-subtle)",
+                border: "none",
+                color: canSend ? "var(--text-inverse)" : "var(--text-faint)",
+                cursor: canSend ? "pointer" : "default",
+                transition: "all .3s cubic-bezier(.16,1,.3,1)",
+                transform: canSend ? "scale(1)" : "scale(0.88)",
+              }}
+            >
+              {shellMode ? (
+                <>
+                  <TerminalIcon size={14} strokeWidth={1.6} />
+                  <span
+                    style={{
+                      fontSize: s(10),
+                      fontFamily: "var(--font-mono)",
+                      letterSpacing: ".1em",
+                    }}
+                  >
+                    {t("chatArea.run")}
+                  </span>
+                </>
+              ) : (
+                <ArrowRight size={16} strokeWidth={1.5} />
+              )}
+            </button>
+          )}
+        </div>
+
+        <div
+          style={{
+            textAlign: "center",
+            marginTop: 8,
+            fontSize: s(8),
+            fontFamily: "var(--font-mono)",
+            color: "var(--text-muted)",
+            letterSpacing: ".1em",
+          }}
+        >
+          {shellMode
+            ? (canRunShell
+                ? t("chatArea.hintShellRun")
+                : t("chatArea.hintShellEmpty"))
+            : t("chatArea.hintChat")}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen, onModelChange, defaultModel, queuedMessages, onUpdateQueuedMessage, onRemoveQueuedMessage, permissionRequests, onRespondPermission, onToggleTerminal, terminalOpen, terminalCount, wallpaper, cwd, draftsPath, onCwdChange, onRefocusTerminal, showNewChatCard, onCreateChat, onCancelNewChat, allCwdRoots, projects, defaultPrBranch, newChatDefaultCwd, coauthorEnabled = false, coauthorTrailer = "", onControlChange, canControlTarget, developerMode = true, tabs = [], activeTabId = null, onSelectTab, onCloseTab, windowControlsVisible = false, locale, runtimeSetup = null, extraModels = [] }) {
+  const s = useFontScale();
+  const t = useMemo(() => createTranslator(locale), [locale]);
+  const isDraftContext = showNewChatCard ? newChatDefaultCwd == null : isDraftConversation(convo, draftsPath);
+  const endRef  = useRef(null);
+  const composerApiRef = useRef(null);
+  // Callback ref so the ResizeObserver re-attaches when the message body
+  // re-mounts (e.g. showNewChatCard toggling). Keep the ref object too so
+  // SelectionToolbar can still read .current.
+  const messageBodyRef = useRef(null);
+  const [messageBodyEl, setMessageBodyEl] = useState(null);
+  const setMessageBodyNode = useCallback((node) => {
+    messageBodyRef.current = node;
+    setMessageBodyEl(node);
+  }, []);
+
+  // Scroll to bottom on new messages and during streaming
+  const scrollRef = useRef(null);
+  const msgCount = convo?.msgs?.length || 0;
+  const lastMsg = convo?.msgs?.[msgCount - 1];
+  const lastParts = lastMsg?.parts;
+  const lastPartText = lastParts?.[lastParts.length - 1]?.text || lastMsg?.text;
+  const prevMsgCount = useRef(0);
+  // Sticky follow-mode: true until the user actively scrolls up, flips back
+  // on when they return to the bottom. Ref (not state) so rapid streaming
+  // updates don't trigger re-renders and stay in sync with scroll events.
+  const followingRef = useRef(true);
+
+  // Coalesce all "pin to bottom" layout writes (streaming chunks + late
+  // image/katex/mermaid/tool resizes) into a single requestAnimationFrame so we
+  // never do multiple synchronous scrollTop writes per frame. Follow-mode and
+  // intent detection are untouched — this only batches the WRITE.
+  const scrollPinFrameRef = useRef(null);
+  const schedulePinToBottom = useCallback(() => {
+    if (scrollPinFrameRef.current != null) return;
+    scrollPinFrameRef.current = requestAnimationFrame(() => {
+      scrollPinFrameRef.current = null;
+      const el = scrollRef.current;
+      if (followingRef.current && el) el.scrollTop = el.scrollHeight;
+    });
+  }, []);
+
+  const cancelPinFrame = useCallback(() => {
+    if (scrollPinFrameRef.current != null) {
+      cancelAnimationFrame(scrollPinFrameRef.current);
+      scrollPinFrameRef.current = null;
+    }
+  }, []);
+
+  // Reset follow state on conversation switch so chat B doesn't inherit
+  // chat A's "user scrolled up" state.
+  useEffect(() => {
+    followingRef.current = true;
+    prevMsgCount.current = 0;
+    cancelPinFrame();
+  }, [convo?.id, cancelPinFrame]);
+
+  // Cancel any pending pin frame on unmount.
+  useEffect(() => cancelPinFrame, [cancelPinFrame]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    // New message (count INCREASED) → force follow on and smooth-scroll to bottom
+    if (msgCount > prevMsgCount.current) {
+      prevMsgCount.current = msgCount;
+      followingRef.current = true;
+      endRef.current?.scrollIntoView({ behavior: "smooth" });
+      return;
+    }
+
+    // Count decreased (edit rewind, /clear, /compact) → track the new count
+    // but don't hijack the user's scroll position.
+    if (msgCount < prevMsgCount.current) {
+      prevMsgCount.current = msgCount;
+      return;
+    }
+
+    // Streaming update → pin to bottom (batched into one rAF) so chunks can't
+    // outrun us without doing a synchronous layout write per commit.
+    if (followingRef.current) {
+      schedulePinToBottom();
+    }
+  }, [msgCount, convo?.isStreaming, lastPartText, schedulePinToBottom]);
+
+  // Pin to bottom whenever content height changes while following. Catches
+  // renders that don't trigger the text-diff effect above — LoadingStatus
+  // growing an extra line when usage arrives, thinking blocks expanding,
+  // mermaid/katex rendering in late, etc.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !messageBodyEl || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      if (followingRef.current) {
+        schedulePinToBottom();
       }
-    }, 0);
+    });
+    ro.observe(messageBodyEl);
+    return () => ro.disconnect();
+  }, [messageBodyEl, schedulePinToBottom]);
+
+  // Track whether the user is near the bottom to toggle the scroll-to-bottom
+  // button, and maintain follow-mode based on user scroll direction.
+  const [showScrollToBottom, setShowScrollToBottom] = useState(false);
+  const showScrollToBottomRef = useRef(false);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    let lastScrollTop = el.scrollTop;
+    // Gate "user scrolled up" detection behind recent real user input.
+    // Otherwise content shrink (thinking block collapses, images clamping
+    // scrollTop) and trackpad momentum bounce silently kill follow-mode.
+    let userIntentUntil = 0;
+    const markIntent = () => { userIntentUntil = Date.now() + 500; };
+
+    const handleScroll = () => {
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      // Require both a meaningful delta and recent user input to disable follow.
+      if (el.scrollTop < lastScrollTop - 8 && Date.now() < userIntentUntil) {
+        followingRef.current = false;
+      }
+      // Reached the bottom again → resume following
+      if (distanceFromBottom < 40) {
+        followingRef.current = true;
+      }
+      lastScrollTop = el.scrollTop;
+      const nextShowScrollToBottom = distanceFromBottom > 120;
+      if (showScrollToBottomRef.current !== nextShowScrollToBottom) {
+        showScrollToBottomRef.current = nextShowScrollToBottom;
+        setShowScrollToBottom(nextShowScrollToBottom);
+      }
+    };
+    handleScroll();
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    el.addEventListener("wheel", markIntent, { passive: true });
+    el.addEventListener("touchstart", markIntent, { passive: true });
+    el.addEventListener("pointerdown", markIntent, { passive: true });
+    el.addEventListener("keydown", markIntent);
+    return () => {
+      el.removeEventListener("scroll", handleScroll);
+      el.removeEventListener("wheel", markIntent);
+      el.removeEventListener("touchstart", markIntent);
+      el.removeEventListener("pointerdown", markIntent);
+      el.removeEventListener("keydown", markIntent);
+    };
+  }, [convo?.id, msgCount]);
+
+  const scrollToBottom = useCallback(() => {
+    followingRef.current = true;
+    endRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  const isStreaming = convo?.isStreaming;
+
+  const setupRequired = Boolean(runtimeSetup?.required);
+  const shellLocation = cwd ? (() => {
+    const parts = cwd.split("/");
+    const wtIdx = parts.indexOf(".worktrees");
+    if (wtIdx >= 0 && wtIdx + 1 < parts.length) {
+      return `${parts[wtIdx - 1]} / ${parts[wtIdx + 1]}`;
+    }
+    return parts.slice(-2).join("/") || parts[parts.length - 1] || cwd;
+  })() : "current workspace";
+
+  // Branch / git-status hint inputs are computed HERE (parent) so the composer
+  // never recomputes git-derived flags on each keystroke. The composer receives
+  // the resolved values and only decides whether to SHOW the hint (which also
+  // depends on shellMode, an input-derived flag the composer owns).
+  const activeModelId = convo?.model || defaultModel;
+  const isMulticaModel = isMulticaModelId(activeModelId);
+  const { status: gitStatus } = useGitStatus(cwd);
+  const hasDirtyWorktree = (gitStatus?.files?.length || 0) > 0;
+  const hasNoUpstream = Boolean(gitStatus?.branch) && !gitStatus?.upstream && !gitStatus?.detached;
+  const branchNeedsAttention = hasDirtyWorktree || hasNoUpstream;
+  const convoId = convo?.id ?? null;
+  const branchHintText = (() => {
+    if (hasDirtyWorktree && hasNoUpstream) return t("chatArea.branchWarnBoth");
+    if (hasDirtyWorktree) return t("chatArea.branchWarnDirty");
+    return t("chatArea.branchWarnNoUpstream");
+  })();
+
+  const showHeaderTabs = tabs.length > 0 && !showNewChatCard;
+  const showConversationTitle = Boolean(convo && !showNewChatCard);
+  const topTabsLeft = sidebarOpen
+    ? 18
+    : IS_MAC
+      ? SIDEBAR_CHROME_RAIL_LEFT + SIDEBAR_CHROME_RAIL_WIDTH + 16
+      : 18;
+  const topTabsRight = windowControlsVisible ? 126 : 24;
+  const headerContentOffset = showHeaderTabs ? 8 : 0;
+  const headerLeftPadding = sidebarOpen ? 24 : IS_MAC ? 50 : 24;
+
+  // Window-level drag guards stay in ChatArea: they only prevent the browser
+  // from navigating when a file is dropped outside the composer's drop zone.
+  useEffect(() => {
+    const preventNav = (e) => { e.preventDefault(); };
+    window.addEventListener("dragover", preventNav);
+    window.addEventListener("drop", preventNav);
+    return () => {
+      window.removeEventListener("dragover", preventNav);
+      window.removeEventListener("drop", preventNav);
+    };
+  }, []);
+
+  const handleTranscriptAnswer = useCallback((text) => {
+    onSend(text);
+  }, [onSend]);
+
+  const handlePickFolder = useCallback(() => window.api?.pickFolder?.(), []);
+
+  // Selection toolbar quoting → forward to the composer's imperative handle so
+  // the quoted text is appended to the composer's OWN input state (keeps typing
+  // decoupled from ChatArea's streaming re-renders).
+  const handleQuote = useCallback((text) => {
+    composerApiRef.current?.quote(text);
   }, []);
 
 
@@ -533,10 +1090,10 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
         flex: 1, display: "flex", flexDirection: "column", minWidth: 0, position: "relative", zIndex: 10,
         ...getPaneSurfaceStyle(Boolean(wallpaper?.dataUrl)),
       }}
-      onDrop={(e) => { e.stopPropagation(); handleDrop(e); setDragOver(false); }}
-      onDragEnter={handleDragEnter}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
+      onDrop={(e) => { e.stopPropagation(); composerApiRef.current?.handleDrop(e); composerApiRef.current?.resetDragState(); }}
+      onDragEnter={(e) => composerApiRef.current?.handleDragEnter(e)}
+      onDragOver={(e) => composerApiRef.current?.handleDragOver(e)}
+      onDragLeave={(e) => composerApiRef.current?.handleDragLeave(e)}
     >
       {/* Drag region. On Windows, shrink right margin so custom controls aren't
           inside the drag hit-area. On macOS, WindowDragSpacer reserves the
@@ -781,471 +1338,30 @@ export default function ChatArea({ convo, onSend, onCancel, onEdit, sidebarOpen,
         </button>
       )}
 
-      {/* Input bar */}
+      {/* Input bar — owns urgent composer state so typing never re-renders the
+          transcript/header and streaming never re-renders the textarea. */}
       {!showNewChatCard &&
-      <div
-        style={{ padding: "12px 28px 24px", display: "flex", justifyContent: "center" }}
-      >
-        <div style={{ width: "100%", maxWidth: 560 }}>
-          {permissionRequests && permissionRequests.length > 0 && (
-            <div style={{ marginBottom: 8 }}>
-              {permissionRequests.map((req) => {
-                const actionButtonStyle = {
-                  height: 24,
-                  padding: "0 9px",
-                  borderRadius: 7,
-                  border: "1px solid var(--control-border)",
-                  background: "transparent",
-                  color: "var(--text-disabled)",
-                  cursor: "pointer",
-                  fontSize: s(9),
-                  fontFamily: "var(--font-mono)",
-                  letterSpacing: ".05em",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                };
-                const labelText = req.isSensitiveFile ? "SENSITIVE" : "PERMISSION";
-                const tool = req.toolName || "Tool";
-                const summary = req.summary || "";
-                return (
-                  <div
-                    key={req.requestId}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      padding: "6px 8px",
-                      marginBottom: 4,
-                      background: "var(--control-bg-subtle)",
-                      border: "1px solid var(--control-border-soft)",
-                      borderRadius: 12,
-                      fontSize: s(12),
-                      color: "var(--text-subtle)",
-                      fontFamily: "var(--font-ui)",
-                    }}
-                  >
-                    <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, minWidth: 0 }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
-                        <span style={{
-                          fontSize: s(9),
-                          fontFamily: "var(--font-mono)",
-                          color: "var(--text-faint)",
-                          letterSpacing: ".06em",
-                          flexShrink: 0,
-                        }}>
-                          {labelText}
-                        </span>
-                        <span style={{
-                          fontSize: s(9),
-                          fontFamily: "var(--font-mono)",
-                          color: "var(--text-disabled)",
-                          letterSpacing: ".06em",
-                        }}>
-                          {String(tool).toUpperCase()}
-                        </span>
-                      </div>
-                      <div style={{
-                        flex: 1,
-                        minWidth: 0,
-                        padding: "2px 8px",
-                        transform: "translateY(-1.5px)",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                        lineHeight: "18px",
-                        color: "var(--text-secondary)",
-                      }}
-                        title={summary}
-                      >
-                        {summary}
-                      </div>
-                    </div>
-                    <div style={{ display: "flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
-                      <button
-                        onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "allow", scope: "once" })}
-                        style={{
-                          ...actionButtonStyle,
-                          background: "var(--control-bg)",
-                          color: "var(--text-secondary)",
-                        }}
-                        title="Allow this request once"
-                      >
-                        ALLOW ONCE
-                      </button>
-                      <button
-                        onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "allow", scope: "session" })}
-                        style={actionButtonStyle}
-                        title="Allow this tool + target for the rest of the session"
-                      >
-                        ALLOW SESSION
-                      </button>
-                      <button
-                        onClick={() => onRespondPermission?.({ requestId: req.requestId, behavior: "deny" })}
-                        style={actionButtonStyle}
-                        title="Deny this request"
-                      >
-                        DENY
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-          {queuedMessages && queuedMessages.length > 0 && (
-            <div style={{ marginBottom: 8 }}>
-              {queuedMessages.map((q, i) => {
-                const isEditingQueueItem = editingQueueId === q.id;
-                const attachmentCount = Array.isArray(q.attachments) ? q.attachments.length : 0;
-                const queueActionButtonStyle = {
-                  height: 24,
-                  padding: "0 9px",
-                  borderRadius: 7,
-                  border: "1px solid var(--control-border)",
-                  background: "transparent",
-                  color: "var(--text-disabled)",
-                  cursor: "pointer",
-                  fontSize: s(9),
-                  fontFamily: "var(--font-mono)",
-                  letterSpacing: ".05em",
-                  display: "inline-flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                };
-                return (
-                  <div
-                    key={q.id || i}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      padding: "6px 8px",
-                      marginBottom: 4,
-                      background: "var(--control-bg-subtle)",
-                      border: "1px solid var(--control-border-soft)",
-                      borderRadius: 12,
-                      fontSize: s(12),
-                      color: "var(--text-subtle)",
-                      fontFamily: "var(--font-ui)",
-                    }}
-                  >
-                    <div style={{ display: "flex", alignItems: "center", gap: 8, flex: 1, minWidth: 0 }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
-                        <span style={{
-                          fontSize: s(9),
-                          fontFamily: "var(--font-mono)",
-                          color: "var(--text-faint)",
-                          letterSpacing: ".06em",
-                          flexShrink: 0,
-                        }}>
-                          {i === 0 ? t("chatArea.queuedNext") : t("chatArea.queued")}
-                        </span>
-                        {attachmentCount > 0 && (
-                          <span style={{
-                            fontSize: s(9),
-                            fontFamily: "var(--font-mono)",
-                            color: "var(--text-faint)",
-                            letterSpacing: ".06em",
-                          }}>
-                            {t("chatArea.attachmentsCount", { value: attachmentCount, suffix: attachmentCount === 1 ? "" : "S" })}
-                          </span>
-                        )}
-                      </div>
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        {isEditingQueueItem ? (
-                          <textarea
-                            ref={queueEditRef}
-                            value={queueDraft}
-                            onChange={(event) => setQueueDraft(event.target.value)}
-                            onKeyDown={(event) => handleQueuedDraftKeyDown(event, q.id)}
-                            rows={1}
-                            style={{
-                              width: "100%",
-                              background: "var(--control-bg-subtle)",
-                              border: "1px solid var(--control-border-soft)",
-                              borderRadius: 7,
-                              padding: "2px 8px",
-                              color: "var(--text-primary)",
-                              fontSize: s(12),
-                              lineHeight: "18px",
-                              fontFamily: "inherit",
-                              resize: "none",
-                              minHeight: 24,
-                              maxHeight: 52,
-                              overflowY: "auto",
-                            }}
-                          />
-                        ) : (
-                          <div style={{
-                            minHeight: 24,
-                            display: "flex",
-                            alignItems: "center",
-                            padding: "2px 8px",
-                            transform: "translateY(-1.5px)",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                            lineHeight: "18px",
-                            color: "var(--text-secondary)",
-                          }}>
-                            {q.text}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 4,
-                        flexShrink: 0,
-                      }}
-                    >
-                      {isEditingQueueItem ? (
-                        <>
-                          <button
-                            onClick={() => saveQueuedEdit(q.id)}
-                            style={{
-                              ...queueActionButtonStyle,
-                              background: "var(--control-bg)",
-                              color: "var(--text-secondary)",
-                            }}
-                          >
-                            {t("common.save")}
-                          </button>
-                          <button
-                            onClick={cancelQueuedEdit}
-                            style={queueActionButtonStyle}
-                          >
-                            {t("common.cancel")}
-                          </button>
-                        </>
-                      ) : (
-                        <>
-                          <button
-                            onClick={() => startQueuedEdit(q)}
-                            style={queueActionButtonStyle}
-                          >
-                            {t("common.edit")}
-                          </button>
-                          <button
-                            onClick={() => removeQueuedItem(q.id)}
-                            style={queueActionButtonStyle}
-                          >
-                            {t("common.delete")}
-                          </button>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-          {/* Slash command palette */}
-          {filteredCommands.length > 0 && (
-            <div style={{
-              marginBottom: 6,
-              background: wallpaper?.dataUrl ? "var(--pane-elevated)" : "var(--overlay-surface)",
-              border: "1px solid var(--control-border)",
-              borderRadius: 10,
-              padding: "4px",
-              backdropFilter: "blur(20px)",
-              boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
-            }}>
-              {filteredCommands.map((c, i) => (
-                <div
-                  key={c.cmd}
-                  onClick={() => { setInput(c.cmd); setSelectedCmd(0); }}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    padding: "6px 10px",
-                    borderRadius: 7,
-                    cursor: "pointer",
-                    background: i === selectedCmd ? "var(--control-bg)" : "transparent",
-                    transition: "background .1s",
-                  }}
-                  onMouseEnter={() => setSelectedCmd(i)}
-                >
-                  <span style={{
-                    fontSize: s(12),
-                    fontFamily: "var(--font-mono)",
-                    color: "var(--text-secondary)",
-                  }}>{c.cmd}</span>
-                  <span style={{
-                    fontSize: s(11),
-                    color: "var(--text-disabled)",
-                    fontFamily: "var(--font-ui)",
-                  }}>{c.desc}</span>
-                </div>
-              ))}
-            </div>
-          )}
-          <MemoImagePreview items={attachments} onRemove={removeAttachment} />
-          {shellMode && (
-            <div
-              style={{
-                marginBottom: 6,
-                fontSize: s(10),
-                fontFamily: "var(--font-mono)",
-                letterSpacing: ".1em",
-                color: "var(--text-muted)",
-              }}
-            >
-              {canRunShell
-                ? t("chatArea.shellModeReady", { loc: shellLocation })
-                : t("chatArea.shellModeEmpty")}
-            </div>
-          )}
-          {showBranchHint && (
-            <div
-              style={{
-                marginBottom: 6,
-                fontSize: s(10),
-                fontFamily: "var(--font-mono)",
-                letterSpacing: ".1em",
-                color: "var(--warning-text)",
-              }}
-            >
-              {branchHintText}
-            </div>
-          )}
-
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 10,
-              background: dragOver
-                ? "var(--accent-bg)"
-                : (inputFocused ? "var(--control-bg)" : "var(--control-bg-subtle)"),
-              border: (shellMode ? "2px solid " : "1px solid ") + (
-                dragOver
-                  ? "var(--accent-border)"
-                  : (inputFocused ? "var(--control-border-strong)" : "var(--control-border)")
-              ),
-              borderRadius: 12,
-              padding: shellMode ? "8px 13px" : "9px 14px",
-              backdropFilter: "blur(20px)",
-              boxShadow: dragOver ? "0 0 0 1px rgba(153,214,255,0.08)" : "none",
-              transition: "border-color .25s, background .25s, box-shadow .25s",
-            }}
-          >
-            <textarea
-              ref={inRef}
-              value={input}
-              onChange={handleInput}
-              onKeyDown={handleKeyDown}
-              onCompositionStart={() => { composingRef.current = true; }}
-              onCompositionEnd={() => { composingRef.current = false; }}
-              onPaste={handlePaste}
-              onFocus={() => setInputFocused(true)}
-              onBlur={() => {
-                composingRef.current = false;
-                setInputFocused(false);
-              }}
-              placeholder={setupRequired && !shellMode ? "Install a runtime to start chatting" : (shellMode ? t("chatArea.placeholderShell") : t("chatArea.placeholderAsk"))}
-              rows={1}
-              style={{
-                flex: 1,
-                background: "transparent",
-                border: "none",
-                resize: "none",
-                color: "var(--text-primary)",
-                fontSize: s(13),
-                lineHeight: 1.5,
-                fontFamily: "var(--font-ui)",
-                maxHeight: 120,
-                height: "auto",
-                display: "block",
-                overflow: "auto",
-              }}
-            />
-            {isStreaming && !input.trim() ? (
-              <button
-                onClick={onCancel}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: 30,
-                  height: 30,
-                  borderRadius: 8,
-                  flexShrink: 0,
-                  background: "var(--control-bg-strong)",
-                  border: "1px solid var(--control-border-strong)",
-                  color: "var(--text-muted)",
-                  cursor: "pointer",
-                  transition: "all .2s",
-                }}
-                onMouseEnter={(e) => { e.currentTarget.style.background = "var(--control-bg-active)"; }}
-                onMouseLeave={(e) => { e.currentTarget.style.background = "var(--control-bg-strong)"; }}
-              >
-                <Square size={10} fill="currentColor" />
-              </button>
-            ) : (
-              <button
-                onClick={send}
-                disabled={!canSend}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  gap: shellMode ? 6 : 0,
-                  width: shellMode ? "auto" : 30,
-                  height: 30,
-                  padding: shellMode ? "0 12px" : 0,
-                  borderRadius: 8,
-                  flexShrink: 0,
-                  background: canSend ? "var(--text-primary)" : "var(--control-bg-subtle)",
-                  border: "none",
-                  color: canSend ? "var(--text-inverse)" : "var(--text-faint)",
-                  cursor: canSend ? "pointer" : "default",
-                  transition: "all .3s cubic-bezier(.16,1,.3,1)",
-                  transform: canSend ? "scale(1)" : "scale(0.88)",
-                }}
-              >
-                {shellMode ? (
-                  <>
-                    <TerminalIcon size={14} strokeWidth={1.6} />
-                    <span
-                      style={{
-                        fontSize: s(10),
-                        fontFamily: "var(--font-mono)",
-                        letterSpacing: ".1em",
-                      }}
-                    >
-                      {t("chatArea.run")}
-                    </span>
-                  </>
-                ) : (
-                  <ArrowRight size={16} strokeWidth={1.5} />
-                )}
-              </button>
-            )}
-          </div>
-
-          <div
-            style={{
-              textAlign: "center",
-              marginTop: 8,
-              fontSize: s(8),
-              fontFamily: "var(--font-mono)",
-              color: "var(--text-muted)",
-              letterSpacing: ".1em",
-            }}
-          >
-            {shellMode
-              ? (canRunShell
-                  ? t("chatArea.hintShellRun")
-                  : t("chatArea.hintShellEmpty"))
-              : t("chatArea.hintChat")}
-          </div>
-        </div>
-      </div>}
+        <ChatComposer
+          composerRef={composerApiRef}
+          onSend={onSend}
+          onCancel={onCancel}
+          isStreaming={isStreaming}
+          setupRequired={setupRequired}
+          shellLocation={shellLocation}
+          permissionRequests={permissionRequests}
+          onRespondPermission={onRespondPermission}
+          queuedMessages={queuedMessages}
+          onUpdateQueuedMessage={onUpdateQueuedMessage}
+          onRemoveQueuedMessage={onRemoveQueuedMessage}
+          isMulticaModel={isMulticaModel}
+          showNewChatCard={showNewChatCard}
+          branchNeedsAttention={branchNeedsAttention}
+          branchHintText={branchHintText}
+          convoId={convoId}
+          hasWallpaper={Boolean(wallpaper?.dataUrl)}
+          t={t}
+          s={s}
+        />}
     </div>
   );
 }

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -128,6 +128,24 @@ const makeMdComponents = (isStreaming = false, s = (x) => x, onAnswer, onControl
       return img ? <AssistantImage {...img} /> : null;
     }
     if (match) {
+      // While this segment is actively streaming, skip Prism syntax
+      // highlighting — re-highlighting code blocks on every ~15Hz stream
+      // commit is the dominant source of long main-thread tasks (it rebuilds
+      // thousands of token elements per frame) and is what makes typing janky.
+      // Render cheap plain monospace now; the completed (non-streaming) render
+      // upgrades to full highlighting once the fence/message settles.
+      if (isStreaming) {
+        return (
+          <code style={{
+            display: "block",
+            whiteSpace: "pre",
+            fontSize: s(12),
+            fontFamily: "var(--font-mono)",
+            lineHeight: 1.6,
+            color: "var(--text-secondary)",
+          }}>{codeString}</code>
+        );
+      }
       return (
         <SyntaxHighlighter
           style={oneDark}

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -60,6 +60,17 @@ const sanitizeSchema = {
   },
 };
 
+// Returns a referentially-stable callback whose identity never changes while
+// always delegating to the latest `fn`. The latest value is kept in a ref that
+// is read only when the returned proxy is invoked (i.e. from event handlers,
+// after commit) — never during render. Isolating this in its own hook keeps the
+// latest-ref pattern contained and the call sites free of ref-read warnings.
+function useStableCallback(fn) {
+  const ref = useRef(fn);
+  useEffect(() => { ref.current = fn; }, [fn]);
+  return useCallback((...args) => ref.current?.(...args), []);
+}
+
 function PreBlock({ rawText, s = (x) => x, children }) {
   const [hovered, setHovered] = useState(false);
   return (
@@ -223,6 +234,20 @@ const MESSAGE_ROOT_STYLE = {
   contentVisibility: "auto",
   containIntrinsicSize: "180px",
 };
+
+// Module-level, referentially-stable plugin arrays. react-markdown compares
+// these by identity to decide whether the processor must be rebuilt; keeping
+// them constant avoids redundant work and lets MarkdownTextPart's memo skip
+// re-parsing unchanged parts during streaming.
+const ASSISTANT_REMARK_PLUGINS = [remarkGfm, remarkMath];
+const ASSISTANT_REHYPE_PLUGINS = [rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex];
+const ASSISTANT_MARKDOWN_PROPS = {
+  remarkPlugins: ASSISTANT_REMARK_PLUGINS,
+  rehypePlugins: ASSISTANT_REHYPE_PLUGINS,
+};
+// User bubbles only need gfm (no math / raw HTML / katex).
+const USER_REMARK_PLUGINS = [remarkGfm];
+const USER_MARKDOWN_PROPS = { remarkPlugins: USER_REMARK_PLUGINS };
 
 function getImmediateImageSrc(image) {
   if (typeof image === "string") return image;
@@ -590,10 +615,51 @@ function renderControlAwareMarkdown({
   });
 }
 
+// Memoized wrapper around the per-text-part markdown render. A COMPLETED text
+// part (msg not streaming, OR not the last part) receives stable props:
+// `text` no longer grows, `isStreaming` is false, `components` is the stable
+// `scaledMdStatic`, and the callbacks are stable proxies (see Message). So memo
+// skips re-rendering — and therefore re-parsing — that part when an unrelated
+// later part changes. Only the active streaming last part re-parses as its
+// `text` grows.
+const MarkdownTextPart = memo(function MarkdownTextPart({
+  text,
+  blockKey,
+  isStreaming,
+  components,
+  onAnswer,
+  onControlChange,
+  canControlTarget,
+}) {
+  return (
+    <>
+      {renderControlAwareMarkdown({
+        text,
+        blockKey,
+        markdownProps: ASSISTANT_MARKDOWN_PROPS,
+        components,
+        isStreaming,
+        onAnswer,
+        onControlChange,
+        canControlTarget,
+      })}
+    </>
+  );
+});
+
 function Message({ msg, modelId, messageIndex, canEdit = false, onEdit, onAnswer, onControlChange, canControlTarget, wallpaper }) {
   const s = useFontScale();
-  const scaledMdStatic = useMemo(() => makeMdComponents(false, s, onAnswer, onControlChange, canControlTarget), [canControlTarget, onAnswer, onControlChange, s]);
-  const scaledMdStreaming = useMemo(() => makeMdComponents(true, s, onAnswer, onControlChange, canControlTarget), [canControlTarget, onAnswer, onControlChange, s]);
+
+  // Wrap the incoming callbacks in stable proxies whose identity never changes
+  // across renders, even if the parent passes a fresh `onAnswer`/`onControlChange`
+  // each commit. This keeps `scaledMdStatic`/`scaledMdStreaming` and the props
+  // handed to MarkdownTextPart referentially stable so memo stays effective for
+  // completed parts during streaming.
+  const stableOnAnswer = useStableCallback(onAnswer);
+  const stableOnControlChange = useStableCallback(onControlChange);
+
+  const scaledMdStatic = useMemo(() => makeMdComponents(false, s, stableOnAnswer, stableOnControlChange, canControlTarget), [canControlTarget, stableOnAnswer, stableOnControlChange, s]);
+  const scaledMdStreaming = useMemo(() => makeMdComponents(true, s, stableOnAnswer, stableOnControlChange, canControlTarget), [canControlTarget, stableOnAnswer, stableOnControlChange, s]);
   const isUser = msg.role === "user";
   const isSystem = msg.role === "system";
   const isShellCommand = msg.mode === "shell-command";
@@ -801,10 +867,10 @@ function Message({ msg, modelId, messageIndex, canEdit = false, onEdit, onAnswer
                 {renderControlAwareMarkdown({
                   text: displayText,
                   blockKey: `user-${msg.id}`,
-                  markdownProps: { remarkPlugins: [remarkGfm] },
+                  markdownProps: USER_MARKDOWN_PROPS,
                   components: scaledMdStatic,
-                  onAnswer,
-                  onControlChange,
+                  onAnswer: stableOnAnswer,
+                  onControlChange: stableOnControlChange,
                   canControlTarget,
                 })}
               </div>
@@ -868,7 +934,7 @@ function Message({ msg, modelId, messageIndex, canEdit = false, onEdit, onAnswer
               letterSpacing: "0.006em",
             }}
           >
-            <Markdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex]} components={scaledMdStatic}>
+            <Markdown remarkPlugins={ASSISTANT_REMARK_PLUGINS} rehypePlugins={ASSISTANT_REHYPE_PLUGINS} components={scaledMdStatic}>
               {sanitizeText(displayText)}
             </Markdown>
           </div>
@@ -909,6 +975,7 @@ function Message({ msg, modelId, messageIndex, canEdit = false, onEdit, onAnswer
         {(msg.parts || []).map((part, i) => {
           if (part.type === "text" && part.text) {
             const isLastPart = i === (msg.parts || []).length - 1;
+            const partStreaming = Boolean(msg.isStreaming && isLastPart);
             return (
               <div key={i} style={{
                 color: "var(--text-primary)",
@@ -918,19 +985,15 @@ function Message({ msg, modelId, messageIndex, canEdit = false, onEdit, onAnswer
                 letterSpacing: "0.008em",
                 marginBottom: 4,
               }}>
-                {renderControlAwareMarkdown({
-                  text: part.text,
-                  blockKey: `part-${part.id || i}`,
-                  markdownProps: {
-                    remarkPlugins: [remarkGfm, remarkMath],
-                    rehypePlugins: [rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex],
-                  },
-                  components: (msg.isStreaming && isLastPart) ? scaledMdStreaming : scaledMdStatic,
-                  isStreaming: msg.isStreaming && isLastPart,
-                  onAnswer,
-                  onControlChange,
-                  canControlTarget,
-                })}
+                <MarkdownTextPart
+                  text={part.text}
+                  blockKey={`part-${part.id || i}`}
+                  isStreaming={partStreaming}
+                  components={partStreaming ? scaledMdStreaming : scaledMdStatic}
+                  onAnswer={stableOnAnswer}
+                  onControlChange={stableOnControlChange}
+                  canControlTarget={canControlTarget}
+                />
               </div>
             );
           }
@@ -1044,13 +1107,10 @@ function Message({ msg, modelId, messageIndex, canEdit = false, onEdit, onAnswer
             {renderControlAwareMarkdown({
               text: msg.text,
               blockKey: `legacy-${msg.id}`,
-              markdownProps: {
-                remarkPlugins: [remarkGfm, remarkMath],
-                rehypePlugins: [rehypeRaw, [rehypeSanitize, sanitizeSchema], rehypeKatex],
-              },
+              markdownProps: ASSISTANT_MARKDOWN_PROPS,
               components: scaledMdStatic,
-              onAnswer,
-              onControlChange,
+              onAnswer: stableOnAnswer,
+              onControlChange: stableOnControlChange,
               canControlTarget,
             })}
           </div>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef, useEffect, useCallback } from "react";
+import { memo, useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { useFontScale } from "../contexts/FontSizeContext";
 import { createTranslator } from "../i18n";
 import { Plus, Search, Trash2, FolderOpen, ChevronRight, Workflow, FolderPlus } from "lucide-react";
@@ -230,7 +230,7 @@ function GitHubIcon({ size = 12 }) {
   );
 }
 
-export default function Sidebar({ convos, active, onSelect, onNew, onDelete, cwd, onPickFolder, onOpenProjectManager, onOpenDispatch, onOpenNewProject, projects, draftsPath, onToggleProjectCollapse, onHideProject, onEditProjectContext, onNewInProject, draftsCollapsed, onToggleDraftsCollapsed, developerMode = true, multicaModels = [], isOpen = true, windowsChrome = false, locale = "en-US" }) {
+function Sidebar({ convos, active, onSelect, onNew, onDelete, cwd, onPickFolder, onOpenProjectManager, onOpenDispatch, onOpenNewProject, projects, draftsPath, onToggleProjectCollapse, onHideProject, onEditProjectContext, onNewInProject, draftsCollapsed, onToggleDraftsCollapsed, developerMode = true, multicaModels = [], isOpen = true, windowsChrome = false, locale = "en-US" }) {
   const s = useFontScale();
   const t = useMemo(() => createTranslator(locale), [locale]);
   const [search, setSearch]     = useState("");
@@ -965,3 +965,5 @@ export default function Sidebar({ convos, active, onSelect, onNew, onDelete, cwd
     </div>
   );
 }
+
+export default memo(Sidebar);

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -458,11 +458,696 @@ function extractOpenCodeError(event) {
   );
 }
 
+// Target ~30fps under heavy token rates: at most one React commit per ~32ms,
+// regardless of how many stream events arrive in between.
+const STREAM_FLUSH_MIN_INTERVAL_MS = 32;
+
+// Terminal / must-show-now events bypass the rAF coalescer and flush
+// synchronously so completion (and the `isStreaming` flip) feels snappy.
+// Mirrors the reducer branches that set nextIsStreaming=false or finalize a
+// message. Missing one is non-fatal — onAgentDone/onAgentError are backstops.
+function isImmediateFlushEvent(event) {
+  if (!event || typeof event !== "object") return false;
+  const type = event.type;
+  if (type === "result") return true;
+  if (type === "turn.completed") return true;
+  if (type === "error") return true; // opencode error branch
+  if (type === "step_finish") return true; // opencode; cheap to always flush
+  if (type === "event_msg" && event.payload?.type === "task_complete") return true;
+  if (typeof type === "string" && type.startsWith("multica:")) {
+    const inner = type.slice("multica:".length);
+    if (
+      inner === "chat:done" ||
+      inner === "task:completed" ||
+      inner === "task:cancelled" ||
+      inner === "task:failed" ||
+      inner === "error"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Pure reducer: takes the previous conversations Map and a single stream event,
+// returns the next Map. Extracted verbatim from the original
+// `setConversations((prev) => { ... })` updater inside `onAgentStream` so that
+// many buffered events can be folded into a single React commit while
+// preserving exact ordering and all provider-specific logic.
+function applyStreamEventToConversations(prev, conversationId, event) {
+  const next = new Map(prev);
+  const convo = next.get(conversationId) || { messages: [], isStreaming: true, error: null };
+  const msgs = [...convo.messages];
+  let lastMsg = msgs[msgs.length - 1];
+  // Some runs finish logically before the underlying CLI process fully
+  // exits, e.g. a background shell keeps stdout/stderr open for a moment.
+  // Track the conversation-level flag separately so we can unblock the UI
+  // on terminal completion events without waiting for `agent-done`.
+  let nextIsStreaming = Boolean(convo.isStreaming);
+
+  if (event.session_id && convo._claudeSessionId !== event.session_id) {
+    convo._claudeSessionId = event.session_id;
+    log("Captured Claude session ID:", {
+      conversationId,
+      sessionId: event.session_id,
+      eventType: event.type,
+      subtype: event.subtype,
+    });
+  }
+
+  const ensureAssistant = () => {
+    if (!lastMsg || lastMsg.role !== "assistant") {
+      lastMsg = {
+        id: uid(),
+        role: "assistant",
+        parts: [],
+        isStreaming: true,
+        isThinking: false,
+        _streamState: cloneStreamState(),
+        _startedAt: Date.now(),
+        _usage: null,
+      };
+      msgs.push(lastMsg);
+    } else if (!lastMsg._startedAt) {
+      lastMsg = { ...lastMsg, _startedAt: Date.now() };
+      msgs[msgs.length - 1] = lastMsg;
+    }
+    return lastMsg;
+  };
+
+  if (typeof event.type === "string" && event.type.startsWith("multica:")) {
+    const inner = event.type.slice("multica:".length);
+    const p = event.payload || {};
+    // transient — resets per-session; stripped in buildPersistedConversationSnapshot
+    const connectedPatch = convo.multicaConnected ? null : { multicaConnected: true };
+
+    // No-op branches return early WITHOUT running ensureAssistant — we
+    // don't want a stray empty assistant bubble if a user echo arrives
+    // before any task:message.
+    if (inner === "chat:message" && p.role === "user") {
+      if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
+      return next;
+    }
+    if (inner === "agent:status") {
+      window.dispatchEvent(new CustomEvent("multica-agent-status", { detail: p.agent }));
+      if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
+      return next;
+    }
+
+    const assistant = ensureAssistant();
+
+    if (inner === "task:message") {
+      const part = mapMulticaTaskMessage(p);
+      if (!part) {
+        if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
+        return next;
+      }
+      const parts = [...(assistant.parts || [])];
+      if (p.type === "tool_result") {
+        const pendingIdx = findPendingMulticaToolIdx(parts, p.tool);
+        if (pendingIdx >= 0) {
+          parts[pendingIdx] = { ...parts[pendingIdx], result: p.output || "", status: "done" };
+        } else {
+          parts.push(part);
+        }
+      } else {
+        parts.push(part);
+      }
+      msgs[msgs.length - 1] = { ...assistant, parts, isStreaming: true };
+      next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: true });
+      return next;
+    }
+
+    if (inner === "chat:done" || inner === "task:completed") {
+      msgs[msgs.length - 1] = freezeElapsed({ ...assistant, isStreaming: false });
+      next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: false });
+      return next;
+    }
+
+    if (inner === "task:cancelled") {
+      msgs[msgs.length - 1] = freezeElapsed({ ...assistant, isStreaming: false });
+      next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: false, error: null });
+      return next;
+    }
+
+    if (inner === "task:failed" || inner === "error") {
+      msgs[msgs.length - 1] = freezeElapsed({
+        ...assistant, isStreaming: false,
+        parts: [...(assistant.parts || []), { type: "text", text: `_Multica ${inner}: ${p.message || p.reason || ""}_` }],
+      });
+      next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: false, error: p.message || inner });
+      return next;
+    }
+
+    if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
+    return next;
+  }
+
+  if (event.type === "stream_event") {
+    const inner = event.event;
+    if (!inner) { next.set(conversationId, { ...convo, messages: msgs }); return next; }
+
+    // Helper to update the last assistant message and keep lastMsg in sync
+    const updateAssistant = (updates) => {
+      const merged = { ...lastMsg, ...updates };
+      msgs[msgs.length - 1] = merged;
+      lastMsg = merged;
+    };
+
+    // Context-window fullness tracking.
+    //
+    // We deliberately track the LATEST API call's usage (not the turn
+    // aggregate). A multi-tool-use turn re-sends the prompt once per
+    // call, so aggregating would make `cache_read` balloon by the number
+    // of calls — that measures how much *work* was done, not how full
+    // the window is. The cumulative snapshot at the END of the last
+    // call is what actually reflects "tokens currently in the window."
+    //
+    // - `message_start` → overwrite `_usage` (new API call begins)
+    // - `message_delta` → merge (output_tokens grows during generation)
+    // - `result` below → ignored for usage (it's turn-aggregated)
+    if (inner.type === "message_start" && inner.message?.usage) {
+      ensureAssistant();
+      updateAssistant({ _usage: { ...inner.message.usage } });
+    } else if (inner.type === "message_delta" && inner.usage) {
+      ensureAssistant();
+      updateAssistant({ _usage: mergeUsage(lastMsg._usage, inner.usage) });
+    }
+
+    if (inner.type === "content_block_start") {
+      const block = inner.content_block;
+      ensureAssistant();
+      const parts = cloneParts(lastMsg.parts);
+      const streamState = cloneStreamState(lastMsg._streamState);
+      const blockIndex = inner.index;
+
+      if (streamState.seenIndexes[blockIndex]) {
+        streamState.currentTurn += 1;
+        streamState.seenIndexes = {};
+        streamState.activeBlocks = {};
+        streamState.activeThinking = {};
+      }
+
+      streamState.seenIndexes[blockIndex] = true;
+      const streamKey = buildBlockKey(streamState.currentTurn, blockIndex);
+      streamState.activeBlocks[blockIndex] = streamKey;
+
+      if (block?.type === "thinking") {
+        parts.push({ type: "thinking", text: "", blockIndex, _streamKey: streamKey });
+        streamState.activeThinking[streamKey] = true;
+        updateAssistant({ parts, isStreaming: true, isThinking: true, _streamState: streamState });
+      } else if (block?.type === "tool_use") {
+        parts.push({
+          type: "tool",
+          id: block.id || "tc" + uid(),
+          name: block.name || "unknown",
+          args: {},
+          argsJson: "",
+          result: null,
+          status: "running",
+          blockIndex,
+          _streamKey: streamKey,
+        });
+        updateAssistant({ parts, isStreaming: true, _streamState: streamState });
+      } else if (block?.type === "text") {
+        parts.push({ type: "text", text: "", blockIndex, _streamKey: streamKey });
+        updateAssistant({ parts, isStreaming: true, _streamState: streamState });
+      } else if (block?.type === "image") {
+        // Anthropic vision-output blocks arrive whole (no per-delta data
+        // for image bytes), so push the full image part on start.
+        const imagePart = buildImagePartFromAnthropicBlock(block);
+        if (imagePart) {
+          parts.push({ ...imagePart, blockIndex, _streamKey: streamKey });
+          updateAssistant({ parts, isStreaming: true, _streamState: streamState });
+        }
+      }
+    } else if (inner.type === "content_block_delta") {
+      ensureAssistant();
+      const parts = cloneParts(lastMsg.parts);
+      const streamState = cloneStreamState(lastMsg._streamState);
+      const delta = inner.delta;
+      const streamKey = streamState.activeBlocks[inner.index];
+      if (delta?.type === "text_delta") {
+        const textIdx = findPartIndexByStreamKey(parts, streamKey, "text");
+        if (textIdx >= 0) {
+          parts[textIdx] = { ...parts[textIdx], text: parts[textIdx].text + (delta.text || "") };
+        }
+        updateAssistant({ parts, isStreaming: true, _streamState: streamState });
+      } else if (delta?.type === "input_json_delta") {
+        const toolIdx = findPartIndexByStreamKey(parts, streamKey, "tool");
+        if (toolIdx >= 0) {
+          const newJson = (parts[toolIdx].argsJson || "") + (delta.partial_json || "");
+          let newArgs = parts[toolIdx].args;
+          try {
+            newArgs = JSON.parse(newJson);
+          } catch {
+            // Keep accumulating partial JSON until it becomes parseable.
+          }
+          parts[toolIdx] = { ...parts[toolIdx], argsJson: newJson, args: newArgs };
+        }
+        updateAssistant({ parts, isStreaming: true, _streamState: streamState });
+      } else if (delta?.type === "thinking_delta") {
+        const thinkingIdx = findPartIndexByStreamKey(parts, streamKey, "thinking");
+        if (thinkingIdx >= 0) {
+          parts[thinkingIdx] = {
+            ...parts[thinkingIdx],
+            text: parts[thinkingIdx].text + (delta.thinking || ""),
+          };
+        }
+        updateAssistant({ parts, isStreaming: true, isThinking: true, _streamState: streamState });
+      }
+    } else if (inner.type === "content_block_stop") {
+      ensureAssistant();
+      const streamState = cloneStreamState(lastMsg._streamState);
+      const stoppedKey = streamState.activeBlocks[inner.index];
+      delete streamState.activeBlocks[inner.index];
+
+      if (stoppedKey && streamState.activeThinking[stoppedKey]) {
+        delete streamState.activeThinking[stoppedKey];
+      }
+
+      updateAssistant({
+        isThinking: Object.keys(streamState.activeThinking).length > 0,
+        _streamState: streamState,
+      });
+    }
+  } else if (event.type === "assistant") {
+    // With --include-partial-messages, assistant events contain full accumulated text.
+    // Only use these if we have NO stream_event parts yet (fallback for non-streaming).
+    // Usage here is per-API-call, not cumulative — skip it to avoid flicker;
+    // the `result` event below owns the authoritative cumulative usage.
+    ensureAssistant();
+    const parts = cloneParts(lastMsg.parts);
+    const hasStreamParts = parts.length > 0;
+    if (!hasStreamParts && event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === "text" && block.text) {
+          parts.push({ type: "text", text: block.text });
+        }
+        if (block.type === "tool_use") {
+          if (!findToolPart(parts, block.id)) {
+            parts.push({
+              type: "tool",
+              id: block.id,
+              name: block.name || "unknown",
+              args: block.input || {},
+              result: null,
+              status: "running",
+            });
+          }
+        }
+        if (block.type === "image") {
+          const imagePart = buildImagePartFromAnthropicBlock(block);
+          if (imagePart) parts.push(imagePart);
+        }
+      }
+      msgs[msgs.length - 1] = { ...lastMsg, parts, isThinking: false };
+      lastMsg = msgs[msgs.length - 1];
+    }
+  } else if (event.type === "user") {
+    // Capture the UUID from user events — needed for rewind/edit
+    if (event.uuid) {
+      log("User event UUID:", event.uuid, "has tool_result:",
+        event.message?.content?.some?.(b => b.type === "tool_result"));
+      // Find the last user message and store the Claude-assigned UUID
+      for (let mi = msgs.length - 1; mi >= 0; mi--) {
+        if (msgs[mi].role === "user" && !msgs[mi].claudeUuid) {
+          msgs[mi] = { ...msgs[mi], claudeUuid: event.uuid };
+          log("Stored claudeUuid on user msg:", msgs[mi].text?.slice(0, 50));
+          break;
+        }
+      }
+    }
+    if (event.message?.content) {
+      for (const block of event.message.content) {
+        if (block.type === "tool_result" && block.tool_use_id) {
+          for (let mi = msgs.length - 1; mi >= 0; mi--) {
+            if (msgs[mi].role === "assistant" && msgs[mi].parts) {
+              const parts = cloneParts(msgs[mi].parts);
+              const tpIdx = parts.findIndex(p => p.type === "tool" && p.id === block.tool_use_id);
+              if (tpIdx >= 0) {
+                parts[tpIdx] = { ...parts[tpIdx], result: block.content, status: "done" };
+                msgs[mi] = { ...msgs[mi], parts };
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+  } else if (event.type === "result") {
+    if (lastMsg && lastMsg.role === "assistant") {
+      // Note: `event.usage` here is aggregated across every API call in
+      // the turn (ballooned `cache_read` when the turn had multiple tool
+      // loops). That's right for cost, wrong for window fullness — we
+      // already captured the final call's cumulative usage from
+      // `message_delta`. Leave `_usage` alone.
+      if (event.is_error || event.subtype === "error_during_execution") {
+        // Surface the error as text in the assistant message
+        const errorText = event.result || event.error
+          || (event.errors && event.errors.length > 0 ? event.errors.join("\n") : null)
+          || "An error occurred.";
+        const parts = cloneParts(lastMsg.parts);
+        parts.push({ type: "text", text: `**Error:** ${errorText}` });
+        msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, parts, isStreaming: false, isThinking: false });
+      } else if (event.terminal_reason === "hook_stopped") {
+        const parts = cloneParts(lastMsg.parts);
+        const hasPausedStatus = parts.some((part) => part.type === "status" && part.kind === "paused");
+        if (!hasPausedStatus) {
+          parts.push({
+            type: "status",
+            kind: "paused",
+            title: "Paused by hook",
+            text: "Claude stopped after a tool hook returned continue: false. This is expected — send another message when you want to continue.",
+          });
+        }
+        msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, parts, isStreaming: false, isThinking: false });
+      } else {
+        msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
+      }
+    }
+    nextIsStreaming = false;
+  }
+
+  // Claude Code plan quota — synthetic event emitted by the main process
+  // after each `result`, sourced from `api.anthropic.com/api/oauth/usage`
+  // (Pro/Max only — silently absent for API-key users). Already
+  // normalized to the same `{ five_hour, seven_day }` shape Codex uses,
+  // so it just attaches to the latest assistant message.
+  else if (event.type === "rate_limits" && event.rate_limits) {
+    const idx = findLatestAssistantIndex(msgs);
+    if (idx >= 0) {
+      msgs[idx] = { ...msgs[idx], _rateLimits: event.rate_limits };
+      if (idx === msgs.length - 1) lastMsg = msgs[idx];
+    }
+  }
+
+  else if (event.type === "session_snapshot" && event.provider === "codex") {
+    if (event.thread_id) {
+      convo._codexThreadId = event.thread_id;
+    }
+    const idx = findLatestAssistantIndex(msgs);
+    if (idx >= 0) {
+      msgs[idx] = {
+        ...msgs[idx],
+        ...(event.usage
+          ? { _usage: mergeUsage(msgs[idx]._usage, event.usage) }
+          : {}),
+        ...(event.rate_limits ? { _rateLimits: event.rate_limits } : {}),
+      };
+      if (idx === msgs.length - 1) lastMsg = msgs[idx];
+    }
+  }
+
+  // Claude Code emits a top-level `system` event with
+  // `subtype: "compact_boundary"` whenever auto-compaction runs. Flag
+  // the message transiently so the live status can show "compacting…";
+  // `freezeElapsed` strips this on stream end so it doesn't persist.
+  else if (event.type === "system" && event.subtype === "compact_boundary") {
+    const am = ensureAssistant();
+    msgs[msgs.length - 1] = { ...am, _compacting: true };
+    lastMsg = msgs[msgs.length - 1];
+  }
+
+  // --- OpenCode JSONL stream events ---
+  else if (
+    event.type === "opencode_stdout" ||
+    event.type === "step_start" ||
+    event.type === "tool_use" ||
+    event.type === "reasoning" ||
+    event.type === "text" ||
+    event.type === "step_finish" ||
+    event.type === "error"
+  ) {
+    const sessionId = extractOpenCodeSessionId(event);
+    if (sessionId) {
+      convo._opencodeSessionId = sessionId;
+      log("Captured OpenCode session ID:", {
+        conversationId,
+        sessionId,
+        eventType: event.type,
+      });
+    }
+
+    if (event.type === "step_start") {
+      ensureAssistant();
+    } else if (event.type === "tool_use") {
+      const am = ensureAssistant();
+      const tool = extractOpenCodeTool(event);
+      const parts = upsertOpenCodePart(cloneParts(am.parts), { type: "tool", ...tool });
+      msgs[msgs.length - 1] = { ...am, parts, isStreaming: true };
+      lastMsg = msgs[msgs.length - 1];
+    } else if (event.type === "reasoning") {
+      const thinkingPart = buildOpenCodeThinkingPart(event);
+      if (thinkingPart) {
+        const am = ensureAssistant();
+        const parts = upsertOpenCodePart(cloneParts(am.parts), thinkingPart);
+        const stillThinking = !Number.isFinite(thinkingPart.durationMs);
+        msgs[msgs.length - 1] = { ...am, parts, isStreaming: true, isThinking: stillThinking };
+        lastMsg = msgs[msgs.length - 1];
+      }
+    } else if (event.type === "text" || event.type === "opencode_stdout") {
+      const textParts = splitOpenCodeTextAndThinkingParts(event);
+      if (textParts.length > 0) {
+        const am = ensureAssistant();
+        const parts = textParts.reduce(
+          (acc, textPart) => upsertOpenCodePart(acc, textPart),
+          cloneParts(am.parts)
+        );
+        msgs[msgs.length - 1] = { ...am, parts, isStreaming: true, isThinking: false };
+        lastMsg = msgs[msgs.length - 1];
+      }
+    } else if (event.type === "error") {
+      const am = ensureAssistant();
+      const parts = cloneParts(am.parts);
+      parts.push({ type: "text", text: `**Error:** ${extractOpenCodeError(event)}` });
+      msgs[msgs.length - 1] = freezeElapsed({ ...am, parts, isStreaming: false, isThinking: false });
+      lastMsg = msgs[msgs.length - 1];
+      nextIsStreaming = false;
+    } else if (event.type === "step_finish") {
+      const am = ensureAssistant();
+      const usage = normalizeOpenCodeUsage(event.part, am._usage);
+      if (usage) {
+        msgs[msgs.length - 1] = { ...am, _usage: usage };
+        lastMsg = msgs[msgs.length - 1];
+      }
+      const reason = event.reason || event.part?.reason || event.status || "";
+      if (/^(stop|done|complete|completed|end_turn)$/i.test(String(reason))) {
+        msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
+        lastMsg = msgs[msgs.length - 1];
+        nextIsStreaming = false;
+      }
+    }
+  }
+
+  // --- Codex JSONL stream events ---
+  else if (event.type === "session_meta" && event.payload?.id) {
+    convo._codexThreadId = event.payload.id;
+    log("Captured Codex thread ID:", {
+      conversationId,
+      threadId: event.payload.id,
+      source: "session_meta",
+    });
+  } else if (event.type === "thread.started") {
+    convo._codexThreadId = event.thread_id;
+    log("Captured Codex thread ID:", {
+      conversationId,
+      threadId: event.thread_id,
+      source: "thread.started",
+    });
+  } else if (event.type === "event_msg" && event.payload?.type === "token_count") {
+    const tokenInfo = event.payload.info;
+    const usage = normalizeCodexUsage(
+      tokenInfo?.last_token_usage || tokenInfo?.total_token_usage,
+      tokenInfo?.model_context_window
+    );
+    const rateLimits = normalizeCodexRateLimits(event.payload.rate_limits);
+    if (usage || rateLimits) {
+      const am = ensureAssistant();
+      const patch = { ...am };
+      if (usage) patch._usage = usage;
+      if (rateLimits) patch._rateLimits = rateLimits;
+      msgs[msgs.length - 1] = patch;
+      lastMsg = msgs[msgs.length - 1];
+    }
+  } else if (event.type === "event_msg" && event.payload?.type === "task_started") {
+    const am = ensureAssistant();
+    const contextWindow = event.payload.model_context_window;
+    if (Number.isFinite(contextWindow)) {
+      msgs[msgs.length - 1] = {
+        ...am,
+        _usage: mergeUsage(am._usage, { context_window: contextWindow }),
+      };
+      lastMsg = msgs[msgs.length - 1];
+    }
+  } else if (event.type === "turn.started") {
+    ensureAssistant();
+  } else if (event.type === "item.started") {
+    const item = event.item || {};
+    if (item.type === "command_execution") {
+      const am = ensureAssistant();
+      const parts = cloneParts(am.parts);
+      parts.push({
+        type: "tool",
+        id: item.id || uid(),
+        name: item.command || "command",
+        args: { command: item.command },
+        result: null,
+        status: "running",
+      });
+      msgs[msgs.length - 1] = { ...am, parts };
+      lastMsg = msgs[msgs.length - 1];
+    }
+  } else if (event.type === "item.completed") {
+    const item = event.item || {};
+    if (item.type === "agent_message") {
+      const am = ensureAssistant();
+      const parts = cloneParts(am.parts);
+      parts.push({ type: "text", text: item.text || "" });
+      msgs[msgs.length - 1] = { ...am, parts };
+      lastMsg = msgs[msgs.length - 1];
+    } else if (item.type === "command_execution") {
+      const am = ensureAssistant();
+      const parts = cloneParts(am.parts);
+      const existingIdx = parts.findIndex(
+        (p) => p.type === "tool" && p.id === item.id
+      );
+      if (existingIdx >= 0) {
+        parts[existingIdx] = {
+          ...parts[existingIdx],
+          result: item.aggregated_output,
+          status: "done",
+        };
+      } else {
+        parts.push({
+          type: "tool",
+          id: item.id || uid(),
+          name: item.command || "command",
+          args: { command: item.command },
+          result: item.aggregated_output,
+          status: "done",
+        });
+      }
+      msgs[msgs.length - 1] = { ...am, parts };
+      lastMsg = msgs[msgs.length - 1];
+    }
+  } else if (event.type === "response_item") {
+    const payload = event.payload || {};
+    if (payload.type === "message" && payload.role === "assistant") {
+      const text = extractCodexResponseText(payload.content);
+      const images = extractCodexResponseImages(payload.content);
+      if (text || images.length > 0) {
+        const am = ensureAssistant();
+        const parts = cloneParts(am.parts);
+        if (text) parts.push({ type: "text", text });
+        for (const imagePart of images) parts.push(imagePart);
+        msgs[msgs.length - 1] = { ...am, parts };
+        lastMsg = msgs[msgs.length - 1];
+      }
+    } else if (payload.type === "function_call" || payload.type === "custom_tool_call") {
+      const am = ensureAssistant();
+      const parts = cloneParts(am.parts);
+      const toolId = payload.call_id || uid();
+      const existingIdx = parts.findIndex((p) => p.type === "tool" && p.id === toolId);
+      const nextTool = {
+        type: "tool",
+        id: toolId,
+        name: payload.name || "tool",
+        args: normalizeCodexToolArgs(payload),
+        result: existingIdx >= 0 ? parts[existingIdx].result : null,
+        status: payload.status === "completed" ? "done" : "running",
+      };
+
+      if (existingIdx >= 0) {
+        parts[existingIdx] = { ...parts[existingIdx], ...nextTool };
+      } else {
+        parts.push(nextTool);
+      }
+
+      msgs[msgs.length - 1] = { ...am, parts };
+      lastMsg = msgs[msgs.length - 1];
+    } else if (payload.type === "function_call_output" || payload.type === "custom_tool_call_output") {
+      const am = ensureAssistant();
+      const parts = cloneParts(am.parts);
+      const existingIdx = parts.findIndex(
+        (p) => p.type === "tool" && p.id === payload.call_id
+      );
+      const result = normalizeCodexToolResult(payload.output);
+
+      if (existingIdx >= 0) {
+        parts[existingIdx] = {
+          ...parts[existingIdx],
+          result,
+          status: "done",
+        };
+      } else {
+        parts.push({
+          type: "tool",
+          id: payload.call_id || uid(),
+          name: "tool",
+          args: {},
+          result,
+          status: "done",
+        });
+      }
+
+      msgs[msgs.length - 1] = { ...am, parts };
+      lastMsg = msgs[msgs.length - 1];
+    }
+  } else if (event.type === "turn.completed") {
+    if (lastMsg && lastMsg.role === "assistant") {
+      // RayLine's live Codex stdout still uses the older
+      // `thread.started`/`turn.completed` schema even though the saved
+      // session JSONL now contains the richer `token_count` event.
+      // Merge this older usage packet as an immediate fallback so the
+      // footer can render without waiting for session-file hydration.
+      const fallbackUsage = normalizeCodexUsage(event.usage);
+      msgs[msgs.length - 1] = freezeElapsed({
+        ...lastMsg,
+        ...(fallbackUsage
+          ? { _usage: mergeUsage(lastMsg._usage, fallbackUsage) }
+          : {}),
+        isStreaming: false,
+        isThinking: false,
+      });
+      lastMsg = msgs[msgs.length - 1];
+    }
+    nextIsStreaming = false;
+  } else if (event.type === "event_msg" && event.payload?.type === "task_complete") {
+    const completionText = event.payload.last_agent_message;
+    const am = ensureAssistant();
+    let parts = cloneParts(am.parts);
+    const hasText = parts.some((part) => part.type === "text" && part.text);
+
+    if (!hasText && completionText) {
+      parts.push({ type: "text", text: completionText });
+    }
+
+    msgs[msgs.length - 1] = freezeElapsed({
+      ...am,
+      parts,
+      isStreaming: false,
+      isThinking: false,
+    });
+    lastMsg = msgs[msgs.length - 1];
+    nextIsStreaming = false;
+  }
+
+  next.set(conversationId, { ...convo, messages: msgs, isStreaming: nextIsStreaming });
+  return next;
+}
+
 export default function useAgent() {
   const [conversations, setConversations] = useState(new Map());
   const cleanupRefs = useRef([]);
   const pendingStartsRef = useRef(new Map());
   const usageHydrationTimersRef = useRef(new Set());
+  // Stream-event coalescing (see PHASE 2 optimization): incoming IPC stream
+  // events are buffered here in arrival order and folded into React state on a
+  // controlled ~30fps cadence instead of one commit per token.
+  const pendingStreamEventsRef = useRef([]);
+  const streamFlushFrameRef = useRef(0);
+  const lastStreamFlushAtRef = useRef(0);
 
   useEffect(() => {
     if (!window.api) return;
@@ -521,652 +1206,61 @@ export default function useAgent() {
       });
     };
 
+    // Apply all buffered stream events in arrival order as a SINGLE React
+    // commit. Lossless: every queued event is reduced; ordering is preserved by
+    // the array + reduce. The evolving Map threads through each event so
+    // in-place `convo._claudeSessionId = ...` mutations on the shared convo
+    // object reference still work (each event does `new Map(prev)` whose
+    // `.get()` returns the same convo object).
+    const flushStreamEvents = () => {
+      const pending = pendingStreamEventsRef.current;
+      if (pending.length === 0) return;
+      pendingStreamEventsRef.current = [];
+      lastStreamFlushAtRef.current = performance.now();
+      setConversations((prev) =>
+        pending.reduce(
+          (map, item) => applyStreamEventToConversations(map, item.conversationId, item.event),
+          prev
+        )
+      );
+    };
+
+    // Schedule a coalesced flush via rAF, throttled to ~30fps. If a frame is
+    // already scheduled, no-op. In the rAF callback, if we flushed too
+    // recently, re-schedule another frame; otherwise flush now.
+    const scheduleStreamFlush = () => {
+      if (streamFlushFrameRef.current) return;
+      const tick = () => {
+        const now = performance.now();
+        if (now - lastStreamFlushAtRef.current < STREAM_FLUSH_MIN_INTERVAL_MS) {
+          streamFlushFrameRef.current = requestAnimationFrame(tick);
+          return;
+        }
+        streamFlushFrameRef.current = 0;
+        flushStreamEvents();
+      };
+      streamFlushFrameRef.current = requestAnimationFrame(tick);
+    };
+
     const offStream = window.api.onAgentStream(({ conversationId, event }) => {
-      setConversations((prev) => {
-        const next = new Map(prev);
-        const convo = next.get(conversationId) || { messages: [], isStreaming: true, error: null };
-        const msgs = [...convo.messages];
-        let lastMsg = msgs[msgs.length - 1];
-        // Some runs finish logically before the underlying CLI process fully
-        // exits, e.g. a background shell keeps stdout/stderr open for a moment.
-        // Track the conversation-level flag separately so we can unblock the UI
-        // on terminal completion events without waiting for `agent-done`.
-        let nextIsStreaming = Boolean(convo.isStreaming);
-
-        if (event.session_id && convo._claudeSessionId !== event.session_id) {
-          convo._claudeSessionId = event.session_id;
-          log("Captured Claude session ID:", {
-            conversationId,
-            sessionId: event.session_id,
-            eventType: event.type,
-            subtype: event.subtype,
-          });
+      pendingStreamEventsRef.current.push({ conversationId, event });
+      // Terminal / must-show-now events bypass the coalescer so completion and
+      // the `isStreaming` flip feel snappy.
+      if (isImmediateFlushEvent(event)) {
+        if (streamFlushFrameRef.current) {
+          cancelAnimationFrame(streamFlushFrameRef.current);
+          streamFlushFrameRef.current = 0;
         }
-
-        const ensureAssistant = () => {
-          if (!lastMsg || lastMsg.role !== "assistant") {
-            lastMsg = {
-              id: uid(),
-              role: "assistant",
-              parts: [],
-              isStreaming: true,
-              isThinking: false,
-              _streamState: cloneStreamState(),
-              _startedAt: Date.now(),
-              _usage: null,
-            };
-            msgs.push(lastMsg);
-          } else if (!lastMsg._startedAt) {
-            lastMsg = { ...lastMsg, _startedAt: Date.now() };
-            msgs[msgs.length - 1] = lastMsg;
-          }
-          return lastMsg;
-        };
-
-        if (typeof event.type === "string" && event.type.startsWith("multica:")) {
-          const inner = event.type.slice("multica:".length);
-          const p = event.payload || {};
-          // transient — resets per-session; stripped in buildPersistedConversationSnapshot
-          const connectedPatch = convo.multicaConnected ? null : { multicaConnected: true };
-
-          // No-op branches return early WITHOUT running ensureAssistant — we
-          // don't want a stray empty assistant bubble if a user echo arrives
-          // before any task:message.
-          if (inner === "chat:message" && p.role === "user") {
-            if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
-            return next;
-          }
-          if (inner === "agent:status") {
-            window.dispatchEvent(new CustomEvent("multica-agent-status", { detail: p.agent }));
-            if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
-            return next;
-          }
-
-          const assistant = ensureAssistant();
-
-          if (inner === "task:message") {
-            const part = mapMulticaTaskMessage(p);
-            if (!part) {
-              if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
-              return next;
-            }
-            const parts = [...(assistant.parts || [])];
-            if (p.type === "tool_result") {
-              const pendingIdx = findPendingMulticaToolIdx(parts, p.tool);
-              if (pendingIdx >= 0) {
-                parts[pendingIdx] = { ...parts[pendingIdx], result: p.output || "", status: "done" };
-              } else {
-                parts.push(part);
-              }
-            } else {
-              parts.push(part);
-            }
-            msgs[msgs.length - 1] = { ...assistant, parts, isStreaming: true };
-            next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: true });
-            return next;
-          }
-
-          if (inner === "chat:done" || inner === "task:completed") {
-            msgs[msgs.length - 1] = freezeElapsed({ ...assistant, isStreaming: false });
-            next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: false });
-            return next;
-          }
-
-          if (inner === "task:cancelled") {
-            msgs[msgs.length - 1] = freezeElapsed({ ...assistant, isStreaming: false });
-            next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: false, error: null });
-            return next;
-          }
-
-          if (inner === "task:failed" || inner === "error") {
-            msgs[msgs.length - 1] = freezeElapsed({
-              ...assistant, isStreaming: false,
-              parts: [...(assistant.parts || []), { type: "text", text: `_Multica ${inner}: ${p.message || p.reason || ""}_` }],
-            });
-            next.set(conversationId, { ...convo, ...connectedPatch, messages: msgs, isStreaming: false, error: p.message || inner });
-            return next;
-          }
-
-          if (connectedPatch) next.set(conversationId, { ...convo, ...connectedPatch });
-          return next;
-        }
-
-        if (event.type === "stream_event") {
-          const inner = event.event;
-          if (!inner) { next.set(conversationId, { ...convo, messages: msgs }); return next; }
-
-          // Helper to update the last assistant message and keep lastMsg in sync
-          const updateAssistant = (updates) => {
-            const merged = { ...lastMsg, ...updates };
-            msgs[msgs.length - 1] = merged;
-            lastMsg = merged;
-          };
-
-          // Context-window fullness tracking.
-          //
-          // We deliberately track the LATEST API call's usage (not the turn
-          // aggregate). A multi-tool-use turn re-sends the prompt once per
-          // call, so aggregating would make `cache_read` balloon by the number
-          // of calls — that measures how much *work* was done, not how full
-          // the window is. The cumulative snapshot at the END of the last
-          // call is what actually reflects "tokens currently in the window."
-          //
-          // - `message_start` → overwrite `_usage` (new API call begins)
-          // - `message_delta` → merge (output_tokens grows during generation)
-          // - `result` below → ignored for usage (it's turn-aggregated)
-          if (inner.type === "message_start" && inner.message?.usage) {
-            ensureAssistant();
-            updateAssistant({ _usage: { ...inner.message.usage } });
-          } else if (inner.type === "message_delta" && inner.usage) {
-            ensureAssistant();
-            updateAssistant({ _usage: mergeUsage(lastMsg._usage, inner.usage) });
-          }
-
-          if (inner.type === "content_block_start") {
-            const block = inner.content_block;
-            ensureAssistant();
-            const parts = cloneParts(lastMsg.parts);
-            const streamState = cloneStreamState(lastMsg._streamState);
-            const blockIndex = inner.index;
-
-            if (streamState.seenIndexes[blockIndex]) {
-              streamState.currentTurn += 1;
-              streamState.seenIndexes = {};
-              streamState.activeBlocks = {};
-              streamState.activeThinking = {};
-            }
-
-            streamState.seenIndexes[blockIndex] = true;
-            const streamKey = buildBlockKey(streamState.currentTurn, blockIndex);
-            streamState.activeBlocks[blockIndex] = streamKey;
-
-            if (block?.type === "thinking") {
-              parts.push({ type: "thinking", text: "", blockIndex, _streamKey: streamKey });
-              streamState.activeThinking[streamKey] = true;
-              updateAssistant({ parts, isStreaming: true, isThinking: true, _streamState: streamState });
-            } else if (block?.type === "tool_use") {
-              parts.push({
-                type: "tool",
-                id: block.id || "tc" + uid(),
-                name: block.name || "unknown",
-                args: {},
-                argsJson: "",
-                result: null,
-                status: "running",
-                blockIndex,
-                _streamKey: streamKey,
-              });
-              updateAssistant({ parts, isStreaming: true, _streamState: streamState });
-            } else if (block?.type === "text") {
-              parts.push({ type: "text", text: "", blockIndex, _streamKey: streamKey });
-              updateAssistant({ parts, isStreaming: true, _streamState: streamState });
-            } else if (block?.type === "image") {
-              // Anthropic vision-output blocks arrive whole (no per-delta data
-              // for image bytes), so push the full image part on start.
-              const imagePart = buildImagePartFromAnthropicBlock(block);
-              if (imagePart) {
-                parts.push({ ...imagePart, blockIndex, _streamKey: streamKey });
-                updateAssistant({ parts, isStreaming: true, _streamState: streamState });
-              }
-            }
-          } else if (inner.type === "content_block_delta") {
-            ensureAssistant();
-            const parts = cloneParts(lastMsg.parts);
-            const streamState = cloneStreamState(lastMsg._streamState);
-            const delta = inner.delta;
-            const streamKey = streamState.activeBlocks[inner.index];
-            if (delta?.type === "text_delta") {
-              const textIdx = findPartIndexByStreamKey(parts, streamKey, "text");
-              if (textIdx >= 0) {
-                parts[textIdx] = { ...parts[textIdx], text: parts[textIdx].text + (delta.text || "") };
-              }
-              updateAssistant({ parts, isStreaming: true, _streamState: streamState });
-            } else if (delta?.type === "input_json_delta") {
-              const toolIdx = findPartIndexByStreamKey(parts, streamKey, "tool");
-              if (toolIdx >= 0) {
-                const newJson = (parts[toolIdx].argsJson || "") + (delta.partial_json || "");
-                let newArgs = parts[toolIdx].args;
-                try {
-                  newArgs = JSON.parse(newJson);
-                } catch {
-                  // Keep accumulating partial JSON until it becomes parseable.
-                }
-                parts[toolIdx] = { ...parts[toolIdx], argsJson: newJson, args: newArgs };
-              }
-              updateAssistant({ parts, isStreaming: true, _streamState: streamState });
-            } else if (delta?.type === "thinking_delta") {
-              const thinkingIdx = findPartIndexByStreamKey(parts, streamKey, "thinking");
-              if (thinkingIdx >= 0) {
-                parts[thinkingIdx] = {
-                  ...parts[thinkingIdx],
-                  text: parts[thinkingIdx].text + (delta.thinking || ""),
-                };
-              }
-              updateAssistant({ parts, isStreaming: true, isThinking: true, _streamState: streamState });
-            }
-          } else if (inner.type === "content_block_stop") {
-            ensureAssistant();
-            const streamState = cloneStreamState(lastMsg._streamState);
-            const stoppedKey = streamState.activeBlocks[inner.index];
-            delete streamState.activeBlocks[inner.index];
-
-            if (stoppedKey && streamState.activeThinking[stoppedKey]) {
-              delete streamState.activeThinking[stoppedKey];
-            }
-
-            updateAssistant({
-              isThinking: Object.keys(streamState.activeThinking).length > 0,
-              _streamState: streamState,
-            });
-          }
-        } else if (event.type === "assistant") {
-          // With --include-partial-messages, assistant events contain full accumulated text.
-          // Only use these if we have NO stream_event parts yet (fallback for non-streaming).
-          // Usage here is per-API-call, not cumulative — skip it to avoid flicker;
-          // the `result` event below owns the authoritative cumulative usage.
-          ensureAssistant();
-          const parts = cloneParts(lastMsg.parts);
-          const hasStreamParts = parts.length > 0;
-          if (!hasStreamParts && event.message?.content) {
-            for (const block of event.message.content) {
-              if (block.type === "text" && block.text) {
-                parts.push({ type: "text", text: block.text });
-              }
-              if (block.type === "tool_use") {
-                if (!findToolPart(parts, block.id)) {
-                  parts.push({
-                    type: "tool",
-                    id: block.id,
-                    name: block.name || "unknown",
-                    args: block.input || {},
-                    result: null,
-                    status: "running",
-                  });
-                }
-              }
-              if (block.type === "image") {
-                const imagePart = buildImagePartFromAnthropicBlock(block);
-                if (imagePart) parts.push(imagePart);
-              }
-            }
-            msgs[msgs.length - 1] = { ...lastMsg, parts, isThinking: false };
-            lastMsg = msgs[msgs.length - 1];
-          }
-        } else if (event.type === "user") {
-          // Capture the UUID from user events — needed for rewind/edit
-          if (event.uuid) {
-            log("User event UUID:", event.uuid, "has tool_result:",
-              event.message?.content?.some?.(b => b.type === "tool_result"));
-            // Find the last user message and store the Claude-assigned UUID
-            for (let mi = msgs.length - 1; mi >= 0; mi--) {
-              if (msgs[mi].role === "user" && !msgs[mi].claudeUuid) {
-                msgs[mi] = { ...msgs[mi], claudeUuid: event.uuid };
-                log("Stored claudeUuid on user msg:", msgs[mi].text?.slice(0, 50));
-                break;
-              }
-            }
-          }
-          if (event.message?.content) {
-            for (const block of event.message.content) {
-              if (block.type === "tool_result" && block.tool_use_id) {
-                for (let mi = msgs.length - 1; mi >= 0; mi--) {
-                  if (msgs[mi].role === "assistant" && msgs[mi].parts) {
-                    const parts = cloneParts(msgs[mi].parts);
-                    const tpIdx = parts.findIndex(p => p.type === "tool" && p.id === block.tool_use_id);
-                    if (tpIdx >= 0) {
-                      parts[tpIdx] = { ...parts[tpIdx], result: block.content, status: "done" };
-                      msgs[mi] = { ...msgs[mi], parts };
-                      break;
-                    }
-                  }
-                }
-              }
-            }
-          }
-        } else if (event.type === "result") {
-          if (lastMsg && lastMsg.role === "assistant") {
-            // Note: `event.usage` here is aggregated across every API call in
-            // the turn (ballooned `cache_read` when the turn had multiple tool
-            // loops). That's right for cost, wrong for window fullness — we
-            // already captured the final call's cumulative usage from
-            // `message_delta`. Leave `_usage` alone.
-            if (event.is_error || event.subtype === "error_during_execution") {
-              // Surface the error as text in the assistant message
-              const errorText = event.result || event.error
-                || (event.errors && event.errors.length > 0 ? event.errors.join("\n") : null)
-                || "An error occurred.";
-              const parts = cloneParts(lastMsg.parts);
-              parts.push({ type: "text", text: `**Error:** ${errorText}` });
-              msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, parts, isStreaming: false, isThinking: false });
-            } else if (event.terminal_reason === "hook_stopped") {
-              const parts = cloneParts(lastMsg.parts);
-              const hasPausedStatus = parts.some((part) => part.type === "status" && part.kind === "paused");
-              if (!hasPausedStatus) {
-                parts.push({
-                  type: "status",
-                  kind: "paused",
-                  title: "Paused by hook",
-                  text: "Claude stopped after a tool hook returned continue: false. This is expected — send another message when you want to continue.",
-                });
-              }
-              msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, parts, isStreaming: false, isThinking: false });
-            } else {
-              msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
-            }
-          }
-          nextIsStreaming = false;
-        }
-
-        // Claude Code plan quota — synthetic event emitted by the main process
-        // after each `result`, sourced from `api.anthropic.com/api/oauth/usage`
-        // (Pro/Max only — silently absent for API-key users). Already
-        // normalized to the same `{ five_hour, seven_day }` shape Codex uses,
-        // so it just attaches to the latest assistant message.
-        else if (event.type === "rate_limits" && event.rate_limits) {
-          const idx = findLatestAssistantIndex(msgs);
-          if (idx >= 0) {
-            msgs[idx] = { ...msgs[idx], _rateLimits: event.rate_limits };
-            if (idx === msgs.length - 1) lastMsg = msgs[idx];
-          }
-        }
-
-        else if (event.type === "session_snapshot" && event.provider === "codex") {
-          if (event.thread_id) {
-            convo._codexThreadId = event.thread_id;
-          }
-          const idx = findLatestAssistantIndex(msgs);
-          if (idx >= 0) {
-            msgs[idx] = {
-              ...msgs[idx],
-              ...(event.usage
-                ? { _usage: mergeUsage(msgs[idx]._usage, event.usage) }
-                : {}),
-              ...(event.rate_limits ? { _rateLimits: event.rate_limits } : {}),
-            };
-            if (idx === msgs.length - 1) lastMsg = msgs[idx];
-          }
-        }
-
-        // Claude Code emits a top-level `system` event with
-        // `subtype: "compact_boundary"` whenever auto-compaction runs. Flag
-        // the message transiently so the live status can show "compacting…";
-        // `freezeElapsed` strips this on stream end so it doesn't persist.
-        else if (event.type === "system" && event.subtype === "compact_boundary") {
-          const am = ensureAssistant();
-          msgs[msgs.length - 1] = { ...am, _compacting: true };
-          lastMsg = msgs[msgs.length - 1];
-        }
-
-        // --- OpenCode JSONL stream events ---
-        else if (
-          event.type === "opencode_stdout" ||
-          event.type === "step_start" ||
-          event.type === "tool_use" ||
-          event.type === "reasoning" ||
-          event.type === "text" ||
-          event.type === "step_finish" ||
-          event.type === "error"
-        ) {
-          const sessionId = extractOpenCodeSessionId(event);
-          if (sessionId) {
-            convo._opencodeSessionId = sessionId;
-            log("Captured OpenCode session ID:", {
-              conversationId,
-              sessionId,
-              eventType: event.type,
-            });
-          }
-
-          if (event.type === "step_start") {
-            ensureAssistant();
-          } else if (event.type === "tool_use") {
-            const am = ensureAssistant();
-            const tool = extractOpenCodeTool(event);
-            const parts = upsertOpenCodePart(cloneParts(am.parts), { type: "tool", ...tool });
-            msgs[msgs.length - 1] = { ...am, parts, isStreaming: true };
-            lastMsg = msgs[msgs.length - 1];
-          } else if (event.type === "reasoning") {
-            const thinkingPart = buildOpenCodeThinkingPart(event);
-            if (thinkingPart) {
-              const am = ensureAssistant();
-              const parts = upsertOpenCodePart(cloneParts(am.parts), thinkingPart);
-              const stillThinking = !Number.isFinite(thinkingPart.durationMs);
-              msgs[msgs.length - 1] = { ...am, parts, isStreaming: true, isThinking: stillThinking };
-              lastMsg = msgs[msgs.length - 1];
-            }
-          } else if (event.type === "text" || event.type === "opencode_stdout") {
-            const textParts = splitOpenCodeTextAndThinkingParts(event);
-            if (textParts.length > 0) {
-              const am = ensureAssistant();
-              const parts = textParts.reduce(
-                (acc, textPart) => upsertOpenCodePart(acc, textPart),
-                cloneParts(am.parts)
-              );
-              msgs[msgs.length - 1] = { ...am, parts, isStreaming: true, isThinking: false };
-              lastMsg = msgs[msgs.length - 1];
-            }
-          } else if (event.type === "error") {
-            const am = ensureAssistant();
-            const parts = cloneParts(am.parts);
-            parts.push({ type: "text", text: `**Error:** ${extractOpenCodeError(event)}` });
-            msgs[msgs.length - 1] = freezeElapsed({ ...am, parts, isStreaming: false, isThinking: false });
-            lastMsg = msgs[msgs.length - 1];
-            nextIsStreaming = false;
-          } else if (event.type === "step_finish") {
-            const am = ensureAssistant();
-            const usage = normalizeOpenCodeUsage(event.part, am._usage);
-            if (usage) {
-              msgs[msgs.length - 1] = { ...am, _usage: usage };
-              lastMsg = msgs[msgs.length - 1];
-            }
-            const reason = event.reason || event.part?.reason || event.status || "";
-            if (/^(stop|done|complete|completed|end_turn)$/i.test(String(reason))) {
-              msgs[msgs.length - 1] = freezeElapsed({ ...lastMsg, isStreaming: false, isThinking: false });
-              lastMsg = msgs[msgs.length - 1];
-              nextIsStreaming = false;
-            }
-          }
-        }
-
-        // --- Codex JSONL stream events ---
-        else if (event.type === "session_meta" && event.payload?.id) {
-          convo._codexThreadId = event.payload.id;
-          log("Captured Codex thread ID:", {
-            conversationId,
-            threadId: event.payload.id,
-            source: "session_meta",
-          });
-        } else if (event.type === "thread.started") {
-          convo._codexThreadId = event.thread_id;
-          log("Captured Codex thread ID:", {
-            conversationId,
-            threadId: event.thread_id,
-            source: "thread.started",
-          });
-        } else if (event.type === "event_msg" && event.payload?.type === "token_count") {
-          const tokenInfo = event.payload.info;
-          const usage = normalizeCodexUsage(
-            tokenInfo?.last_token_usage || tokenInfo?.total_token_usage,
-            tokenInfo?.model_context_window
-          );
-          const rateLimits = normalizeCodexRateLimits(event.payload.rate_limits);
-          if (usage || rateLimits) {
-            const am = ensureAssistant();
-            const patch = { ...am };
-            if (usage) patch._usage = usage;
-            if (rateLimits) patch._rateLimits = rateLimits;
-            msgs[msgs.length - 1] = patch;
-            lastMsg = msgs[msgs.length - 1];
-          }
-        } else if (event.type === "event_msg" && event.payload?.type === "task_started") {
-          const am = ensureAssistant();
-          const contextWindow = event.payload.model_context_window;
-          if (Number.isFinite(contextWindow)) {
-            msgs[msgs.length - 1] = {
-              ...am,
-              _usage: mergeUsage(am._usage, { context_window: contextWindow }),
-            };
-            lastMsg = msgs[msgs.length - 1];
-          }
-        } else if (event.type === "turn.started") {
-          ensureAssistant();
-        } else if (event.type === "item.started") {
-          const item = event.item || {};
-          if (item.type === "command_execution") {
-            const am = ensureAssistant();
-            const parts = cloneParts(am.parts);
-            parts.push({
-              type: "tool",
-              id: item.id || uid(),
-              name: item.command || "command",
-              args: { command: item.command },
-              result: null,
-              status: "running",
-            });
-            msgs[msgs.length - 1] = { ...am, parts };
-            lastMsg = msgs[msgs.length - 1];
-          }
-        } else if (event.type === "item.completed") {
-          const item = event.item || {};
-          if (item.type === "agent_message") {
-            const am = ensureAssistant();
-            const parts = cloneParts(am.parts);
-            parts.push({ type: "text", text: item.text || "" });
-            msgs[msgs.length - 1] = { ...am, parts };
-            lastMsg = msgs[msgs.length - 1];
-          } else if (item.type === "command_execution") {
-            const am = ensureAssistant();
-            const parts = cloneParts(am.parts);
-            const existingIdx = parts.findIndex(
-              (p) => p.type === "tool" && p.id === item.id
-            );
-            if (existingIdx >= 0) {
-              parts[existingIdx] = {
-                ...parts[existingIdx],
-                result: item.aggregated_output,
-                status: "done",
-              };
-            } else {
-              parts.push({
-                type: "tool",
-                id: item.id || uid(),
-                name: item.command || "command",
-                args: { command: item.command },
-                result: item.aggregated_output,
-                status: "done",
-              });
-            }
-            msgs[msgs.length - 1] = { ...am, parts };
-            lastMsg = msgs[msgs.length - 1];
-          }
-        } else if (event.type === "response_item") {
-          const payload = event.payload || {};
-          if (payload.type === "message" && payload.role === "assistant") {
-            const text = extractCodexResponseText(payload.content);
-            const images = extractCodexResponseImages(payload.content);
-            if (text || images.length > 0) {
-              const am = ensureAssistant();
-              const parts = cloneParts(am.parts);
-              if (text) parts.push({ type: "text", text });
-              for (const imagePart of images) parts.push(imagePart);
-              msgs[msgs.length - 1] = { ...am, parts };
-              lastMsg = msgs[msgs.length - 1];
-            }
-          } else if (payload.type === "function_call" || payload.type === "custom_tool_call") {
-            const am = ensureAssistant();
-            const parts = cloneParts(am.parts);
-            const toolId = payload.call_id || uid();
-            const existingIdx = parts.findIndex((p) => p.type === "tool" && p.id === toolId);
-            const nextTool = {
-              type: "tool",
-              id: toolId,
-              name: payload.name || "tool",
-              args: normalizeCodexToolArgs(payload),
-              result: existingIdx >= 0 ? parts[existingIdx].result : null,
-              status: payload.status === "completed" ? "done" : "running",
-            };
-
-            if (existingIdx >= 0) {
-              parts[existingIdx] = { ...parts[existingIdx], ...nextTool };
-            } else {
-              parts.push(nextTool);
-            }
-
-            msgs[msgs.length - 1] = { ...am, parts };
-            lastMsg = msgs[msgs.length - 1];
-          } else if (payload.type === "function_call_output" || payload.type === "custom_tool_call_output") {
-            const am = ensureAssistant();
-            const parts = cloneParts(am.parts);
-            const existingIdx = parts.findIndex(
-              (p) => p.type === "tool" && p.id === payload.call_id
-            );
-            const result = normalizeCodexToolResult(payload.output);
-
-            if (existingIdx >= 0) {
-              parts[existingIdx] = {
-                ...parts[existingIdx],
-                result,
-                status: "done",
-              };
-            } else {
-              parts.push({
-                type: "tool",
-                id: payload.call_id || uid(),
-                name: "tool",
-                args: {},
-                result,
-                status: "done",
-              });
-            }
-
-            msgs[msgs.length - 1] = { ...am, parts };
-            lastMsg = msgs[msgs.length - 1];
-          }
-        } else if (event.type === "turn.completed") {
-          if (lastMsg && lastMsg.role === "assistant") {
-            // RayLine's live Codex stdout still uses the older
-            // `thread.started`/`turn.completed` schema even though the saved
-            // session JSONL now contains the richer `token_count` event.
-            // Merge this older usage packet as an immediate fallback so the
-            // footer can render without waiting for session-file hydration.
-            const fallbackUsage = normalizeCodexUsage(event.usage);
-            msgs[msgs.length - 1] = freezeElapsed({
-              ...lastMsg,
-              ...(fallbackUsage
-                ? { _usage: mergeUsage(lastMsg._usage, fallbackUsage) }
-                : {}),
-              isStreaming: false,
-              isThinking: false,
-            });
-            lastMsg = msgs[msgs.length - 1];
-          }
-          nextIsStreaming = false;
-        } else if (event.type === "event_msg" && event.payload?.type === "task_complete") {
-          const completionText = event.payload.last_agent_message;
-          const am = ensureAssistant();
-          let parts = cloneParts(am.parts);
-          const hasText = parts.some((part) => part.type === "text" && part.text);
-
-          if (!hasText && completionText) {
-            parts.push({ type: "text", text: completionText });
-          }
-
-          msgs[msgs.length - 1] = freezeElapsed({
-            ...am,
-            parts,
-            isStreaming: false,
-            isThinking: false,
-          });
-          lastMsg = msgs[msgs.length - 1];
-          nextIsStreaming = false;
-        }
-
-        next.set(conversationId, { ...convo, messages: msgs, isStreaming: nextIsStreaming });
-        return next;
-      });
+        flushStreamEvents();
+      } else {
+        scheduleStreamFlush();
+      }
     });
 
     const offDone = window.api.onAgentDone(({ conversationId, provider, threadId }) => {
+      // Backstop: apply any buffered tokens BEFORE this done finalization so we
+      // never freeze a message before its last coalesced tokens land.
+      flushStreamEvents();
       pendingStartsRef.current.delete(conversationId);
       let codexThreadId = null;
       let needsUsageHydration = false;
@@ -1204,6 +1298,9 @@ export default function useAgent() {
     });
 
     const offError = window.api.onAgentError(({ conversationId, error }) => {
+      // Backstop: apply any buffered tokens BEFORE this error finalization so
+      // buffered output isn't lost when the error message is appended.
+      flushStreamEvents();
       pendingStartsRef.current.delete(conversationId);
       setConversations((prev) => {
         const next = new Map(prev);
@@ -1228,6 +1325,13 @@ export default function useAgent() {
       cleanupFns.forEach((fn) => fn?.());
       usageHydrationTimers.forEach((timerId) => window.clearTimeout(timerId));
       usageHydrationTimers.clear();
+      // Cancel any scheduled stream flush and drop buffered events. No flush on
+      // unmount — the state being flushed into is going away anyway.
+      if (streamFlushFrameRef.current) {
+        cancelAnimationFrame(streamFlushFrameRef.current);
+        streamFlushFrameRef.current = 0;
+      }
+      pendingStreamEventsRef.current = [];
     };
   }, []);
 

--- a/src/hooks/useAgent.js
+++ b/src/hooks/useAgent.js
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, startTransition } from "react";
 import { createLogger } from "../utils/logger";
 
 let _msgId = 0;
@@ -1212,17 +1212,26 @@ export default function useAgent() {
     // in-place `convo._claudeSessionId = ...` mutations on the shared convo
     // object reference still work (each event does `new Map(prev)` whose
     // `.get()` returns the same convo object).
-    const flushStreamEvents = () => {
+    const flushStreamEvents = (urgent = false) => {
       const pending = pendingStreamEventsRef.current;
       if (pending.length === 0) return;
       pendingStreamEventsRef.current = [];
       lastStreamFlushAtRef.current = performance.now();
-      setConversations((prev) =>
-        pending.reduce(
-          (map, item) => applyStreamEventToConversations(map, item.conversationId, item.event),
-          prev
-        )
-      );
+      const commit = () =>
+        setConversations((prev) =>
+          pending.reduce(
+            (map, item) => applyStreamEventToConversations(map, item.conversationId, item.event),
+            prev
+          )
+        );
+      // Coalesced mid-stream flushes are marked as a non-urgent transition so
+      // React renders them at low priority and yields to urgent work (composer
+      // keystrokes, scroll) — this is what keeps typing smooth while a rich
+      // response streams. Terminal/backstop flushes commit urgently so the
+      // final content and the `isStreaming` flip appear immediately and stay
+      // correctly ordered before done/error finalization.
+      if (urgent) commit();
+      else startTransition(commit);
     };
 
     // Schedule a coalesced flush via rAF, throttled to ~30fps. If a frame is
@@ -1251,7 +1260,7 @@ export default function useAgent() {
           cancelAnimationFrame(streamFlushFrameRef.current);
           streamFlushFrameRef.current = 0;
         }
-        flushStreamEvents();
+        flushStreamEvents(true);
       } else {
         scheduleStreamFlush();
       }
@@ -1260,7 +1269,7 @@ export default function useAgent() {
     const offDone = window.api.onAgentDone(({ conversationId, provider, threadId }) => {
       // Backstop: apply any buffered tokens BEFORE this done finalization so we
       // never freeze a message before its last coalesced tokens land.
-      flushStreamEvents();
+      flushStreamEvents(true);
       pendingStartsRef.current.delete(conversationId);
       let codexThreadId = null;
       let needsUsageHydration = false;
@@ -1300,7 +1309,7 @@ export default function useAgent() {
     const offError = window.api.onAgentError(({ conversationId, error }) => {
       // Backstop: apply any buffered tokens BEFORE this error finalization so
       // buffered output isn't lost when the error message is appended.
-      flushStreamEvents();
+      flushStreamEvents(true);
       pendingStartsRef.current.delete(conversationId);
       setConversations((prev) => {
         const next = new Map(prev);


### PR DESCRIPTION
Closes #226 (Phases 2–6; P1 instrumentation harness and P7 CSS pass intentionally out of scope for this PR).

## What & why

The UI committed React state **once per stream event** (per token/delta, >100/sec). Because IPC stream events arrive in separate event-loop turns, React could not batch them, so every token re-rendered `ChatArea`, **every** `Message`, and the `Sidebar`. Root chain: `setConversations` → new `Map` → `getConversation` new identity → `activeData`/`convo`/`convosForSidebar` all recompute → whole tree re-renders.

These changes make the existing effects **cheaper and better scheduled** — no visual/UX simplification. Glass/blur, typography, rounded surfaces, hover feedback, transitions, rich markdown, syntax highlighting, math, mermaid, tool blocks, status footer, scroll-to-bottom, and sidebar visual language are all preserved.

## Commits (one per phase)

- **Phase 2 — `perf(streaming)`** (`useAgent.js`): buffer stream events losslessly in a ref; flush in a single `setConversations` on a `requestAnimationFrame` cadence throttled to ~30fps. The per-event reducer is extracted **verbatim** into a pure function and replayed in arrival order (exact ordering + all provider logic preserved). Terminal events flush immediately; `onAgentDone`/`onAgentError` flush pending first as a backstop so no tokens are dropped.
- **Phase 3 + 5 — `perf(chat)`** (`ChatArea.jsx`): extract a memoized `ChatComposer` owning all keystroke-driven state, fed only primitives + stable callbacks, so streaming no longer re-renders the textarea and typing no longer re-renders the transcript; `t`/`COMMANDS` memoized; quoting + whole-pane drag-drop preserved via an imperative handle. Auto-scroll pinning + ResizeObserver batched into one coalesced rAF (`schedulePinToBottom`); follow-mode and scroll-up intent detection unchanged.
- **Phase 4 — `perf(message)`** (`Message.jsx`): memoized `MarkdownTextPart` so completed text parts skip re-parsing during streaming; only the active last part re-parses. Plugin arrays hoisted to module constants; callbacks made stable via `useStableCallback`. Identical rendered output.
- **Phase 6 — `perf(sidebar)`** (`Sidebar.jsx`, `App.jsx`): `Sidebar` wrapped in `memo` with stable callbacks; `convosForSidebar` rebuilt so unchanged rows keep object identity (memoized rows skip) and the streaming row's preview text is throttled to ~2/sec while `isStreaming` flips promptly and the final preview stays accurate. Throttle timer armed in an effect (no render-time side effects). `ProjectGroup` was already memoized — untouched.

## Verification done

- ✅ ESLint clean on all 5 changed files (17 pre-existing errors in untouched `pm-components/` remain).
- ✅ `npm run build` (vite) passes.
- ✅ Manual code review of every integration seam (verbatim reducer extraction, composer memo + stable parent callbacks, MarkdownTextPart memo boundary, scroll rAF batching, sidebar identity reuse).

## Manual runtime test checklist (not yet exercised in a live session)

- [ ] Type continuously in the composer while a long markdown response streams — no character lag, transcript keeps pinning.
- [ ] Large code-block / table response streaming while typing.
- [ ] Conversation with 100+ messages; sidebar with 100+ conversations across many projects.
- [ ] Search the sidebar while a stream is active; footer counts correct.
- [ ] Send (Enter) clears input instantly; Cancel appears only when streaming + input empty.
- [ ] IME/CJK composition (no premature Enter-send); slash-command palette; queued-message edit/save/cancel/delete.
- [ ] Drag-drop a file anywhere in the chat pane; paste image; quote-to-input from selection toolbar.
- [ ] Scroll-to-bottom button + late image/KaTeX/mermaid/tool pinning while following; user scroll-up disables follow.
- [ ] Final assistant content and sidebar preview/title are accurate the instant a stream ends (no stale/dropped tail).
- [ ] Multiple conversations streaming concurrently.
- [ ] Control/interactive blocks, mermaid, math, images still render and stay interactive.

## Regression risks watched

Dropped/reordered tokens (mitigated: lossless FIFO replay + immediate terminal flush + onDone backstop); final flush before `isStreaming` clears; scroll follow on late content; stale sidebar preview after completion; memoization hiding legitimate locale/font-scale/active-convo/wallpaper/model/permission updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)