### PR TITLE
SSH attachment upload and remote file channel

### DIFF
--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -8,6 +8,7 @@ const { createLogger } = require("./logger.cjs");
 const { buildClaudeUpstreamEnv, summarizeProviderUpstream, appendClaudeUpstreamArgs } = require("./provider-upstreams.cjs");
 const { describeRemoteRuntime, normalizeRemoteRuntime, spawnRemoteCommand } = require("./remote-runtime.cjs");
 const { stageRemoteAttachments } = require("./remote-attachments.cjs");
+const { startRemoteChannel } = require("./remote-channel.cjs");
 
 const activeAgents = new Map();
 const log = createLogger("agent-manager");
@@ -57,6 +58,20 @@ function cleanupRemoteAttachments(state) {
   cleanup().catch((err) => log("Remote attachment cleanup failed:", err?.message || err));
 }
 
+function finishRemoteChannel(state) {
+  const channel = state?.remoteChannel;
+  if (!channel) return;
+  state.remoteChannel = null;
+  channel.finish().catch((err) => log("Remote channel finish failed:", err?.message || err));
+}
+
+function disposeRemoteChannel(state) {
+  const channel = state?.remoteChannel;
+  if (!channel) return;
+  state.remoteChannel = null;
+  channel.dispose().catch((err) => log("Remote channel dispose failed:", err?.message || err));
+}
+
 let cachedClaudeBin = null;
 
 function resolveClaudeBin() {
@@ -84,7 +99,7 @@ function resolveLaunchCwd({ cwd, sessionId }) {
   throw new Error(`Invalid working directory: ${cwd}`);
 }
 
-function buildClaudeArgs({ model, sessionId, resumeSessionId, forkSession, projectContext, includeLocalMcp = true, remote = false }) {
+function buildClaudeArgs({ model, sessionId, resumeSessionId, forkSession, projectContext, includeLocalMcp = true, remote = false, remoteChannel = null }) {
   const args = [
     "--print",
     "--input-format=stream-json",
@@ -186,6 +201,10 @@ The user can see and type into these terminals in real time.`;
 REMOTE SSH RUNTIME:
 You are running on a remote SSH host from RayLine. RayLine's local terminal MCP tools and local terminal CLI are not available on this host.
 Use normal shell commands on the remote host for long-running processes, and tell the user when a command must keep running after your turn.`;
+
+    if (remoteChannel?.instructions) {
+      appendPrompt += `\n\n${remoteChannel.instructions}`;
+    }
   }
 
   const trimmedProjectContext = typeof projectContext === "string" ? projectContext.trim() : "";
@@ -322,6 +341,7 @@ async function startAgent({ conversationId, prompt, model, cwd, images, files, s
     sessionAllowlist,
     stdinClosed: false,
     remoteAttachmentCleanup: null,
+    remoteChannel: null,
   };
   activeAgents.set(conversationId, state);
 
@@ -343,6 +363,19 @@ async function startAgent({ conversationId, prompt, model, cwd, images, files, s
       return null;
     }
     state.remoteAttachmentCleanup = stagedRemoteAttachments?.cleanup || null;
+
+    try {
+      state.remoteChannel = await startRemoteChannel({ conversationId, provider: "claude" });
+      log("Started RayLine SSH channel:", state.remoteChannel.describe());
+    } catch (err) {
+      log("RayLine SSH channel unavailable:", err?.message || err);
+      state.remoteChannel = null;
+    }
+
+    if (state.cancelled || activeAgents.get(conversationId) !== state) {
+      disposeRemoteChannel(state);
+      return null;
+    }
   }
 
   const fullPrompt = buildPromptWithAttachments(
@@ -371,6 +404,7 @@ async function startAgent({ conversationId, prompt, model, cwd, images, files, s
       projectContext,
       includeLocalMcp: !remote,
       remote: Boolean(remote),
+      remoteChannel: state.remoteChannel,
     });
     appendClaudeUpstreamArgs(args, providerUpstreamConfig, model, { patchLocalSettings: !remote });
 
@@ -415,8 +449,9 @@ async function startAgent({ conversationId, prompt, model, cwd, images, files, s
             env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
             stdio: ["pipe", "pipe", "pipe"],
           }, {
-            env: { FORCE_COLOR: "0", ...upstreamEnv },
+            env: { FORCE_COLOR: "0", ...upstreamEnv, ...(state.remoteChannel?.env || {}) },
             cwd: remote.cwd,
+            sshArgs: state.remoteChannel?.sshArgs,
           })
         : spawnCli(claudeBin, args, {
             cwd: launchCwd,
@@ -425,6 +460,7 @@ async function startAgent({ conversationId, prompt, model, cwd, images, files, s
           });
     } catch (err) {
       cleanupRemoteAttachments(state);
+      disposeRemoteChannel(state);
       if (activeAgents.get(conversationId) === state) activeAgents.delete(conversationId);
       webContents.send("agent-error", { conversationId, error: err.message || String(err) });
       webContents.send("agent-done", { conversationId, exitCode: -1 });
@@ -620,6 +656,7 @@ async function startAgent({ conversationId, prompt, model, cwd, images, files, s
         },
       });
       cleanupRemoteAttachments(state);
+      finishRemoteChannel(state);
 
       if (state.cancelled) {
         if (isCurrentState) {
@@ -656,6 +693,7 @@ async function startAgent({ conversationId, prompt, model, cwd, images, files, s
       const isCurrentState = activeAgents.get(conversationId) === state;
       log("Spawn error:", err.message);
       cleanupRemoteAttachments(state);
+      disposeRemoteChannel(state);
       if (isCurrentState) activeAgents.delete(conversationId);
       webContents.send("agent-error", { conversationId, error: err.message });
       if (isCurrentState) webContents.send("agent-done", { conversationId, exitCode: -1 });
@@ -767,6 +805,7 @@ function cancelAgent(conversationId) {
     state.pendingPermissions.clear();
   }
   cleanupRemoteAttachments(state);
+  finishRemoteChannel(state);
 
   if (state.child) {
     try { state.endStdin?.(); } catch {}
@@ -785,6 +824,7 @@ function cancelAll() {
     if (!state) continue;
     state.cancelled = true;
     cleanupRemoteAttachments(state);
+    finishRemoteChannel(state);
     if (!state.child) {
       activeAgents.delete(conversationId);
       if (!state.webContents?.isDestroyed?.()) {

--- a/electron/agent-manager.cjs
+++ b/electron/agent-manager.cjs
@@ -7,6 +7,7 @@ const { fetchClaudeUsage } = require("./claude-usage-fetcher.cjs");
 const { createLogger } = require("./logger.cjs");
 const { buildClaudeUpstreamEnv, summarizeProviderUpstream, appendClaudeUpstreamArgs } = require("./provider-upstreams.cjs");
 const { describeRemoteRuntime, normalizeRemoteRuntime, spawnRemoteCommand } = require("./remote-runtime.cjs");
+const { stageRemoteAttachments } = require("./remote-attachments.cjs");
 
 const activeAgents = new Map();
 const log = createLogger("agent-manager");
@@ -47,6 +48,13 @@ function shouldEmitStderrError({ stderrBuffer, resultEvent, exitCode, signal, ca
   if (cancelled || stoppedForQuestion) return false;
   if (resultEvent?.is_error || resultEvent?.subtype === "error_during_execution") return true;
   return !resultEvent && (exitCode !== 0 || Boolean(signal));
+}
+
+function cleanupRemoteAttachments(state) {
+  const cleanup = state?.remoteAttachmentCleanup;
+  if (!cleanup) return;
+  state.remoteAttachmentCleanup = null;
+  cleanup().catch((err) => log("Remote attachment cleanup failed:", err?.message || err));
 }
 
 let cachedClaudeBin = null;
@@ -228,10 +236,16 @@ function classifyPermissionRequest(req) {
 function buildPromptWithAttachments(prompt, images, files, options = {}) {
   let fullPrompt = prompt;
   const isRemote = Boolean(options.remote);
+  const imagesArePaths = Boolean(options.imagesArePaths);
   if (images && images.length > 0) {
     const imgPaths = [];
     for (let i = 0; i < images.length; i++) {
-      const dataUrl = images[i];
+      const dataUrl = typeof images[i] === "string" ? images[i] : images[i]?.dataUrl;
+      if (imagesArePaths && typeof dataUrl === "string" && dataUrl) {
+        imgPaths.push(dataUrl);
+        continue;
+      }
+      if (typeof dataUrl !== "string") continue;
       const match = dataUrl.match(/^data:image\/([\w+.-]+);base64,(.+)$/);
       if (match && !isRemote) {
         const ext = match[1] === "jpeg" ? "jpg" : match[1];
@@ -241,7 +255,8 @@ function buildPromptWithAttachments(prompt, images, files, options = {}) {
       }
     }
     if (imgPaths.length > 0) {
-      fullPrompt = `[Attached images: ${imgPaths.join(", ")}]\n\n${prompt}`;
+      const label = isRemote ? "Attached images uploaded to the remote SSH host" : "Attached images";
+      fullPrompt = `[${label}: ${imgPaths.join(", ")}]\n\n${prompt}`;
     } else if (isRemote) {
       fullPrompt = `[Attached images were provided in RayLine, but they were not copied to the remote SSH host.]\n\n${prompt}`;
     }
@@ -249,15 +264,14 @@ function buildPromptWithAttachments(prompt, images, files, options = {}) {
 
   if (files && files.length > 0) {
     const filePaths = files.map((f) => f.path).join("\n");
-    fullPrompt = isRemote
-      ? `[Attached files were provided in RayLine, but these local paths were not copied to the remote SSH host:\n${filePaths}]\n\n${fullPrompt}`
-      : `[Attached files:\n${filePaths}]\n\n${fullPrompt}`;
+    const label = isRemote ? "Attached files uploaded to the remote SSH host" : "Attached files";
+    fullPrompt = `[${label}:\n${filePaths}]\n\n${fullPrompt}`;
   }
 
   return fullPrompt;
 }
 
-function startAgent({ conversationId, prompt, model, cwd, images, files, sessionId, resumeSessionId, forkSession, providerUpstreamConfig, remoteRuntime, projectContext }, webContents) {
+async function startAgent({ conversationId, prompt, model, cwd, images, files, sessionId, resumeSessionId, forkSession, providerUpstreamConfig, remoteRuntime, projectContext }, webContents) {
   cancelAgent(conversationId);
 
   const agentSessionId = resumeSessionId || sessionId;
@@ -280,8 +294,6 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
     webContents.send("agent-done", { conversationId, exitCode: -1 });
     return null;
   }
-
-  const fullPrompt = buildPromptWithAttachments(prompt, images, files, { remote: Boolean(remote) });
 
   const existing = activeAgents.get(conversationId);
   const sessionAllowlist = existing?.sessionAllowlist instanceof Set
@@ -309,7 +321,36 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
     pendingPermissions: new Map(),
     sessionAllowlist,
     stdinClosed: false,
+    remoteAttachmentCleanup: null,
   };
+  activeAgents.set(conversationId, state);
+
+  let stagedRemoteAttachments = null;
+  if (remote) {
+    try {
+      stagedRemoteAttachments = await stageRemoteAttachments(remote, { images, files });
+    } catch (err) {
+      if (state.cancelled || activeAgents.get(conversationId) !== state) return null;
+      const error = `Failed to upload attachments to the remote SSH host: ${err?.message || err}`;
+      log(error);
+      activeAgents.delete(conversationId);
+      webContents.send("agent-error", { conversationId, error });
+      webContents.send("agent-done", { conversationId, exitCode: -1 });
+      return null;
+    }
+    if (state.cancelled || activeAgents.get(conversationId) !== state) {
+      await stagedRemoteAttachments?.cleanup?.().catch(() => {});
+      return null;
+    }
+    state.remoteAttachmentCleanup = stagedRemoteAttachments?.cleanup || null;
+  }
+
+  const fullPrompt = buildPromptWithAttachments(
+    prompt,
+    remote ? stagedRemoteAttachments?.images : images,
+    remote ? stagedRemoteAttachments?.files : files,
+    { remote: Boolean(remote), imagesArePaths: Boolean(remote) }
+  );
 
   const upstreamEnv = buildClaudeUpstreamEnv(providerUpstreamConfig);
   const upstreamSummary = summarizeProviderUpstream(providerUpstreamConfig, "claude");
@@ -366,20 +407,29 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
     log("Full args:", args.join(" "));
     log("Prompt:", runPrompt.slice(0, 100));
 
-    const child = remote
-      ? spawnRemoteCommand(remote, claudeBin, args, {
-          cwd: process.cwd(),
-          env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
-          stdio: ["pipe", "pipe", "pipe"],
-        }, {
-          env: { FORCE_COLOR: "0", ...upstreamEnv },
-          cwd: remote.cwd,
-        })
-      : spawnCli(claudeBin, args, {
-          cwd: launchCwd,
-          env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath(), ...upstreamEnv },
-          stdio: ["pipe", "pipe", "pipe"],
-        });
+    let child;
+    try {
+      child = remote
+        ? spawnRemoteCommand(remote, claudeBin, args, {
+            cwd: process.cwd(),
+            env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
+            stdio: ["pipe", "pipe", "pipe"],
+          }, {
+            env: { FORCE_COLOR: "0", ...upstreamEnv },
+            cwd: remote.cwd,
+          })
+        : spawnCli(claudeBin, args, {
+            cwd: launchCwd,
+            env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath(), ...upstreamEnv },
+            stdio: ["pipe", "pipe", "pipe"],
+          });
+    } catch (err) {
+      cleanupRemoteAttachments(state);
+      if (activeAgents.get(conversationId) === state) activeAgents.delete(conversationId);
+      webContents.send("agent-error", { conversationId, error: err.message || String(err) });
+      webContents.send("agent-done", { conversationId, exitCode: -1 });
+      return null;
+    }
 
     state.child = child;
     state.stdinClosed = false;
@@ -569,6 +619,7 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
           firstToolUseMs: state.firstToolUseMs,
         },
       });
+      cleanupRemoteAttachments(state);
 
       if (state.cancelled) {
         if (isCurrentState) {
@@ -604,6 +655,7 @@ function startAgent({ conversationId, prompt, model, cwd, images, files, session
     child.on("error", (err) => {
       const isCurrentState = activeAgents.get(conversationId) === state;
       log("Spawn error:", err.message);
+      cleanupRemoteAttachments(state);
       if (isCurrentState) activeAgents.delete(conversationId);
       webContents.send("agent-error", { conversationId, error: err.message });
       if (isCurrentState) webContents.send("agent-done", { conversationId, exitCode: -1 });
@@ -701,27 +753,45 @@ function respondPermission({ conversationId, requestId, behavior, message, updat
 
 function cancelAgent(conversationId) {
   const state = activeAgents.get(conversationId);
-  if (state?.child) {
-    log("Cancelling agent:", conversationId);
-    state.cancelled = true;
-    if (state.pendingPermissions?.size) {
-      for (const requestId of state.pendingPermissions.keys()) {
-        writeControlResponse(state, requestId, {
-          behavior: "deny",
-          message: "Cancelled",
-        });
-      }
-      state.pendingPermissions.clear();
+  if (!state) return;
+
+  log("Cancelling agent:", conversationId);
+  state.cancelled = true;
+  if (state.pendingPermissions?.size) {
+    for (const requestId of state.pendingPermissions.keys()) {
+      writeControlResponse(state, requestId, {
+        behavior: "deny",
+        message: "Cancelled",
+      });
     }
+    state.pendingPermissions.clear();
+  }
+  cleanupRemoteAttachments(state);
+
+  if (state.child) {
     try { state.endStdin?.(); } catch {}
     state.child.kill("SIGTERM");
+    return;
+  }
+
+  activeAgents.delete(conversationId);
+  if (!state.webContents?.isDestroyed?.()) {
+    state.webContents.send("agent-done", { conversationId, exitCode: null, signal: "SIGTERM" });
   }
 }
 
 function cancelAll() {
-  for (const [, state] of activeAgents) {
-    if (!state?.child) continue;
+  for (const [conversationId, state] of activeAgents) {
+    if (!state) continue;
     state.cancelled = true;
+    cleanupRemoteAttachments(state);
+    if (!state.child) {
+      activeAgents.delete(conversationId);
+      if (!state.webContents?.isDestroyed?.()) {
+        state.webContents.send("agent-done", { conversationId, exitCode: null, signal: "SIGTERM" });
+      }
+      continue;
+    }
     try { state.endStdin?.(); } catch {}
     state.child.kill("SIGTERM");
   }

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -10,6 +10,7 @@ const {
   summarizeProviderUpstream,
 } = require("./provider-upstreams.cjs");
 const { describeRemoteRuntime, normalizeRemoteRuntime, spawnRemoteCommand } = require("./remote-runtime.cjs");
+const { stageRemoteAttachments } = require("./remote-attachments.cjs");
 
 const activeAgents = new Map();
 const TERMINAL_CLI_PATH = path.join(__dirname, "../scripts/claudi-terminal.cjs");
@@ -29,6 +30,13 @@ function shouldEmitStderrError({ stderrBuffer, exitCode, signal, cancelled, sawT
   if (cancelled) return false;
   if (sawTurnCompleted && exitCode === 0 && !signal) return false;
   return exitCode !== 0 || Boolean(signal) || !sawTurnCompleted;
+}
+
+function cleanupRemoteAttachments(state) {
+  const cleanup = state?.remoteAttachmentCleanup;
+  if (!cleanup) return;
+  state.remoteAttachmentCleanup = null;
+  cleanup().catch((err) => log("Remote attachment cleanup failed:", err?.message || err));
 }
 
 function scheduleSessionSnapshot(webContents, conversationId, threadId, attempt = 0) {
@@ -115,9 +123,8 @@ function buildClaudiPrompt(prompt, files, mcpServers, options = {}) {
 
   if (files && files.length > 0) {
     const filePaths = files.map((f) => f.path).join("\n");
-    fullPrompt = options.remote
-      ? `[Attached files were provided in RayLine, but these local paths were not copied to the remote SSH host:\n${filePaths}]\n\n${fullPrompt}`
-      : `[Attached files:\n${filePaths}]\n\n${fullPrompt}`;
+    const label = options.remote ? "Attached files uploaded to the remote SSH host" : "Attached files";
+    fullPrompt = `[${label}:\n${filePaths}]\n\n${fullPrompt}`;
   }
 
   const hasTerminalSessions = (mcpServers || []).some(
@@ -297,10 +304,47 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
     return null;
   }
 
+  const state = {
+    conversationId,
+    webContents,
+    child: null,
+    cancelled: false,
+    sawTurnCompleted: false,
+    lastErrorMessage: null,
+    threadId: null,
+    remoteAttachmentCleanup: null,
+  };
+  activeAgents.set(conversationId, state);
+
+  let stagedRemoteAttachments = null;
+  if (remote) {
+    try {
+      stagedRemoteAttachments = await stageRemoteAttachments(remote, { images, files });
+    } catch (error) {
+      if (state.cancelled || activeAgents.get(conversationId) !== state) return null;
+      const message = `Failed to upload attachments to the remote SSH host: ${error?.message || error}`;
+      log(message);
+      activeAgents.delete(conversationId);
+      webContents.send("agent-error", { conversationId, error: message });
+      webContents.send("agent-done", { conversationId, exitCode: -1, provider: "codex" });
+      return null;
+    }
+    if (state.cancelled || activeAgents.get(conversationId) !== state) {
+      await stagedRemoteAttachments?.cleanup?.().catch(() => {});
+      return null;
+    }
+    state.remoteAttachmentCleanup = stagedRemoteAttachments?.cleanup || null;
+  }
+
   // Handle images — decode base64 data URLs to temp files, pass via -i
-  if (!remote && images && images.length > 0) {
+  if (remote && stagedRemoteAttachments?.images?.length > 0) {
+    for (const remoteImagePath of stagedRemoteAttachments.images) {
+      args.push("-i", remoteImagePath);
+    }
+  } else if (!remote && images && images.length > 0) {
     for (let i = 0; i < images.length; i++) {
-      const dataUrl = images[i];
+      const dataUrl = typeof images[i] === "string" ? images[i] : images[i]?.dataUrl;
+      if (typeof dataUrl !== "string") continue;
       const match = dataUrl.match(/^data:image\/([\w+.-]+);base64,(.+)$/);
       if (match) {
         const ext = match[1] === "jpeg" ? "jpg" : match[1];
@@ -313,13 +357,19 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
 
   // `--image` is variadic in the Codex CLI, so terminate option parsing
   // before the prompt or the prompt may be consumed as another image path.
-  const fullPrompt = buildClaudiPrompt(prompt, files, mcpServers, { remote: Boolean(remote) });
+  const fullPrompt = buildClaudiPrompt(
+    prompt,
+    remote ? stagedRemoteAttachments?.files : files,
+    mcpServers,
+    { remote: Boolean(remote) }
+  );
   args.push("--", fullPrompt);
 
   const codexBin = remote ? (remote.commandPath || "codex") : resolveCodexBin();
   if (!remote && !codexBin) {
     const error = "Unable to locate the Codex CLI binary";
     log(error);
+    if (activeAgents.get(conversationId) === state) activeAgents.delete(conversationId);
     webContents.send("agent-error", { conversationId, error });
     webContents.send("agent-done", { conversationId, exitCode: -1 });
     return null;
@@ -330,32 +380,42 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
   log("Prompt:", fullPrompt.slice(0, 100));
 
   const codexEnv = buildCodexUpstreamEnv(providerUpstreamConfig, upstreamRuntime);
-  const child = remote
-    ? spawnRemoteCommand(remote, codexBin, args, {
-        cwd: process.cwd(),
-        env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
-        // Codex stalls before the first network request when stdin is /dev/null.
-        // Give it a pipe and immediately close it so it observes EOF correctly.
-        stdio: ["pipe", "pipe", "pipe"],
-      }, {
-        env: { FORCE_COLOR: "0", ...codexEnv },
-        cwd: remote.cwd,
-      })
-    : spawnCli(codexBin, args, {
-        cwd: launchCwd,
-        env: {
-          ...process.env,
-          FORCE_COLOR: "0",
-          PATH: buildSpawnPath(),
-          ...codexEnv,
-          CLAUDI_TERMINAL_CLI: TERMINAL_CLI_PATH,
-          CLAUDI_TERMINAL_PORT: global.terminalWsPort ? String(global.terminalWsPort) : "",
-          CLAUDI_TERMINAL_MCP_CONFIG: global.mcpConfigPath || "",
-        },
-        // Codex stalls before the first network request when stdin is /dev/null.
-        // Give it a pipe and immediately close it so it observes EOF correctly.
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+  let child;
+  try {
+    child = remote
+      ? spawnRemoteCommand(remote, codexBin, args, {
+          cwd: process.cwd(),
+          env: { ...process.env, FORCE_COLOR: "0", PATH: buildSpawnPath() },
+          // Codex stalls before the first network request when stdin is /dev/null.
+          // Give it a pipe and immediately close it so it observes EOF correctly.
+          stdio: ["pipe", "pipe", "pipe"],
+        }, {
+          env: { FORCE_COLOR: "0", ...codexEnv },
+          cwd: remote.cwd,
+        })
+      : spawnCli(codexBin, args, {
+          cwd: launchCwd,
+          env: {
+            ...process.env,
+            FORCE_COLOR: "0",
+            PATH: buildSpawnPath(),
+            ...codexEnv,
+            CLAUDI_TERMINAL_CLI: TERMINAL_CLI_PATH,
+            CLAUDI_TERMINAL_PORT: global.terminalWsPort ? String(global.terminalWsPort) : "",
+            CLAUDI_TERMINAL_MCP_CONFIG: global.mcpConfigPath || "",
+          },
+          // Codex stalls before the first network request when stdin is /dev/null.
+          // Give it a pipe and immediately close it so it observes EOF correctly.
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+  } catch (error) {
+    cleanupRemoteAttachments(state);
+    if (activeAgents.get(conversationId) === state) activeAgents.delete(conversationId);
+    webContents.send("agent-error", { conversationId, error: error.message || String(error) });
+    webContents.send("agent-done", { conversationId, exitCode: -1, provider: "codex" });
+    return null;
+  }
+  state.child = child;
   child.stdin?.on("error", () => {});
   child.stdin?.end();
 
@@ -364,16 +424,6 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
     child.once("exit", () => upstreamRuntime.bridge.close());
     child.once("error", () => upstreamRuntime.bridge.close());
   }
-
-  const state = {
-    child,
-    cancelled: false,
-    sawTurnCompleted: false,
-    lastErrorMessage: null,
-    threadId: null,
-  };
-
-  activeAgents.set(conversationId, state);
 
   let buffer = "";
   let stderrBuffer = "";
@@ -436,6 +486,7 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
       log("Flushing remaining buffer:", buffer.slice(0, 200));
       parseLine(buffer);
     }
+    cleanupRemoteAttachments(state);
 
     if (state.cancelled) {
       if (isCurrentState) {
@@ -486,6 +537,7 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
   child.on("error", (err) => {
     const isCurrentState = activeAgents.get(conversationId) === state;
     log("Spawn error:", err.message);
+    cleanupRemoteAttachments(state);
     if (isCurrentState) activeAgents.delete(conversationId);
     webContents.send("agent-error", { conversationId, error: err.message });
     if (isCurrentState) {
@@ -498,17 +550,47 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
 
 function cancelCodexAgent(conversationId) {
   const state = activeAgents.get(conversationId);
-  if (state?.child) {
-    log("Cancelling codex agent:", conversationId);
-    state.cancelled = true;
+  if (!state) return;
+
+  log("Cancelling codex agent:", conversationId);
+  state.cancelled = true;
+  cleanupRemoteAttachments(state);
+
+  if (state.child) {
     state.child.kill("SIGTERM");
+    return;
+  }
+
+  activeAgents.delete(conversationId);
+  if (!state.webContents?.isDestroyed?.()) {
+    state.webContents.send("agent-done", {
+      conversationId,
+      exitCode: null,
+      signal: "SIGTERM",
+      provider: "codex",
+      threadId: state.threadId,
+    });
   }
 }
 
 function cancelAllCodex() {
-  for (const [, state] of activeAgents) {
+  for (const [conversationId, state] of activeAgents) {
     state.cancelled = true;
-    state.child.kill("SIGTERM");
+    cleanupRemoteAttachments(state);
+    if (state.child) {
+      state.child.kill("SIGTERM");
+      continue;
+    }
+    activeAgents.delete(conversationId);
+    if (!state.webContents?.isDestroyed?.()) {
+      state.webContents.send("agent-done", {
+        conversationId,
+        exitCode: null,
+        signal: "SIGTERM",
+        provider: "codex",
+        threadId: state.threadId,
+      });
+    }
   }
 }
 

--- a/electron/codex-agent-manager.cjs
+++ b/electron/codex-agent-manager.cjs
@@ -11,6 +11,7 @@ const {
 } = require("./provider-upstreams.cjs");
 const { describeRemoteRuntime, normalizeRemoteRuntime, spawnRemoteCommand } = require("./remote-runtime.cjs");
 const { stageRemoteAttachments } = require("./remote-attachments.cjs");
+const { startRemoteChannel } = require("./remote-channel.cjs");
 
 const activeAgents = new Map();
 const TERMINAL_CLI_PATH = path.join(__dirname, "../scripts/claudi-terminal.cjs");
@@ -37,6 +38,20 @@ function cleanupRemoteAttachments(state) {
   if (!cleanup) return;
   state.remoteAttachmentCleanup = null;
   cleanup().catch((err) => log("Remote attachment cleanup failed:", err?.message || err));
+}
+
+function finishRemoteChannel(state) {
+  const channel = state?.remoteChannel;
+  if (!channel) return;
+  state.remoteChannel = null;
+  channel.finish().catch((err) => log("Remote channel finish failed:", err?.message || err));
+}
+
+function disposeRemoteChannel(state) {
+  const channel = state?.remoteChannel;
+  if (!channel) return;
+  state.remoteChannel = null;
+  channel.dispose().catch((err) => log("Remote channel dispose failed:", err?.message || err));
 }
 
 function scheduleSessionSnapshot(webContents, conversationId, threadId, attempt = 0) {
@@ -157,6 +172,10 @@ CLI examples:
 - node "$CLAUDI_TERMINAL_CLI" read <name> --lines 80
 - node "$CLAUDI_TERMINAL_CLI" kill <name>`;
 
+  const remoteChannelInstructions = options.remote && options.remoteChannel?.instructions
+    ? `\n\n${options.remoteChannel.instructions}`
+    : "";
+
   const claudiInstructions = `System context for this run:
 You are running inside RayLine, a desktop GUI client for coding agents.
 The user is interacting via a chat interface, not a terminal.
@@ -206,7 +225,7 @@ Example:
 
 When a control is not live-bound and the user submits it, RayLine will send a normal follow-up chat message with the selected value back into the conversation.
 
-${terminalInstructions}
+${terminalInstructions}${remoteChannelInstructions}
 
 The text below is the actual user prompt.
 --- USER PROMPT ---
@@ -313,6 +332,7 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
     lastErrorMessage: null,
     threadId: null,
     remoteAttachmentCleanup: null,
+    remoteChannel: null,
   };
   activeAgents.set(conversationId, state);
 
@@ -334,6 +354,19 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
       return null;
     }
     state.remoteAttachmentCleanup = stagedRemoteAttachments?.cleanup || null;
+
+    try {
+      state.remoteChannel = await startRemoteChannel({ conversationId, provider: "codex" });
+      log("Started RayLine SSH channel:", state.remoteChannel.describe());
+    } catch (error) {
+      log("RayLine SSH channel unavailable:", error?.message || error);
+      state.remoteChannel = null;
+    }
+
+    if (state.cancelled || activeAgents.get(conversationId) !== state) {
+      disposeRemoteChannel(state);
+      return null;
+    }
   }
 
   // Handle images — decode base64 data URLs to temp files, pass via -i
@@ -361,7 +394,7 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
     prompt,
     remote ? stagedRemoteAttachments?.files : files,
     mcpServers,
-    { remote: Boolean(remote) }
+    { remote: Boolean(remote), remoteChannel: state.remoteChannel }
   );
   args.push("--", fullPrompt);
 
@@ -390,8 +423,9 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
           // Give it a pipe and immediately close it so it observes EOF correctly.
           stdio: ["pipe", "pipe", "pipe"],
         }, {
-          env: { FORCE_COLOR: "0", ...codexEnv },
+          env: { FORCE_COLOR: "0", ...codexEnv, ...(state.remoteChannel?.env || {}) },
           cwd: remote.cwd,
+          sshArgs: state.remoteChannel?.sshArgs,
         })
       : spawnCli(codexBin, args, {
           cwd: launchCwd,
@@ -410,6 +444,7 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
         });
   } catch (error) {
     cleanupRemoteAttachments(state);
+    disposeRemoteChannel(state);
     if (activeAgents.get(conversationId) === state) activeAgents.delete(conversationId);
     webContents.send("agent-error", { conversationId, error: error.message || String(error) });
     webContents.send("agent-done", { conversationId, exitCode: -1, provider: "codex" });
@@ -487,6 +522,7 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
       parseLine(buffer);
     }
     cleanupRemoteAttachments(state);
+    finishRemoteChannel(state);
 
     if (state.cancelled) {
       if (isCurrentState) {
@@ -538,6 +574,7 @@ async function startCodexAgent({ conversationId, prompt, model, effort, cwd, ima
     const isCurrentState = activeAgents.get(conversationId) === state;
     log("Spawn error:", err.message);
     cleanupRemoteAttachments(state);
+    disposeRemoteChannel(state);
     if (isCurrentState) activeAgents.delete(conversationId);
     webContents.send("agent-error", { conversationId, error: err.message });
     if (isCurrentState) {
@@ -555,6 +592,7 @@ function cancelCodexAgent(conversationId) {
   log("Cancelling codex agent:", conversationId);
   state.cancelled = true;
   cleanupRemoteAttachments(state);
+  finishRemoteChannel(state);
 
   if (state.child) {
     state.child.kill("SIGTERM");
@@ -577,6 +615,7 @@ function cancelAllCodex() {
   for (const [conversationId, state] of activeAgents) {
     state.cancelled = true;
     cleanupRemoteAttachments(state);
+    finishRemoteChannel(state);
     if (state.child) {
       state.child.kill("SIGTERM");
       continue;

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -836,6 +836,25 @@ ipcMain.handle("store-message-image", async (_event, input = {}) => {
   }
 });
 
+function handleAgentLaunchError(sender, opts, err, provider) {
+  const conversationId = opts?.conversationId;
+  if (!conversationId || sender.isDestroyed?.()) return;
+  const error = err?.message || String(err);
+  console.error("[agent] launch failed:", error);
+  sender.send("agent-error", { conversationId, error });
+  sender.send("agent-done", {
+    conversationId,
+    exitCode: -1,
+    ...(provider ? { provider } : {}),
+  });
+}
+
+function watchAgentLaunch(start, sender, opts, provider) {
+  Promise.resolve()
+    .then(start)
+    .catch((err) => handleAgentLaunchError(sender, opts, err, provider));
+}
+
 // IPC: agent
 ipcMain.on("agent-start", (event, opts) => {
   const runtimeProvider = opts.runtimeProvider || opts.remoteRuntime?.provider || opts.provider;
@@ -848,11 +867,11 @@ ipcMain.on("agent-start", (event, opts) => {
       event.sender.send("agent-done", { conversationId: opts.conversationId });
     });
   } else if (runtimeProvider === "codex") {
-    startCodexAgent(opts, event.sender);
+    watchAgentLaunch(() => startCodexAgent(opts, event.sender), event.sender, opts, "codex");
   } else if (runtimeProvider === "opencode") {
-    startOpenCodeAgent(opts, event.sender);
+    watchAgentLaunch(() => startOpenCodeAgent(opts, event.sender), event.sender, opts, "opencode");
   } else {
-    startAgent(opts, event.sender);
+    watchAgentLaunch(() => startAgent(opts, event.sender), event.sender, opts, "claude");
   }
 });
 
@@ -868,11 +887,26 @@ ipcMain.on("agent-cancel", (_event, { conversationId }) => {
 ipcMain.on("agent-edit-resend", (event, opts) => {
   const runtimeProvider = opts.runtimeProvider || opts.remoteRuntime?.provider || opts.provider;
   if (runtimeProvider === "codex") {
-    startCodexAgent({ ...opts, resumeSessionId: opts.resumeSessionId }, event.sender);
+    watchAgentLaunch(
+      () => startCodexAgent({ ...opts, resumeSessionId: opts.resumeSessionId }, event.sender),
+      event.sender,
+      opts,
+      "codex"
+    );
   } else if (runtimeProvider === "opencode") {
-    startOpenCodeAgent({ ...opts, resumeSessionId: opts.resumeSessionId }, event.sender);
+    watchAgentLaunch(
+      () => startOpenCodeAgent({ ...opts, resumeSessionId: opts.resumeSessionId }, event.sender),
+      event.sender,
+      opts,
+      "opencode"
+    );
   } else {
-    startAgent({ ...opts, forkSession: true }, event.sender);
+    watchAgentLaunch(
+      () => startAgent({ ...opts, forkSession: true }, event.sender),
+      event.sender,
+      opts,
+      "claude"
+    );
   }
 });
 

--- a/electron/remote-attachments.cjs
+++ b/electron/remote-attachments.cjs
@@ -1,0 +1,188 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { pipeline } = require("stream/promises");
+const { buildSpawnPath } = require("./cli-bin-resolver.cjs");
+const { normalizeRemoteRuntime, spawnRemoteCommand } = require("./remote-runtime.cjs");
+
+const REMOTE_ATTACHMENT_DIR_PREFIX = "/tmp/rayline-attachments-";
+
+function quotePosix(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function safeFilename(value, fallback) {
+  const raw = path.basename(typeof value === "string" && value.trim() ? value.trim() : fallback);
+  const cleaned = raw
+    .replace(/[^\w.+-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 120);
+  if (!cleaned || cleaned === "." || cleaned === "..") return fallback;
+  return cleaned;
+}
+
+function extensionForMime(mime) {
+  const normalized = String(mime || "").toLowerCase();
+  if (normalized === "image/jpeg") return "jpg";
+  if (normalized === "image/png") return "png";
+  if (normalized === "image/gif") return "gif";
+  if (normalized === "image/webp") return "webp";
+  if (normalized === "image/svg+xml") return "svg";
+  const match = normalized.match(/^image\/([a-z0-9.+-]+)$/);
+  return match ? match[1].replace(/[^a-z0-9.+-]/g, "") || "png" : "png";
+}
+
+function parseImageDataUrl(image) {
+  const dataUrl = typeof image === "string" ? image : image?.dataUrl;
+  if (typeof dataUrl !== "string") return null;
+  const match = dataUrl.match(/^data:([^;,]+);base64,([\s\S]+)$/i);
+  if (!match) return null;
+  return {
+    mime: match[1],
+    buffer: Buffer.from(match[2].replace(/\s+/g, ""), "base64"),
+  };
+}
+
+function createRemoteAttachmentDir() {
+  const suffix = [
+    process.pid,
+    Date.now(),
+    crypto.randomBytes(6).toString("hex"),
+  ].join("-");
+  return `${REMOTE_ATTACHMENT_DIR_PREFIX}${suffix}`;
+}
+
+function remotePathInDir(remoteDir, index, filename) {
+  const prefix = String(index + 1).padStart(2, "0");
+  return `${remoteDir}/${prefix}-${filename}`;
+}
+
+function spawnRemoteShell(remote, script) {
+  return spawnRemoteCommand(remote, "sh", ["-lc", script], {
+    cwd: process.cwd(),
+    env: { ...process.env, PATH: buildSpawnPath() },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+function waitForRemoteProcess(child, label) {
+  let stdout = "";
+  let stderr = "";
+
+  child.stdout?.on("data", (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr?.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (exitCode, signal) => {
+      if (exitCode === 0) {
+        resolve(stdout);
+        return;
+      }
+      const detail = stderr.trim() || stdout.trim() || `${label} failed with ${signal || `exit code ${exitCode}`}`;
+      reject(new Error(detail));
+    });
+  });
+}
+
+async function uploadRemoteInput(remote, remoteDir, remotePath, input) {
+  const script = `umask 077; mkdir -p ${quotePosix(remoteDir)} && cat > ${quotePosix(remotePath)}`;
+  const child = spawnRemoteShell(remote, script);
+  const closePromise = waitForRemoteProcess(child, `Upload ${remotePath}`);
+  child.stdin?.on("error", () => {});
+
+  try {
+    if (input?.localPath) {
+      await pipeline(fs.createReadStream(input.localPath), child.stdin);
+    } else {
+      child.stdin.end(input?.buffer || Buffer.alloc(0));
+    }
+  } catch (error) {
+    closePromise.catch(() => {});
+    child.kill("SIGTERM");
+    throw error;
+  }
+
+  await closePromise;
+}
+
+async function cleanupRemoteAttachmentDir(remoteRuntime, remoteDir) {
+  const remote = normalizeRemoteRuntime(remoteRuntime);
+  if (!remote || typeof remoteDir !== "string" || !remoteDir.startsWith(REMOTE_ATTACHMENT_DIR_PREFIX)) return;
+  const child = spawnRemoteShell(remote, `rm -rf ${quotePosix(remoteDir)}`);
+  child.stdin?.on("error", () => {});
+  child.stdin?.end();
+  await waitForRemoteProcess(child, `Cleanup ${remoteDir}`);
+}
+
+async function stageRemoteAttachments(remoteRuntime, attachments = {}) {
+  const remote = normalizeRemoteRuntime(remoteRuntime);
+  if (!remote) return null;
+
+  const imageInputs = Array.isArray(attachments.images) ? attachments.images : [];
+  const fileInputs = Array.isArray(attachments.files) ? attachments.files : [];
+  if (imageInputs.length === 0 && fileInputs.length === 0) {
+    return {
+      images: [],
+      files: [],
+      remoteDir: "",
+      cleanup: async () => {},
+    };
+  }
+
+  const remoteDir = createRemoteAttachmentDir();
+  const stagedImages = [];
+  const stagedFiles = [];
+
+  try {
+    for (let i = 0; i < imageInputs.length; i += 1) {
+      const parsed = parseImageDataUrl(imageInputs[i]);
+      if (!parsed) continue;
+      const sourceName = typeof imageInputs[i] === "object" ? imageInputs[i].name : "";
+      const filename = safeFilename(sourceName, `image-${i + 1}.${extensionForMime(parsed.mime)}`);
+      const remotePath = remotePathInDir(remoteDir, i, filename);
+      await uploadRemoteInput(remote, remoteDir, remotePath, { buffer: parsed.buffer });
+      stagedImages.push(remotePath);
+    }
+
+    for (let i = 0; i < fileInputs.length; i += 1) {
+      const file = fileInputs[i] || {};
+      const localPath = typeof file.path === "string" ? file.path : "";
+      if (!localPath) continue;
+      const stat = await fs.promises.stat(localPath);
+      if (!stat.isFile()) {
+        throw new Error(`Attached file is not a regular file: ${localPath}`);
+      }
+
+      const filename = safeFilename(file.name || path.basename(localPath), `file-${i + 1}`);
+      const remotePath = remotePathInDir(remoteDir, stagedImages.length + i, filename);
+      await uploadRemoteInput(remote, remoteDir, remotePath, { localPath });
+      stagedFiles.push({
+        ...file,
+        path: remotePath,
+        originalPath: localPath,
+      });
+    }
+  } catch (error) {
+    await cleanupRemoteAttachmentDir(remote, remoteDir).catch(() => {});
+    throw error;
+  }
+
+  return {
+    images: stagedImages,
+    files: stagedFiles,
+    remoteDir,
+    cleanup: () => cleanupRemoteAttachmentDir(remote, remoteDir),
+  };
+}
+
+module.exports = {
+  cleanupRemoteAttachmentDir,
+  stageRemoteAttachments,
+};

--- a/electron/remote-channel.cjs
+++ b/electron/remote-channel.cjs
@@ -1,0 +1,382 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const http = require("http");
+const os = require("os");
+const path = require("path");
+const { Transform } = require("stream");
+const { pipeline } = require("stream/promises");
+
+const REMOTE_PORT_MIN = 42000;
+const REMOTE_PORT_MAX = 60999;
+const DOWNLOAD_TTL_MS = 2 * 60 * 60 * 1000;
+const MAX_UPLOAD_BYTES = Number(process.env.RAYLINE_REMOTE_CHANNEL_MAX_UPLOAD_BYTES || 512 * 1024 * 1024);
+
+function safeFilename(value, fallback = "rayline-file") {
+  const raw = path.basename(typeof value === "string" && value.trim() ? value.trim() : fallback);
+  const cleaned = raw
+    .replace(/[^\w.+ -]+/g, "_")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 160);
+  if (!cleaned || cleaned === "." || cleaned === "..") return fallback;
+  return cleaned;
+}
+
+function safePathSegment(value, fallback) {
+  return safeFilename(value, fallback).replace(/\s+/g, "-").replace(/[^A-Za-z0-9_.+-]/g, "_");
+}
+
+function chooseRemotePort() {
+  const span = REMOTE_PORT_MAX - REMOTE_PORT_MIN + 1;
+  return REMOTE_PORT_MIN + crypto.randomInt(span);
+}
+
+function getStorageRoot() {
+  const configured = typeof process.env.RAYLINE_REMOTE_CHANNEL_DIR === "string"
+    ? process.env.RAYLINE_REMOTE_CHANNEL_DIR.trim()
+    : "";
+  if (configured) return configured;
+
+  const downloads = path.join(os.homedir(), "Downloads");
+  try {
+    if (fs.existsSync(downloads) && fs.statSync(downloads).isDirectory()) {
+      return path.join(downloads, "RayLine Remote Files");
+    }
+  } catch {}
+
+  return path.join(os.tmpdir(), "rayline-remote-files");
+}
+
+function getHeader(req, name) {
+  const value = req.headers[String(name).toLowerCase()];
+  if (Array.isArray(value)) return value[0] || "";
+  return typeof value === "string" ? value : "";
+}
+
+function isAuthorized(req, url, token) {
+  const headerToken = getHeader(req, "x-rayline-token");
+  if (headerToken && headerToken === token) return true;
+
+  const auth = getHeader(req, "authorization");
+  if (auth.toLowerCase().startsWith("bearer ") && auth.slice(7).trim() === token) return true;
+
+  return url.searchParams.get("token") === token;
+}
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload, null, 2);
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(body),
+    "Cache-Control": "no-store",
+  });
+  res.end(body);
+}
+
+function sendError(res, statusCode, message) {
+  sendJson(res, statusCode, { ok: false, error: message });
+}
+
+function parseContentDispositionFilename(header) {
+  if (!header) return "";
+  const utf8Match = header.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match?.[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch {}
+  }
+  const quotedMatch = header.match(/filename="([^"]+)"/i);
+  if (quotedMatch?.[1]) return quotedMatch[1];
+  const bareMatch = header.match(/filename=([^;]+)/i);
+  return bareMatch?.[1]?.trim() || "";
+}
+
+function getUploadFilename(req, url) {
+  return safeFilename(
+    url.searchParams.get("name")
+      || getHeader(req, "x-rayline-filename")
+      || parseContentDispositionFilename(getHeader(req, "content-disposition")),
+    `rayline-file-${Date.now()}`
+  );
+}
+
+function createByteLimitStream(maxBytes) {
+  let bytes = 0;
+  const stream = new Transform({
+    transform(chunk, _encoding, callback) {
+      bytes += chunk.length;
+      if (bytes > maxBytes) {
+        const err = new Error(`Upload exceeds ${Math.round(maxBytes / (1024 * 1024))} MB.`);
+        err.statusCode = 413;
+        callback(err);
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+  Object.defineProperty(stream, "bytes", { get: () => bytes });
+  return stream;
+}
+
+async function receiveUpload(req, filePath) {
+  const declaredLength = Number(getHeader(req, "content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_UPLOAD_BYTES) {
+    const err = new Error(`Upload exceeds ${Math.round(MAX_UPLOAD_BYTES / (1024 * 1024))} MB.`);
+    err.statusCode = 413;
+    throw err;
+  }
+
+  const limiter = createByteLimitStream(MAX_UPLOAD_BYTES);
+  try {
+    await pipeline(req, limiter, fs.createWriteStream(filePath, { flags: "wx", mode: 0o600 }));
+  } catch (err) {
+    await fs.promises.unlink(filePath).catch(() => {});
+    throw err;
+  }
+  return limiter.bytes;
+}
+
+function contentTypeForName(name) {
+  const ext = path.extname(name).toLowerCase();
+  if (ext === ".png") return "image/png";
+  if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+  if (ext === ".gif") return "image/gif";
+  if (ext === ".webp") return "image/webp";
+  if (ext === ".svg") return "image/svg+xml";
+  if (ext === ".pdf") return "application/pdf";
+  if (ext === ".txt" || ext === ".md" || ext === ".log") return "text/plain; charset=utf-8";
+  if (ext === ".json") return "application/json; charset=utf-8";
+  if (ext === ".html" || ext === ".htm") return "text/html; charset=utf-8";
+  return "application/octet-stream";
+}
+
+function listen(server, host) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+function buildInstructionText(channel) {
+  return `RayLine SSH channel:
+RayLine opened an authenticated localhost bridge from this remote SSH host back to the user's Mac.
+Use it when you need to send generated files, screenshots, archives, or other artifacts back to the user.
+- Base URL on this remote host: ${channel.remoteBaseUrl}
+- Auth token env var: $RAYLINE_SSH_CHANNEL_TOKEN
+
+Upload a file and paste the returned markdown link in your reply:
+\`\`\`sh
+file="/path/to/artifact"
+curl -fsS -X POST "$RAYLINE_SSH_CHANNEL_URL/upload?name=$(basename "$file")" \\
+  -H "X-RayLine-Token: $RAYLINE_SSH_CHANNEL_TOKEN" \\
+  --data-binary @"$file"
+\`\`\`
+
+The JSON response includes "markdown", "downloadUrl", and "localPath". Use the markdown value for user-facing download links. Never print the token.`;
+}
+
+async function startRemoteChannel({ conversationId = "session", provider = "agent" } = {}) {
+  const token = crypto.randomBytes(24).toString("base64url");
+  const remotePort = chooseRemotePort();
+  const files = new Map();
+  const storageDir = path.join(
+    getStorageRoot(),
+    `${safePathSegment(provider, "agent")}-${safePathSegment(conversationId, "session")}-${Date.now().toString(36)}`
+  );
+  await fs.promises.mkdir(storageDir, { recursive: true, mode: 0o700 });
+
+  let uploadEnabled = true;
+  let closed = false;
+  let ttlTimer = null;
+  let localBaseUrl = "";
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url || "/", "http://127.0.0.1");
+    const pathname = url.pathname;
+
+    try {
+      if (req.method === "GET" && pathname.startsWith("/download/")) {
+        const [, , id] = pathname.split("/");
+        const entry = files.get(id);
+        if (!entry) {
+          sendError(res, 404, "File not found.");
+          return;
+        }
+        res.writeHead(200, {
+          "Content-Type": contentTypeForName(entry.name),
+          "Content-Length": entry.bytes,
+          "Content-Disposition": `attachment; filename="${entry.name.replace(/"/g, "")}"`,
+          "Cache-Control": "private, max-age=3600",
+        });
+        fs.createReadStream(entry.path).pipe(res);
+        return;
+      }
+
+      if (!isAuthorized(req, url, token)) {
+        sendError(res, 401, "Missing or invalid RayLine SSH channel token.");
+        return;
+      }
+
+      if (req.method === "GET" && pathname === "/health") {
+        sendJson(res, 200, { ok: true, provider, conversationId });
+        return;
+      }
+
+      if (req.method === "GET" && pathname === "/manifest") {
+        sendJson(res, 200, {
+          ok: true,
+          endpoints: {
+            upload: "/upload?name=<filename>",
+            files: "/files",
+            health: "/health",
+          },
+          maxUploadBytes: MAX_UPLOAD_BYTES,
+        });
+        return;
+      }
+
+      if (req.method === "GET" && pathname === "/files") {
+        sendJson(res, 200, {
+          ok: true,
+          files: Array.from(files.values()).map((entry) => ({
+            id: entry.id,
+            name: entry.name,
+            bytes: entry.bytes,
+            localPath: entry.path,
+            downloadUrl: entry.downloadUrl,
+            markdown: entry.markdown,
+            createdAt: entry.createdAt,
+          })),
+        });
+        return;
+      }
+
+      if (req.method === "POST" && (pathname === "/upload" || pathname === "/files")) {
+        if (!uploadEnabled) {
+          sendError(res, 410, "This RayLine SSH channel is no longer accepting uploads.");
+          return;
+        }
+
+        const id = crypto.randomBytes(10).toString("hex");
+        const name = getUploadFilename(req, url);
+        const diskName = `${id}-${safeFilename(name)}`;
+        const filePath = path.join(storageDir, diskName);
+        const bytes = await receiveUpload(req, filePath);
+        const downloadUrl = `${localBaseUrl}/download/${id}/${encodeURIComponent(name)}`;
+        const entry = {
+          id,
+          name,
+          path: filePath,
+          bytes,
+          downloadUrl,
+          markdown: `[Download ${name}](${downloadUrl})`,
+          createdAt: new Date().toISOString(),
+        };
+        files.set(id, entry);
+        sendJson(res, 201, {
+          ok: true,
+          id,
+          name,
+          bytes,
+          localPath: filePath,
+          downloadUrl,
+          markdown: entry.markdown,
+          expiresInSeconds: Math.round(DOWNLOAD_TTL_MS / 1000),
+        });
+        return;
+      }
+
+      sendError(res, 404, "Unknown RayLine SSH channel endpoint.");
+    } catch (err) {
+      sendError(res, err?.statusCode || 500, err?.message || String(err));
+    }
+  });
+
+  server.on("clientError", (err, socket) => {
+    socket.end("HTTP/1.1 400 Bad Request\r\n\r\n");
+  });
+
+  await listen(server, "127.0.0.1");
+  const address = server.address();
+  const localPort = typeof address === "object" && address ? address.port : 0;
+  localBaseUrl = `http://127.0.0.1:${localPort}`;
+  const remoteBaseUrl = `http://127.0.0.1:${remotePort}`;
+
+  const close = async () => {
+    if (closed) return;
+    closed = true;
+    if (ttlTimer) {
+      clearTimeout(ttlTimer);
+      ttlTimer = null;
+    }
+    await closeServer(server).catch(() => {});
+  };
+
+  const channel = {
+    provider,
+    conversationId,
+    token,
+    localPort,
+    remotePort,
+    localBaseUrl,
+    remoteBaseUrl,
+    sshArgs: [
+      "-o", "ExitOnForwardFailure=yes",
+      "-R", `127.0.0.1:${remotePort}:127.0.0.1:${localPort}`,
+    ],
+    env: {
+      RAYLINE_SSH_CHANNEL_URL: remoteBaseUrl,
+      RAYLINE_SSH_CHANNEL_TOKEN: token,
+      RAYLINE_SSH_CHANNEL_REMOTE_PORT: String(remotePort),
+    },
+    get fileCount() {
+      return files.size;
+    },
+    instructions: "",
+    describe() {
+      return {
+        provider,
+        conversationId,
+        localPort,
+        remotePort,
+        storageDir,
+        files: files.size,
+      };
+    },
+    async finish() {
+      uploadEnabled = false;
+      if (files.size === 0) {
+        await close();
+        return;
+      }
+      if (!ttlTimer) {
+        ttlTimer = setTimeout(() => {
+          close().catch(() => {});
+        }, DOWNLOAD_TTL_MS);
+        ttlTimer.unref?.();
+      }
+    },
+    async dispose() {
+      uploadEnabled = false;
+      await close();
+    },
+  };
+  channel.instructions = buildInstructionText(channel);
+
+  return channel;
+}
+
+module.exports = {
+  startRemoteChannel,
+};

--- a/electron/remote-runtime.cjs
+++ b/electron/remote-runtime.cjs
@@ -89,7 +89,8 @@ function spawnRemoteCommand(remoteRuntime, command, args, options = {}, remoteOp
     cwd: remoteOptions.cwd || runtime.cwd,
   });
   const [sshBin, ...sshArgs] = parseSshCommand(runtime.sshCommand);
-  return spawn(sshBin, [...sshArgs, remoteCommand], options);
+  const extraSshArgs = Array.isArray(remoteOptions.sshArgs) ? remoteOptions.sshArgs.filter(Boolean) : [];
+  return spawn(sshBin, [...sshArgs, ...extraSshArgs, remoteCommand], options);
 }
 
 function describeRemoteRuntime(remoteRuntime) {


### PR DESCRIPTION
## Summary
- stage local files and image attachments onto remote SSH hosts before launching remote Claude/Codex
- add a per-run authenticated RayLine SSH channel over reverse port forwarding so remote agents can upload artifacts back to the Mac
- inject remote env vars and instructions for producing user-facing download links

## Validation
- node --check on changed Electron modules
- npx eslint on changed Electron modules
- local bridge upload/download smoke test
- npm run build:electron:mac
- signed, notarized, stapled, and Gatekeeper-validated the rebuilt DMG and app bundle